### PR TITLE
feat: Spatial SQL playground: interactive query editor in Admin UI (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is the official admin UI for managing Honua Server instances:
 - **Operator Spec Workspace**: Stub-backed three-pane NL + DSL + preview workspace for walking the spec workflow end to end
 - **Identity Workspace**: OIDC provider lifecycle (list / create / edit / enable / delete), provider status, auth diagnostics, and API-key gap surface — see [Identity workspace](#identity-workspace) below
 - **License Workspace**: BYOL license status, entitlement inspection, expiry banding, replace flow, and operator-actionable diagnostics — see [License workspace](#license-workspace) below
+- **Spatial SQL Playground**: Browser-based PostGIS-aware SQL editor with schema autocomplete, MapLibre preview, EXPLAIN tree, and named-view save flow — see [Spatial SQL playground](#spatial-sql-playground) below
 
 ## Architecture
 
@@ -282,6 +283,58 @@ Server-side gaps surfaced by this workspace are catalogued in
 duplicate endpoint-set consolidation, server-side `IssuanceSource`,
 real Ed25519 verification on `ApplyLicenseAsync`, phone-home health
 field, marketplace-aware surfaces).
+
+### Spatial SQL Playground
+
+The SQL playground lives at `/operator/sql` (gated by `[Authorize]`; reuses
+the same `DevAuthenticationStateProvider` shim as the spec workspace until
+the real admin auth provider lands). It registers as a `MudNavLink` inside
+the shared `Shared/NavMenu.razor` so it lives in the same shell as Spec
+Workspace.
+
+The route includes:
+
+- A SQL editor with PostGIS-aware highlighting and schema-driven
+  autocomplete (tables, columns, PostGIS function/operator reference).
+- A schema sidebar with click-to-insert tables, columns, and PostGIS
+  helpers, plus a manual refresh button to defeat cache staleness.
+- A results pane with `Table | Map` tabs. Map auto-selects when the result
+  carries a geometry column. The geometry column is identified from the
+  server-supplied `GeometryColumnIndex`, never from client guessing.
+- A collapsible EXPLAIN tree with per-node row counts, actual time, and a
+  warning chip when the planner row estimate is off by ≥10×.
+- Save-as-view dialog that returns FeatureServer / OGC API Features /
+  OData URLs once the named view is registered.
+- Per-query mutation override dialog. The operator must tick the
+  acknowledgement before the request is re-sent with `allowMutation=true`;
+  the resulting `auditEntryId` is shown back next to the result chip.
+- Result export to CSV, GeoJSON, and clipboard. Exports refuse to run
+  while the result is truncated until the operator opts in via the
+  toolbar.
+
+#### Wiring
+
+Backend calls funnel through `ISpatialSqlClient`
+(`src/Honua.Admin/Services/SpatialSql/`). S1 ships the deterministic
+`StubSpatialSqlClient`, which seeds two geometry tables, a curated PostGIS
+reference, and an in-memory named-view registry. The HTTP-backed client
+will land once the matching server endpoints
+(`POST /api/v1/admin/sql/{execute,explain,views}`,
+`GET /api/v1/admin/sql/schema`) ship — the page is feature-flagged behind
+the operator role until then.
+
+`SpatialSqlPlaygroundState` emits `ISpatialSqlTelemetry` events
+(`schema_loaded`, `query_submitted`, `query_completed`, `query_rejected`,
+`mutation_override_accepted`, `cap_reached`, `view_saved`,
+`export_triggered`) via the default `ILogger` sink. AOT/trim-friendly:
+all DTOs are wired through the source-generated `SpatialSqlJsonContext`;
+the EXPLAIN parser and exporter are reflection-free; the MapLibre interop
+re-uses the existing vendored bootstrap from the spec workspace.
+
+The S1 scope deliberately excludes Monaco / CodeMirror integration, write
+SQL beyond the per-query override, multi-database routing, query history
+sharing across operators, and live `pg_proc` introspection — each is
+tracked as a follow-on against `honua-server` or a future admin ticket.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the official admin UI for managing Honua Server instances:
 ## Architecture
 
 - **Frontend**: Blazor WebAssembly with MudBlazor components
-- **Backend Communication**: Operator S1 uses the in-repo `ISpecWorkspaceClient` stub; the [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) gRPC client swap is a follow-on
+- **Backend Communication**: Operator S1 uses the in-repo `ISpecWorkspaceClient` and `ISpatialSqlClient` stubs; the [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) gRPC client and the SQL HTTP adapter swap in once the matching server endpoints land
 - **Deployment**: Static web app (can be hosted on CDN)
 
 ## Development
@@ -296,6 +296,10 @@ The route includes:
 
 - A SQL editor with PostGIS-aware highlighting and schema-driven
   autocomplete (tables, columns, PostGIS function/operator reference).
+  Built on the same textarea+overlay pattern as the spec workspace's
+  `DslSectionEditor` — Monaco / CodeMirror is deliberately deferred to
+  keep the WASM bundle flat; the inner widget can be swapped later
+  without touching `SqlEditor.razor`'s public surface.
 - A schema sidebar with click-to-insert tables, columns, and PostGIS
   helpers, plus a manual refresh button to defeat cache staleness.
 - A results pane with `Table | Map` tabs. Map auto-selects when the result
@@ -304,7 +308,9 @@ The route includes:
 - A collapsible EXPLAIN tree with per-node row counts, actual time, and a
   warning chip when the planner row estimate is off by ≥10×.
 - Save-as-view dialog that returns FeatureServer / OGC API Features /
-  OData URLs once the named view is registered.
+  OData URLs once the named view is registered. The dialog stays open on
+  success and renders each URL with a copy-to-clipboard button so the
+  operator can grab them before dismissing.
 - Per-query mutation override dialog. The operator must tick the
   acknowledgement before the request is re-sent with `allowMutation=true`;
   the resulting `auditEntryId` is shown back next to the result chip.
@@ -320,16 +326,35 @@ Backend calls funnel through `ISpatialSqlClient`
 reference, and an in-memory named-view registry. The HTTP-backed client
 will land once the matching server endpoints
 (`POST /api/v1/admin/sql/{execute,explain,views}`,
-`GET /api/v1/admin/sql/schema`) ship — the page is feature-flagged behind
-the operator role until then.
+`GET /api/v1/admin/sql/schema`) ship — the page is kept behind
+`[Authorize]` (the same `DevAuthenticationStateProvider` that backs the
+spec workspace) until then.
 
-`SpatialSqlPlaygroundState` emits `ISpatialSqlTelemetry` events
-(`schema_loaded`, `query_submitted`, `query_completed`, `query_rejected`,
-`mutation_override_accepted`, `cap_reached`, `view_saved`,
-`export_triggered`) via the default `ILogger` sink. AOT/trim-friendly:
-all DTOs are wired through the source-generated `SpatialSqlJsonContext`;
-the EXPLAIN parser and exporter are reflection-free; the MapLibre interop
-re-uses the existing vendored bootstrap from the spec workspace.
+`SpatialSqlPlaygroundState` emits `ISpatialSqlTelemetry` events via the
+default `ILogger` sink. The vocabulary is:
+
+| Event | Trigger |
+| --- | --- |
+| `schema_loaded` / `schema_load_failed` | autocomplete schema fetch outcome |
+| `query_submitted` | run-query button or keybinding (with `allow_mutation`) |
+| `query_completed` (latency) | run succeeded; carries `rows`, `truncated`, `has_geometry`, `audit_entry_id` |
+| `query_rejected` | server / client error (mutation block, transport, server error) |
+| `cap_reached` | result truncation flag; carries `row_limit` |
+| `explain_completed` (latency) / `explain_rejected` | EXPLAIN call outcome |
+| `view_saved` / `view_save_rejected` | named-view registration outcome |
+| `mutation_override_accepted` | operator confirmed the mutation dialog |
+| `export_triggered` | CSV / GeoJSON / clipboard export, with `format` and `rows` |
+| `export_rejected` | client-side export failure (e.g. non-WGS84 GeoJSON) surfaced as a toolbar alert |
+| `results_tab_changed` | operator toggled `Table` ↔ `Map` |
+
+AOT/trim-friendly: all DTOs (including the `MapPreviewFeature` JS-interop
+DTO) are declared in the source-generated `SpatialSqlJsonContext` ahead of
+the HTTP client landing, so the upcoming `HttpSpatialSqlClient` can
+serialize without reflection; the EXPLAIN parser and exporter are
+reflection-free; the MapLibre interop re-uses the existing vendored
+bootstrap from the spec workspace. GeoJSON export follows RFC 7946 — no
+legacy `crs` member, and non-WGS84 SRIDs are rejected so reprojection
+stays a server-side responsibility.
 
 The S1 scope deliberately excludes Monaco / CodeMirror integration, write
 SQL beyond the per-query override, multi-database routing, query history

--- a/README.md
+++ b/README.md
@@ -306,7 +306,10 @@ The route includes:
   carries a geometry column. The geometry column is identified from the
   server-supplied `GeometryColumnIndex`, never from client guessing.
 - A collapsible EXPLAIN tree with per-node row counts, actual time, and a
-  warning chip when the planner row estimate is off by ≥10×.
+  warning chip when the planner row estimate is off by ≥10×. EXPLAIN
+  refuses mutating SQL outright — `EXPLAIN ANALYZE` would execute the
+  statement on the server and the EXPLAIN endpoint has no audited
+  mutation-override hook, so the per-query override applies to Run only.
 - Save-as-view dialog that returns FeatureServer / OGC API Features /
   OData URLs once the named view is registered. The dialog stays open on
   success and renders each URL with a copy-to-clipboard button so the

--- a/README.md
+++ b/README.md
@@ -354,7 +354,10 @@ serialize without reflection; the EXPLAIN parser and exporter are
 reflection-free; the MapLibre interop re-uses the existing vendored
 bootstrap from the spec workspace. GeoJSON export follows RFC 7946 — no
 legacy `crs` member, and non-WGS84 SRIDs are rejected so reprojection
-stays a server-side responsibility.
+stays a server-side responsibility. The MapLibre preview enforces the
+same WGS84 guard: a non-4326 result keeps the operator on the table tab
+and surfaces a "preview requires WGS84" banner instead of mis-rendering
+coordinates.
 
 The S1 scope deliberately excludes Monaco / CodeMirror integration, write
 SQL beyond the per-query override, multi-database routing, query history

--- a/src/Honua.Admin/Components/SpatialSql/ExplainNodeView.razor
+++ b/src/Honua.Admin/Components/SpatialSql/ExplainNodeView.razor
@@ -1,0 +1,54 @@
+@* Recursive node renderer for the EXPLAIN tree. Pulled into its own component so
+   the parent can stay declarative and the recursion is clear. *@
+@using Honua.Admin.Models.SpatialSql
+
+<div class="explain-node" data-testid="@($"explain-node-{Node.NodeType.Replace(' ', '-').ToLowerInvariant()}")">
+    <MudStack Row Spacing="2" AlignItems="AlignItems.Center">
+        @if (Node.Children.Count > 0)
+        {
+            <MudIconButton Icon="@(_expanded ? Icons.Material.Filled.ExpandMore : Icons.Material.Filled.ChevronRight)"
+                           Size="Size.Small"
+                           OnClick="Toggle"
+                           data-testid="@($"explain-toggle-{Node.NodeType.Replace(' ', '-').ToLowerInvariant()}")" />
+        }
+        else
+        {
+            <span class="explain-node-spacer"></span>
+        }
+        <MudText Typo="Typo.body2"><strong>@Node.NodeType</strong></MudText>
+        @if (!string.IsNullOrWhiteSpace(Node.Relation))
+        {
+            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small">@Node.Relation</MudChip>
+        }
+        <MudChip T="string" Variant="Variant.Text" Size="Size.Small" data-testid="explain-node-rows">
+            rows @Node.ActualRows.ToString("0")
+        </MudChip>
+        <MudChip T="string" Variant="Variant.Text" Size="Size.Small" data-testid="explain-node-time">
+            @Node.ActualTotalMs.ToString("0.00") ms
+        </MudChip>
+        @if (Node.RowEstimateOff)
+        {
+            <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled" data-testid="explain-node-misestimate">
+                est ≠ actual (planned @Node.PlanRows.ToString("0"))
+            </MudChip>
+        }
+    </MudStack>
+    @if (_expanded && Node.Children.Count > 0)
+    {
+        <div class="explain-children">
+            @foreach (var child in Node.Children)
+            {
+                <ExplainNodeView Node="child" Depth="@(Depth + 1)" />
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private bool _expanded = true;
+
+    [Parameter] public required ExplainNode Node { get; set; }
+    [Parameter] public int Depth { get; set; }
+
+    private void Toggle() => _expanded = !_expanded;
+}

--- a/src/Honua.Admin/Components/SpatialSql/ExplainNodeView.razor
+++ b/src/Honua.Admin/Components/SpatialSql/ExplainNodeView.razor
@@ -1,5 +1,7 @@
 @* Recursive node renderer for the EXPLAIN tree. Pulled into its own component so
-   the parent can stay declarative and the recursion is clear. *@
+   the parent can stay declarative and the recursion is clear. Numeric formatting
+   uses InvariantCulture to keep '.' as the decimal separator across locales. *@
+@using System.Globalization
 @using Honua.Admin.Models.SpatialSql
 
 <div class="explain-node" data-testid="@($"explain-node-{Node.NodeType.Replace(' ', '-').ToLowerInvariant()}")">
@@ -21,15 +23,15 @@
             <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small">@Node.Relation</MudChip>
         }
         <MudChip T="string" Variant="Variant.Text" Size="Size.Small" data-testid="explain-node-rows">
-            rows @Node.ActualRows.ToString("0")
+            rows @Node.ActualRows.ToString("0", CultureInfo.InvariantCulture)
         </MudChip>
         <MudChip T="string" Variant="Variant.Text" Size="Size.Small" data-testid="explain-node-time">
-            @Node.ActualTotalMs.ToString("0.00") ms
+            @Node.ActualTotalMs.ToString("0.00", CultureInfo.InvariantCulture) ms
         </MudChip>
         @if (Node.RowEstimateOff)
         {
             <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled" data-testid="explain-node-misestimate">
-                est ≠ actual (planned @Node.PlanRows.ToString("0"))
+                est ≠ actual (planned @Node.PlanRows.ToString("0", CultureInfo.InvariantCulture))
             </MudChip>
         }
     </MudStack>

--- a/src/Honua.Admin/Components/SpatialSql/ExplainTreeView.razor
+++ b/src/Honua.Admin/Components/SpatialSql/ExplainTreeView.razor
@@ -1,0 +1,35 @@
+@* Recursive collapsible tree for EXPLAIN nodes. Each node shows its operator,
+   actual rows, planner-vs-actual delta, and accumulated time. Mis-estimated
+   rows (>= 10x off in either direction) get a warning chip. *@
+@using Honua.Admin.Models.SpatialSql
+
+<div class="spatial-sql-explain" data-testid="explain-tree">
+    @if (Plan is null)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text" data-testid="explain-empty">
+            Run EXPLAIN to populate the plan tree.
+        </MudAlert>
+    }
+    else if (Plan.IsError)
+    {
+        <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" data-testid="explain-error">
+            <strong>@Plan.Error!.Code</strong>: @Plan.Error.Message
+        </MudAlert>
+    }
+    else
+    {
+        <MudStack Row Spacing="2" AlignItems="AlignItems.Center" Class="mb-2">
+            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" data-testid="explain-total">
+                total @Plan.TotalElapsedMs.ToString("0.0") ms
+            </MudChip>
+            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" data-testid="explain-planning">
+                planning @Plan.PlanningMs.ToString("0.0") ms
+            </MudChip>
+        </MudStack>
+        <ExplainNodeView Node="Plan.Root" Depth="0" />
+    }
+</div>
+
+@code {
+    [Parameter] public ExplainPlan? Plan { get; set; }
+}

--- a/src/Honua.Admin/Components/SpatialSql/ExplainTreeView.razor
+++ b/src/Honua.Admin/Components/SpatialSql/ExplainTreeView.razor
@@ -1,6 +1,8 @@
 @* Recursive collapsible tree for EXPLAIN nodes. Each node shows its operator,
    actual rows, planner-vs-actual delta, and accumulated time. Mis-estimated
-   rows (>= 10x off in either direction) get a warning chip. *@
+   rows (>= 10x off in either direction) get a warning chip. Numeric formatting
+   uses InvariantCulture to keep '.' as the decimal separator across locales. *@
+@using System.Globalization
 @using Honua.Admin.Models.SpatialSql
 
 <div class="spatial-sql-explain" data-testid="explain-tree">
@@ -20,10 +22,10 @@
     {
         <MudStack Row Spacing="2" AlignItems="AlignItems.Center" Class="mb-2">
             <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" data-testid="explain-total">
-                total @Plan.TotalElapsedMs.ToString("0.0") ms
+                total @Plan.TotalElapsedMs.ToString("0.0", CultureInfo.InvariantCulture) ms
             </MudChip>
             <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" data-testid="explain-planning">
-                planning @Plan.PlanningMs.ToString("0.0") ms
+                planning @Plan.PlanningMs.ToString("0.0", CultureInfo.InvariantCulture) ms
             </MudChip>
         </MudStack>
         <ExplainNodeView Node="Plan.Root" Depth="0" />

--- a/src/Honua.Admin/Components/SpatialSql/MutationConfirmDialog.razor
+++ b/src/Honua.Admin/Components/SpatialSql/MutationConfirmDialog.razor
@@ -1,0 +1,51 @@
+@* Per-query operator override for write SQL. The operator must explicitly tick the
+   confirmation checkbox before the dialog returns Ok. The state store arms the
+   override; the next ExecuteAsync is sent with allowMutation=true and the
+   server records the audit entry. *@
+
+<MudDialog data-testid="mutation-confirm-dialog">
+    <DialogContent>
+        <MudStack Spacing="2">
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Filled" Dense="true">
+                This statement will modify data. Honua admin runs SQL read-only by default — submitting requires an explicit override.
+            </MudAlert>
+            <MudPaper Class="pa-2" Elevation="0">
+                <pre style="white-space: pre-wrap; word-break: break-word; margin: 0;">@Sql</pre>
+            </MudPaper>
+            <MudCheckBox T="bool"
+                         @bind-Value="_acknowledged"
+                         Color="Color.Warning"
+                         data-testid="mutation-confirm-ack">
+                I understand this will modify data and accept the audit log entry.
+            </MudCheckBox>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" data-testid="mutation-confirm-cancel">Cancel</MudButton>
+        <MudButton Color="Color.Warning"
+                   Variant="Variant.Filled"
+                   Disabled="@(!_acknowledged)"
+                   OnClick="Submit"
+                   data-testid="mutation-confirm-submit">
+            Run with override
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+
+    [Parameter] public string Sql { get; set; } = string.Empty;
+
+    private bool _acknowledged;
+
+    private void Submit()
+    {
+        if (_acknowledged)
+        {
+            Dialog.Close(DialogResult.Ok(true));
+        }
+    }
+
+    private void Cancel() => Dialog.Cancel();
+}

--- a/src/Honua.Admin/Components/SpatialSql/SaveViewDialog.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SaveViewDialog.razor
@@ -1,8 +1,10 @@
-@* Save current SQL as a named virtual layer. The dialog returns the
-   <c>NamedViewRegistration</c> from the server which the caller surfaces as the
-   FeatureServer / OGC API Features / OData URL chips. *@
+@* Save current SQL as a named virtual layer. After a successful registration the
+   dialog stays open and renders the FeatureServer / OGC API Features / OData URLs
+   so the operator can copy each one before dismissing. The dialog never auto-closes
+   on success — that would hide the URLs the operator came here to retrieve. *@
 @using Honua.Admin.Models.SpatialSql
 @using Honua.Admin.Services.SpatialSql
+@inject IJSRuntime JS
 
 <MudDialog data-testid="save-view-dialog">
     <DialogContent>
@@ -10,11 +12,13 @@
             <MudTextField T="string"
                           Label="Name"
                           Required="true"
+                          Disabled="@IsRegistered"
                           @bind-Value="_name"
                           data-testid="save-view-name" />
             <MudTextField T="string"
                           Label="Description (optional)"
                           Lines="3"
+                          Disabled="@IsRegistered"
                           @bind-Value="_description"
                           data-testid="save-view-description" />
             @if (_error is not null)
@@ -23,30 +27,45 @@
                     @_error
                 </MudAlert>
             }
-            @if (Registration is not null && !Registration.IsError)
+            @if (Registration is { IsError: false } reg)
             {
                 <MudPaper Class="pa-2" Elevation="0" data-testid="save-view-success">
-                    <MudText Typo="Typo.subtitle2">Registered as <code>@Registration.Name</code></MudText>
+                    <MudText Typo="Typo.subtitle2">Registered as <code>@reg.Name</code></MudText>
                     <MudStack Spacing="1" Class="mt-1">
-                        @if (Registration.FeatureServerUrl is not null)
+                        @if (reg.FeatureServerUrl is { } featureServerUrl)
                         {
                             <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
                                 <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Small">FeatureServer</MudChip>
-                                <code data-testid="save-view-featureserver-url">@Registration.FeatureServerUrl</code>
+                                <code data-testid="save-view-featureserver-url">@featureServerUrl</code>
+                                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
+                                               Size="Size.Small"
+                                               OnClick="@(() => CopyUrlAsync(featureServerUrl))"
+                                               data-testid="save-view-featureserver-copy"
+                                               title="Copy FeatureServer URL" />
                             </MudStack>
                         }
-                        @if (Registration.OgcFeaturesUrl is not null)
+                        @if (reg.OgcFeaturesUrl is { } ogcUrl)
                         {
                             <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
                                 <MudChip T="string" Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Small">OGC API</MudChip>
-                                <code data-testid="save-view-ogc-url">@Registration.OgcFeaturesUrl</code>
+                                <code data-testid="save-view-ogc-url">@ogcUrl</code>
+                                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
+                                               Size="Size.Small"
+                                               OnClick="@(() => CopyUrlAsync(ogcUrl))"
+                                               data-testid="save-view-ogc-copy"
+                                               title="Copy OGC API URL" />
                             </MudStack>
                         }
-                        @if (Registration.ODataUrl is not null)
+                        @if (reg.ODataUrl is { } odataUrl)
                         {
                             <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
                                 <MudChip T="string" Color="Color.Tertiary" Variant="Variant.Outlined" Size="Size.Small">OData</MudChip>
-                                <code data-testid="save-view-odata-url">@Registration.ODataUrl</code>
+                                <code data-testid="save-view-odata-url">@odataUrl</code>
+                                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
+                                               Size="Size.Small"
+                                               OnClick="@(() => CopyUrlAsync(odataUrl))"
+                                               data-testid="save-view-odata-copy"
+                                               title="Copy OData URL" />
                             </MudStack>
                         }
                     </MudStack>
@@ -55,14 +74,26 @@
         </MudStack>
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="Cancel" data-testid="save-view-cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary"
-                   Variant="Variant.Filled"
-                   Disabled="@_busy"
-                   OnClick="Submit"
-                   data-testid="save-view-submit">
-            Save
-        </MudButton>
+        @if (IsRegistered)
+        {
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       OnClick="Done"
+                       data-testid="save-view-done">
+                Done
+            </MudButton>
+        }
+        else
+        {
+            <MudButton OnClick="Cancel" data-testid="save-view-cancel">Cancel</MudButton>
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       Disabled="@_busy"
+                       OnClick="Submit"
+                       data-testid="save-view-submit">
+                Save
+            </MudButton>
+        }
     </DialogActions>
 </MudDialog>
 
@@ -77,6 +108,8 @@
     private bool _busy;
 
     public NamedViewRegistration? Registration { get; private set; }
+
+    private bool IsRegistered => Registration is { IsError: false };
 
     private async Task Submit()
     {
@@ -95,10 +128,9 @@
             {
                 _error = Registration.Error?.Message;
             }
-            else
-            {
-                Dialog.Close(DialogResult.Ok(Registration));
-            }
+            // Successful registration intentionally keeps the dialog open so the
+            // FeatureServer / OGC / OData URLs render and the operator can copy
+            // them. Dismissal happens via the Done button.
         }
         catch (Exception ex)
         {
@@ -110,5 +142,20 @@
         }
     }
 
+    private void Done() => Dialog.Close(DialogResult.Ok(Registration));
+
     private void Cancel() => Dialog.Cancel();
+
+    private async Task CopyUrlAsync(string url)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("spatialSql.copyToClipboard", url);
+        }
+        catch
+        {
+            // Clipboard API unavailable (test/pre-render); the URL stays visible
+            // in the success panel so the operator can copy manually.
+        }
+    }
 }

--- a/src/Honua.Admin/Components/SpatialSql/SaveViewDialog.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SaveViewDialog.razor
@@ -5,6 +5,7 @@
 @using Honua.Admin.Models.SpatialSql
 @using Honua.Admin.Services.SpatialSql
 @inject IJSRuntime JS
+@implements IDisposable
 
 <MudDialog data-testid="save-view-dialog">
     <DialogContent>
@@ -106,6 +107,7 @@
     private string _description = string.Empty;
     private string? _error;
     private bool _busy;
+    private CancellationTokenSource? _cts;
 
     public NamedViewRegistration? Registration { get; private set; }
 
@@ -121,9 +123,11 @@
         }
 
         _busy = true;
+        var cts = new CancellationTokenSource();
+        _cts = cts;
         try
         {
-            Registration = await State.SaveViewAsync(_name, _description, default);
+            Registration = await State.SaveViewAsync(_name, _description, cts.Token);
             if (Registration.IsError)
             {
                 _error = Registration.Error?.Message;
@@ -132,6 +136,14 @@
             // FeatureServer / OGC / OData URLs render and the operator can copy
             // them. Dismissal happens via the Done button.
         }
+        catch (OperationCanceledException)
+        {
+            // The operator dismissed the dialog (or the surrounding scope
+            // cancelled) while the save was in flight. The state store routes
+            // OCE to Idle and emits no view_save_rejected telemetry; the
+            // dialog must mirror that and not surface a red "operation
+            // canceled" error.
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
@@ -139,12 +151,31 @@
         finally
         {
             _busy = false;
+            if (ReferenceEquals(_cts, cts))
+            {
+                _cts = null;
+            }
+            cts.Dispose();
         }
     }
 
     private void Done() => Dialog.Close(DialogResult.Ok(Registration));
 
-    private void Cancel() => Dialog.Cancel();
+    private void Cancel()
+    {
+        // Cancel any in-flight save first so the awaited SaveViewAsync raises
+        // OCE (which the Submit catch handles silently) instead of completing
+        // against a torn-down dialog.
+        _cts?.Cancel();
+        Dialog.Cancel();
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+    }
 
     private async Task CopyUrlAsync(string url)
     {

--- a/src/Honua.Admin/Components/SpatialSql/SaveViewDialog.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SaveViewDialog.razor
@@ -1,0 +1,114 @@
+@* Save current SQL as a named virtual layer. The dialog returns the
+   <c>NamedViewRegistration</c> from the server which the caller surfaces as the
+   FeatureServer / OGC API Features / OData URL chips. *@
+@using Honua.Admin.Models.SpatialSql
+@using Honua.Admin.Services.SpatialSql
+
+<MudDialog data-testid="save-view-dialog">
+    <DialogContent>
+        <MudStack Spacing="2">
+            <MudTextField T="string"
+                          Label="Name"
+                          Required="true"
+                          @bind-Value="_name"
+                          data-testid="save-view-name" />
+            <MudTextField T="string"
+                          Label="Description (optional)"
+                          Lines="3"
+                          @bind-Value="_description"
+                          data-testid="save-view-description" />
+            @if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" data-testid="save-view-error">
+                    @_error
+                </MudAlert>
+            }
+            @if (Registration is not null && !Registration.IsError)
+            {
+                <MudPaper Class="pa-2" Elevation="0" data-testid="save-view-success">
+                    <MudText Typo="Typo.subtitle2">Registered as <code>@Registration.Name</code></MudText>
+                    <MudStack Spacing="1" Class="mt-1">
+                        @if (Registration.FeatureServerUrl is not null)
+                        {
+                            <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+                                <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Small">FeatureServer</MudChip>
+                                <code data-testid="save-view-featureserver-url">@Registration.FeatureServerUrl</code>
+                            </MudStack>
+                        }
+                        @if (Registration.OgcFeaturesUrl is not null)
+                        {
+                            <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+                                <MudChip T="string" Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Small">OGC API</MudChip>
+                                <code data-testid="save-view-ogc-url">@Registration.OgcFeaturesUrl</code>
+                            </MudStack>
+                        }
+                        @if (Registration.ODataUrl is not null)
+                        {
+                            <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+                                <MudChip T="string" Color="Color.Tertiary" Variant="Variant.Outlined" Size="Size.Small">OData</MudChip>
+                                <code data-testid="save-view-odata-url">@Registration.ODataUrl</code>
+                            </MudStack>
+                        }
+                    </MudStack>
+                </MudPaper>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" data-testid="save-view-cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   Disabled="@_busy"
+                   OnClick="Submit"
+                   data-testid="save-view-submit">
+            Save
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+
+    [Parameter] public SpatialSqlPlaygroundState State { get; set; } = default!;
+
+    private string _name = string.Empty;
+    private string _description = string.Empty;
+    private string? _error;
+    private bool _busy;
+
+    public NamedViewRegistration? Registration { get; private set; }
+
+    private async Task Submit()
+    {
+        _error = null;
+        if (string.IsNullOrWhiteSpace(_name))
+        {
+            _error = "A view name is required.";
+            return;
+        }
+
+        _busy = true;
+        try
+        {
+            Registration = await State.SaveViewAsync(_name, _description, default);
+            if (Registration.IsError)
+            {
+                _error = Registration.Error?.Message;
+            }
+            else
+            {
+                Dialog.Close(DialogResult.Ok(Registration));
+            }
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private void Cancel() => Dialog.Cancel();
+}

--- a/src/Honua.Admin/Components/SpatialSql/SchemaExplorer.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SchemaExplorer.razor
@@ -1,0 +1,102 @@
+@* Schema sidebar — shows tables/columns/PostGIS reference. Clicking a column or
+   function inserts the token into the SQL editor through the playground state. *@
+@using Honua.Admin.Models.SpatialSql
+@using Honua.Admin.Services.SpatialSql
+
+<div class="spatial-sql-schema" data-testid="sql-schema-explorer">
+    <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+        <MudText Typo="Typo.subtitle2">Schema</MudText>
+        <MudSpacer />
+        <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                       Size="Size.Small"
+                       OnClick="OnRefreshRequested"
+                       data-testid="sql-schema-refresh"
+                       title="Refresh schema" />
+    </MudStack>
+
+    @if (Snapshot is null)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text" data-testid="sql-schema-empty">
+            Loading schema…
+        </MudAlert>
+    }
+    else
+    {
+        <MudExpansionPanels MultiExpansion="true" Dense="true" Elevation="0">
+            <MudExpansionPanel Text="Tables" Expanded="true" data-testid="sql-schema-tables">
+                <MudStack Spacing="1">
+                    @foreach (var table in Snapshot.Tables)
+                    {
+                        <MudPaper Class="pa-1" Elevation="0" data-testid="@($"sql-schema-table-{table.Name}")">
+                            <MudButton Variant="Variant.Text"
+                                       Size="Size.Small"
+                                       StartIcon="@Icons.Material.Filled.TableChart"
+                                       OnClick="@(() => InsertTokenAsync(table.Name))"
+                                       data-testid="@($"sql-schema-table-insert-{table.Name}")">
+                                @table.Name
+                            </MudButton>
+                            <MudStack Spacing="0" Class="pl-3">
+                                @foreach (var column in table.Columns)
+                                {
+                                    <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                                        <MudButton Variant="Variant.Text"
+                                                   Size="Size.Small"
+                                                   OnClick="@(() => InsertTokenAsync(column.Name))"
+                                                   data-testid="@($"sql-schema-column-{table.Name}-{column.Name}")">
+                                            @column.Name
+                                        </MudButton>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@column.Type</MudText>
+                                        @if (string.Equals(column.Name, table.GeometryColumn, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            <MudChip T="string" Color="Color.Primary" Size="Size.Small" Variant="Variant.Outlined">geom</MudChip>
+                                        }
+                                    </MudStack>
+                                }
+                            </MudStack>
+                        </MudPaper>
+                    }
+                </MudStack>
+            </MudExpansionPanel>
+            <MudExpansionPanel Text="PostGIS functions" data-testid="sql-schema-functions">
+                <MudStack Spacing="1">
+                    @foreach (var fn in Snapshot.Functions)
+                    {
+                        <MudButton Variant="Variant.Text"
+                                   Size="Size.Small"
+                                   OnClick="@(() => InsertTokenAsync(fn.Name + "("))"
+                                   data-testid="@($"sql-schema-fn-{fn.Name}")"
+                                   title="@fn.Documentation">
+                            <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+                                <MudText Typo="Typo.body2"><strong>@fn.Name</strong></MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@fn.Signature</MudText>
+                            </MudStack>
+                        </MudButton>
+                    }
+                </MudStack>
+            </MudExpansionPanel>
+            <MudExpansionPanel Text="PostGIS operators" data-testid="sql-schema-operators">
+                <MudStack Spacing="0">
+                    @foreach (var op in Snapshot.Operators)
+                    {
+                        <MudStack Row AlignItems="AlignItems.Center" Spacing="2" data-testid="@($"sql-schema-op-{op.Symbol}")">
+                            <MudText Typo="Typo.body2"><code>@op.Symbol</code></MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@op.Description</MudText>
+                        </MudStack>
+                    }
+                </MudStack>
+            </MudExpansionPanel>
+        </MudExpansionPanels>
+    }
+</div>
+
+@code {
+    [Parameter] public SchemaSnapshot? Snapshot { get; set; }
+
+    [Parameter] public EventCallback<string> OnInsertToken { get; set; }
+
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    private Task InsertTokenAsync(string token) => OnInsertToken.InvokeAsync(token);
+
+    private Task OnRefreshRequested() => OnRefresh.InvokeAsync();
+}

--- a/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
@@ -116,7 +116,7 @@
                             <SqlTableResults Result="@State.LastResult" />
                         </MudTabPanel>
                         <MudTabPanel Text="Map" Disabled="@(State.LastResult is null || !State.LastResult.HasGeometry)" data-testid="sql-results-tab-map">
-                            <SqlMapPreview Features="@State.BuildMapFeatures()" />
+                            <SqlMapPreview Features="@State.BuildMapFeatures()" BlockedReason="@State.MapPreviewBlockedReason" />
                         </MudTabPanel>
                     </MudTabs>
                 </MudStack>

--- a/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
@@ -228,19 +228,26 @@
 
     private async Task ExportCsvAsync()
     {
-        var csv = State.ExportCsv();
-        await DownloadAsync("results.csv", "text/csv", csv);
+        if (TryExport(State.ExportCsv) is { } csv)
+        {
+            await DownloadAsync("results.csv", "text/csv", csv);
+        }
     }
 
     private async Task ExportGeoJsonAsync()
     {
-        var geojson = State.ExportGeoJson();
-        await DownloadAsync("results.geojson", "application/geo+json", geojson);
+        if (TryExport(State.ExportGeoJson) is { } geojson)
+        {
+            await DownloadAsync("results.geojson", "application/geo+json", geojson);
+        }
     }
 
     private async Task ExportClipboardAsync()
     {
-        var text = State.ExportClipboard();
+        if (TryExport(State.ExportClipboard) is not { } text)
+        {
+            return;
+        }
         try
         {
             await JS.InvokeVoidAsync("spatialSql.copyToClipboard", text);
@@ -248,6 +255,19 @@
         catch
         {
             // No clipboard support — keep the export attempt non-fatal.
+        }
+    }
+
+    private string? TryExport(Func<string> exporter)
+    {
+        try
+        {
+            return exporter();
+        }
+        catch (InvalidOperationException ex)
+        {
+            State.SetExportError(ex.Message);
+            return null;
         }
     }
 

--- a/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
@@ -157,8 +157,7 @@
         or SpatialSqlPaneStatus.Explaining
         or SpatialSqlPaneStatus.Saving;
 
-    private bool CanSaveView => !_isBusy
-        && State.LastResult is { IsError: false, Rows.Count: > 0 };
+    private bool CanSaveView => !_isBusy && State.CanSaveCurrentResult();
 
     private bool CanExport => State.CanExportRows();
 

--- a/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SpatialSqlPlaygroundBody.razor
@@ -1,0 +1,277 @@
+@* Three-pane SQL playground body — Editor + Schema | Results + Map | EXPLAIN.
+   Uses the same shell idiom as <c>SpecWorkspaceBody</c>: a grid of cells with
+   the action toolbar pinned at the top so the editor and result panes share
+   identical layout chrome. *@
+@using Honua.Admin.Models.SpatialSql
+@using Honua.Admin.Services.SpatialSql
+@inject SpatialSqlPlaygroundState State
+@inject IDialogService DialogService
+@inject IJSRuntime JS
+@implements IDisposable
+
+<div class="spatial-sql-root" data-testid="spatial-sql-root">
+    <div class="spatial-sql-toolbar">
+        <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+            <MudButton StartIcon="@Icons.Material.Filled.PlayArrow"
+                       Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       Size="Size.Small"
+                       Disabled="@_isBusy"
+                       OnClick="OnRunAsync"
+                       data-testid="sql-run-button">
+                Run
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Insights"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@_isBusy"
+                       OnClick="OnExplainAsync"
+                       data-testid="sql-explain-button">
+                EXPLAIN
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Save"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@(!CanSaveView)"
+                       OnClick="OnSaveAsViewAsync"
+                       data-testid="sql-save-button">
+                Save as view
+            </MudButton>
+            <MudSpacer />
+            <MudButton StartIcon="@Icons.Material.Filled.GetApp"
+                       Variant="Variant.Text"
+                       Size="Size.Small"
+                       Disabled="@(!CanExport)"
+                       OnClick="ExportCsvAsync"
+                       data-testid="sql-export-csv">
+                CSV
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Map"
+                       Variant="Variant.Text"
+                       Size="Size.Small"
+                       Disabled="@(!CanExportGeoJson)"
+                       OnClick="ExportGeoJsonAsync"
+                       data-testid="sql-export-geojson">
+                GeoJSON
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.ContentCopy"
+                       Variant="Variant.Text"
+                       Size="Size.Small"
+                       Disabled="@(!CanExport)"
+                       OnClick="ExportClipboardAsync"
+                       data-testid="sql-export-clipboard">
+                Copy
+            </MudButton>
+        </MudStack>
+        @if (State.LastError is not null)
+        {
+            <MudAlert Severity="Severity.Error" Class="mt-2" Dense="true" Variant="Variant.Filled" data-testid="sql-toolbar-error">
+                @State.LastError
+            </MudAlert>
+        }
+        @if (State.LastResult is { Truncated: true })
+        {
+            <MudStack Row Spacing="2" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" Class="flex-grow-1" data-testid="sql-toolbar-truncated">
+                    Result was capped at @State.LastResult.RowLimit rows. Exports require explicit confirmation.
+                </MudAlert>
+                <MudButton Size="Size.Small"
+                           Variant="Variant.Outlined"
+                           Color="Color.Warning"
+                           OnClick="ConfirmTruncatedExport"
+                           Disabled="@State.ExportTruncatedConfirmed"
+                           data-testid="sql-confirm-truncated">
+                    @(State.ExportTruncatedConfirmed ? "Truncated export armed" : "Allow truncated export")
+                </MudButton>
+            </MudStack>
+        }
+    </div>
+
+    <div class="spatial-sql-grid">
+        <div class="spatial-sql-cell spatial-sql-editor-cell" data-testid="spatial-sql-editor-cell">
+            <MudPaper Class="spec-pane pa-2 h-100" Elevation="0">
+                <MudStack Class="h-100" Spacing="2">
+                    <MudText Typo="Typo.h6">SQL editor</MudText>
+                    <SqlEditor @ref="_editorRef"
+                               Sql="@State.Sql"
+                               SqlChanged="OnSqlChanged"
+                               Schema="@State.Schema" />
+                    <SchemaExplorer Snapshot="@State.Schema"
+                                    OnInsertToken="InsertSchemaToken"
+                                    OnRefresh="RefreshSchemaAsync" />
+                </MudStack>
+            </MudPaper>
+        </div>
+
+        <div class="spatial-sql-cell spatial-sql-results-cell" data-testid="spatial-sql-results-cell">
+            <MudPaper Class="spec-pane pa-2 h-100" Elevation="0">
+                <MudStack Class="h-100" Spacing="2">
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                        <MudText Typo="Typo.h6">Results</MudText>
+                        <MudSpacer />
+                        <MudChip T="string" Color="@StatusColor(State.Status)" Size="Size.Small" Variant="Variant.Outlined" data-testid="sql-status-chip">@State.Status</MudChip>
+                    </MudStack>
+                    <MudTabs Outlined="true" Position="Position.Top" ActivePanelIndex="@_activeTabIndex" ActivePanelIndexChanged="OnTabChanged">
+                        <MudTabPanel Text="Table" data-testid="sql-results-tab-table">
+                            <SqlTableResults Result="@State.LastResult" />
+                        </MudTabPanel>
+                        <MudTabPanel Text="Map" Disabled="@(State.LastResult is null || !State.LastResult.HasGeometry)" data-testid="sql-results-tab-map">
+                            <SqlMapPreview Features="@State.BuildMapFeatures()" />
+                        </MudTabPanel>
+                    </MudTabs>
+                </MudStack>
+            </MudPaper>
+        </div>
+
+        <div class="spatial-sql-cell spatial-sql-plan-cell" data-testid="spatial-sql-plan-cell">
+            <MudPaper Class="spec-pane pa-2 h-100" Elevation="0">
+                <MudStack Class="h-100" Spacing="2">
+                    <MudText Typo="Typo.h6">Plan</MudText>
+                    <ExplainTreeView Plan="@State.LastPlan" />
+                </MudStack>
+            </MudPaper>
+        </div>
+    </div>
+</div>
+
+@code {
+    private SqlEditor? _editorRef;
+    private int _activeTabIndex;
+
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += StateChanged;
+        if (State.Schema is null)
+        {
+            await State.LoadSchemaAsync();
+        }
+        SyncTabIndex();
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= StateChanged;
+    }
+
+    private bool _isBusy => State.Status is SpatialSqlPaneStatus.Executing
+        or SpatialSqlPaneStatus.Explaining
+        or SpatialSqlPaneStatus.Saving;
+
+    private bool CanSaveView => !_isBusy
+        && State.LastResult is { IsError: false, Rows.Count: > 0 };
+
+    private bool CanExport => State.CanExportRows();
+
+    private bool CanExportGeoJson => CanExport && State.LastResult?.HasGeometry == true;
+
+    private async Task OnRunAsync()
+    {
+        if (MutationGuard.IsMutating(State.Sql) && !State.MutationOverrideArmed)
+        {
+            var parameters = new DialogParameters { ["Sql"] = State.Sql };
+            var dialog = await DialogService.ShowAsync<MutationConfirmDialog>("Confirm mutation", parameters);
+            var result = await dialog.Result;
+            if (result is null || result.Canceled)
+            {
+                return;
+            }
+            State.ArmMutationOverride();
+        }
+        await State.RunQueryAsync();
+    }
+
+    private Task OnExplainAsync() => State.RunExplainAsync();
+
+    private async Task OnSaveAsViewAsync()
+    {
+        var parameters = new DialogParameters { ["State"] = State };
+        await DialogService.ShowAsync<SaveViewDialog>("Save as named view", parameters);
+    }
+
+    private void OnSqlChanged(string sql)
+    {
+        State.SetSql(sql);
+    }
+
+    private async Task InsertSchemaToken(string token)
+    {
+        if (_editorRef is not null)
+        {
+            await _editorRef.InsertExternalTokenAsync(token);
+        }
+        else
+        {
+            State.SetSql(string.IsNullOrWhiteSpace(State.Sql) ? token : $"{State.Sql} {token}");
+        }
+    }
+
+    private Task RefreshSchemaAsync() => State.LoadSchemaAsync();
+
+    private void StateChanged()
+    {
+        SyncTabIndex();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void SyncTabIndex()
+    {
+        _activeTabIndex = State.ResultsTab == "map" ? 1 : 0;
+    }
+
+    private void OnTabChanged(int index)
+    {
+        _activeTabIndex = index;
+        State.SetResultsTab(index == 1 ? "map" : "table");
+    }
+
+    private void ConfirmTruncatedExport() => State.ConfirmTruncatedExport();
+
+    private async Task ExportCsvAsync()
+    {
+        var csv = State.ExportCsv();
+        await DownloadAsync("results.csv", "text/csv", csv);
+    }
+
+    private async Task ExportGeoJsonAsync()
+    {
+        var geojson = State.ExportGeoJson();
+        await DownloadAsync("results.geojson", "application/geo+json", geojson);
+    }
+
+    private async Task ExportClipboardAsync()
+    {
+        var text = State.ExportClipboard();
+        try
+        {
+            await JS.InvokeVoidAsync("spatialSql.copyToClipboard", text);
+        }
+        catch
+        {
+            // No clipboard support — keep the export attempt non-fatal.
+        }
+    }
+
+    private async Task DownloadAsync(string filename, string mimeType, string content)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("spatialSql.downloadFile", filename, mimeType, content);
+        }
+        catch
+        {
+            // Pre-render / test environments do not have the helper; the export
+            // still succeeded at the state-store level.
+        }
+    }
+
+    private static Color StatusColor(SpatialSqlPaneStatus status) => status switch
+    {
+        SpatialSqlPaneStatus.Idle => Color.Default,
+        SpatialSqlPaneStatus.Loading => Color.Info,
+        SpatialSqlPaneStatus.Executing => Color.Info,
+        SpatialSqlPaneStatus.Explaining => Color.Info,
+        SpatialSqlPaneStatus.Saving => Color.Info,
+        SpatialSqlPaneStatus.Error => Color.Error,
+        _ => Color.Default
+    };
+}

--- a/src/Honua.Admin/Components/SpatialSql/SqlEditor.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SqlEditor.razor
@@ -1,0 +1,300 @@
+@* SQL editor + autocomplete dropdown. Built on the same textarea+overlay pattern
+   as DslSectionEditor — keeps the bundle flat and reuses the existing
+   spec-workspace-interop selection helper. The autocomplete catalogue is
+   schema-aware: typing inside a token offers tables, columns, PostGIS
+   functions, and PostGIS operators. *@
+@using System.Text
+@using System.Text.Encodings.Web
+@using Honua.Admin.Models.SpatialSql
+@inject IJSRuntime JS
+
+<div class="spatial-sql-editor" data-testid="sql-editor-shell">
+    <div class="spec-editor-shell">
+        <pre class="spec-editor-underlay" aria-hidden="true">@((MarkupString)BuildHighlight())</pre>
+        <textarea class="spec-editor-input"
+                  value="@Sql"
+                  @ref="_editorRef"
+                  @oninput="HandleInputAsync"
+                  @onclick="HandleSelectionChangedAsync"
+                  @onkeyup="HandleSelectionChangedAsync"
+                  @onmouseup="HandleSelectionChangedAsync"
+                  data-testid="sql-editor-textarea"
+                  spellcheck="false"></textarea>
+    </div>
+
+    @if (_completions.Count > 0)
+    {
+        <MudPaper Class="spec-intellisense-popover mt-2 pa-1" Elevation="0" data-testid="sql-editor-completions">
+            <MudList T="string" Dense="true">
+                @foreach (var item in _completions)
+                {
+                    <MudListItem T="string"
+                                 OnClick="@(() => InsertCompletionAsync(item))"
+                                 Icon="@IconFor(item.Kind)"
+                                 data-testid="@($"sql-completion-{item.Kind}-{item.Token}")">
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.body2"><strong>@item.Label</strong></MudText>
+                            @if (!string.IsNullOrWhiteSpace(item.Detail))
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@item.Detail</MudText>
+                            }
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    }
+</div>
+
+@code {
+    [Parameter] public string Sql { get; set; } = string.Empty;
+
+    [Parameter] public EventCallback<string> SqlChanged { get; set; }
+
+    [Parameter] public SchemaSnapshot? Schema { get; set; }
+
+    private ElementReference _editorRef;
+    private int _selectionStart;
+    private int _selectionEnd;
+    private List<CompletionItem> _completions = new();
+
+    private async Task HandleInputAsync(ChangeEventArgs args)
+    {
+        Sql = args.Value?.ToString() ?? string.Empty;
+        await SqlChanged.InvokeAsync(Sql);
+        await RefreshSelectionAsync();
+        BuildCompletions();
+    }
+
+    private async Task HandleSelectionChangedAsync()
+    {
+        await RefreshSelectionAsync();
+        BuildCompletions();
+    }
+
+    private async Task RefreshSelectionAsync()
+    {
+        try
+        {
+            var selection = await JS.InvokeAsync<TextSelection>("specWorkspace.getTextSelection", _editorRef);
+            _selectionStart = selection.Start;
+            _selectionEnd = selection.End;
+        }
+        catch
+        {
+            _selectionStart = Sql.Length;
+            _selectionEnd = Sql.Length;
+        }
+    }
+
+    private void BuildCompletions()
+    {
+        _completions.Clear();
+        if (Schema is null)
+        {
+            return;
+        }
+
+        var cursor = Math.Clamp(_selectionStart, 0, Sql.Length);
+        var prefixSpan = ExtractPrefix(Sql, cursor);
+        if (prefixSpan is null)
+        {
+            return;
+        }
+
+        var (prefix, _, _) = prefixSpan.Value;
+        if (prefix.Length == 0)
+        {
+            return;
+        }
+
+        var lowered = prefix.ToLowerInvariant();
+        foreach (var table in Schema.Tables)
+        {
+            if (table.Name.StartsWith(lowered, StringComparison.OrdinalIgnoreCase))
+            {
+                _completions.Add(new CompletionItem(
+                    Token: table.Name,
+                    Label: table.Name,
+                    Detail: table.Description ?? "table",
+                    Kind: CompletionKind.Table));
+            }
+
+            foreach (var column in table.Columns)
+            {
+                if (column.Name.StartsWith(lowered, StringComparison.OrdinalIgnoreCase))
+                {
+                    _completions.Add(new CompletionItem(
+                        Token: column.Name,
+                        Label: column.Name,
+                        Detail: $"{table.Name}.{column.Type}",
+                        Kind: CompletionKind.Column));
+                }
+            }
+        }
+
+        foreach (var fn in Schema.Functions)
+        {
+            if (fn.Name.StartsWith(lowered, StringComparison.OrdinalIgnoreCase))
+            {
+                _completions.Add(new CompletionItem(
+                    Token: fn.Name,
+                    Label: fn.Name,
+                    Detail: fn.Signature,
+                    Kind: CompletionKind.Function));
+            }
+        }
+
+        if (_completions.Count > 12)
+        {
+            _completions = _completions.Take(12).ToList();
+        }
+    }
+
+    private async Task InsertCompletionAsync(CompletionItem item)
+    {
+        var span = ExtractPrefix(Sql, _selectionStart);
+        if (span is null)
+        {
+            _completions.Clear();
+            return;
+        }
+
+        var (_, start, end) = span.Value;
+        var insertion = item.Kind == CompletionKind.Function ? item.Token + "(" : item.Token;
+        var next = Sql[..start] + insertion + Sql[end..];
+        Sql = next;
+        _selectionStart = start + insertion.Length;
+        _selectionEnd = _selectionStart;
+        _completions.Clear();
+        await SqlChanged.InvokeAsync(Sql);
+    }
+
+    public async Task InsertExternalTokenAsync(string token)
+    {
+        var insertionStart = Math.Clamp(_selectionStart, 0, Sql.Length);
+        var insertionEnd = Math.Clamp(_selectionEnd, insertionStart, Sql.Length);
+        Sql = Sql[..insertionStart] + token + Sql[insertionEnd..];
+        _selectionStart = insertionStart + token.Length;
+        _selectionEnd = _selectionStart;
+        _completions.Clear();
+        await SqlChanged.InvokeAsync(Sql);
+    }
+
+    private static (string Prefix, int Start, int End)? ExtractPrefix(string sql, int cursor)
+    {
+        cursor = Math.Clamp(cursor, 0, sql.Length);
+        var start = cursor;
+        while (start > 0 && IsTokenChar(sql[start - 1]))
+        {
+            start--;
+        }
+        if (start == cursor)
+        {
+            return null;
+        }
+        return (sql[start..cursor], start, cursor);
+    }
+
+    private static bool IsTokenChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '_';
+
+    private string BuildHighlight()
+    {
+        if (Sql.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        var index = 0;
+        while (index < Sql.Length)
+        {
+            var ch = Sql[index];
+            if (char.IsLetter(ch) || ch == '_')
+            {
+                var end = index;
+                while (end < Sql.Length && (char.IsLetterOrDigit(Sql[end]) || Sql[end] == '_'))
+                {
+                    end++;
+                }
+                var token = Sql[index..end];
+                if (SqlKeywords.Contains(token.ToUpperInvariant()))
+                {
+                    sb.Append("<span class=\"sql-keyword\">");
+                    sb.Append(HtmlEncoder.Default.Encode(token));
+                    sb.Append("</span>");
+                }
+                else if (token.StartsWith("ST_", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append("<span class=\"sql-postgis\">");
+                    sb.Append(HtmlEncoder.Default.Encode(token));
+                    sb.Append("</span>");
+                }
+                else
+                {
+                    sb.Append(HtmlEncoder.Default.Encode(token));
+                }
+                index = end;
+            }
+            else if (ch == '\'')
+            {
+                var end = index + 1;
+                while (end < Sql.Length && Sql[end] != '\'')
+                {
+                    end++;
+                }
+                end = Math.Min(end + 1, Sql.Length);
+                sb.Append("<span class=\"sql-literal\">");
+                sb.Append(HtmlEncoder.Default.Encode(Sql[index..end]));
+                sb.Append("</span>");
+                index = end;
+            }
+            else if (ch == '-' && index + 1 < Sql.Length && Sql[index + 1] == '-')
+            {
+                var end = index;
+                while (end < Sql.Length && Sql[end] != '\n')
+                {
+                    end++;
+                }
+                sb.Append("<span class=\"sql-comment\">");
+                sb.Append(HtmlEncoder.Default.Encode(Sql[index..end]));
+                sb.Append("</span>");
+                index = end;
+            }
+            else
+            {
+                sb.Append(HtmlEncoder.Default.Encode(ch.ToString()));
+                index++;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static readonly HashSet<string> SqlKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SELECT", "FROM", "WHERE", "GROUP", "BY", "ORDER", "LIMIT", "OFFSET", "JOIN", "ON", "INNER",
+        "LEFT", "RIGHT", "OUTER", "AS", "AND", "OR", "NOT", "IN", "IS", "NULL", "CASE", "WHEN",
+        "THEN", "ELSE", "END", "WITH", "UNION", "ALL", "DISTINCT", "HAVING", "EXISTS", "EXPLAIN",
+        "ANALYZE", "ASC", "DESC", "TRUE", "FALSE"
+    };
+
+    private static string IconFor(CompletionKind kind) => kind switch
+    {
+        CompletionKind.Table => Icons.Material.Filled.TableChart,
+        CompletionKind.Column => Icons.Material.Filled.ViewColumn,
+        CompletionKind.Function => Icons.Material.Filled.Functions,
+        _ => Icons.Material.Filled.Code
+    };
+
+    private sealed record CompletionItem(string Token, string Label, string Detail, CompletionKind Kind);
+
+    private enum CompletionKind
+    {
+        Table,
+        Column,
+        Function
+    }
+
+    private sealed record TextSelection(int Start, int End);
+}

--- a/src/Honua.Admin/Components/SpatialSql/SqlMapPreview.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SqlMapPreview.razor
@@ -42,6 +42,12 @@
     {
         if (!string.IsNullOrEmpty(BlockedReason) || Features.Count == 0)
         {
+            // Canvas is no longer in the DOM. If we initialized a map on a prior
+            // render, tear down the JS state now — the cached entry's container
+            // points at a detached element, and the maplibre instance bound to it
+            // would otherwise be reused on the next renderable transition,
+            // turning setMapFeatures into a silent no-op against stale DOM.
+            await TeardownIfInitializedAsync();
             return;
         }
 
@@ -69,18 +75,22 @@
         }
     }
 
-    public async ValueTask DisposeAsync()
+    private async Task TeardownIfInitializedAsync()
     {
-        if (_initialized)
+        if (!_initialized)
         {
-            try
-            {
-                await JS.InvokeVoidAsync("spatialSql.disposeMap", _elementId);
-            }
-            catch
-            {
-                // best-effort teardown
-            }
+            return;
         }
+        try
+        {
+            await JS.InvokeVoidAsync("spatialSql.disposeMap", _elementId);
+        }
+        catch
+        {
+            // best-effort teardown
+        }
+        _initialized = false;
     }
+
+    public ValueTask DisposeAsync() => new(TeardownIfInitializedAsync());
 }

--- a/src/Honua.Admin/Components/SpatialSql/SqlMapPreview.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SqlMapPreview.razor
@@ -1,0 +1,73 @@
+@* MapLibre preview for geometry-bearing SQL results. Uses the same vendored
+   MapLibre interop as <c>SpecWorkspace.MapPreview</c> — geometry payloads are
+   already GeoJSON, so we hand them to a thin interop helper that injects them
+   into the existing source/layer setup. *@
+@using Honua.Admin.Services.SpatialSql
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+<div class="spatial-sql-map" data-testid="sql-map-preview">
+    @if (Features.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text" data-testid="sql-map-empty">
+            No geometry rows to preview. Run a query that returns a geometry column.
+        </MudAlert>
+    }
+    else
+    {
+        <div id="@_elementId" class="spec-map-canvas" data-testid="sql-map-canvas"></div>
+    }
+</div>
+
+@code {
+    private readonly string _elementId = $"sql-map-{Guid.NewGuid():n}";
+    private bool _initialized;
+
+    [Parameter] public IReadOnlyList<MapPreviewFeature> Features { get; set; } = Array.Empty<MapPreviewFeature>();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (Features.Count == 0)
+        {
+            return;
+        }
+
+        if (!_initialized)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("spatialSql.initializeMap", _elementId);
+                _initialized = true;
+            }
+            catch
+            {
+                // interop missing — fall through silently; tests/pre-render don't need a live map
+                return;
+            }
+        }
+
+        try
+        {
+            await JS.InvokeVoidAsync("spatialSql.setMapFeatures", _elementId, Features);
+        }
+        catch
+        {
+            // non-fatal: interop helper missing in this environment
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_initialized)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("spatialSql.disposeMap", _elementId);
+            }
+            catch
+            {
+                // best-effort teardown
+            }
+        }
+    }
+}

--- a/src/Honua.Admin/Components/SpatialSql/SqlMapPreview.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SqlMapPreview.razor
@@ -7,7 +7,13 @@
 @implements IAsyncDisposable
 
 <div class="spatial-sql-map" data-testid="sql-map-preview">
-    @if (Features.Count == 0)
+    @if (!string.IsNullOrEmpty(BlockedReason))
+    {
+        <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="sql-map-blocked">
+            @BlockedReason
+        </MudAlert>
+    }
+    else if (Features.Count == 0)
     {
         <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text" data-testid="sql-map-empty">
             No geometry rows to preview. Run a query that returns a geometry column.
@@ -25,9 +31,16 @@
 
     [Parameter] public IReadOnlyList<MapPreviewFeature> Features { get; set; } = Array.Empty<MapPreviewFeature>();
 
+    /// <summary>
+    /// When non-null the map renders a warning instead of a canvas — used to mirror
+    /// the GeoJSON exporter's WGS84 guard so non-4326 results refuse to preview
+    /// instead of silently mis-rendering.
+    /// </summary>
+    [Parameter] public string? BlockedReason { get; set; }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (Features.Count == 0)
+        if (!string.IsNullOrEmpty(BlockedReason) || Features.Count == 0)
         {
             return;
         }

--- a/src/Honua.Admin/Components/SpatialSql/SqlTableResults.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SqlTableResults.razor
@@ -1,5 +1,7 @@
 @* Tabular renderer for SQL results. Columns and types come from the server-supplied
-   metadata so the geometry column can be marked without client-side guessing. *@
+   metadata so the geometry column can be marked without client-side guessing.
+   Uses MudDataGrid (per the approved design) with TemplateColumns generated from
+   Result.Columns so the grid stays dynamic across arbitrary SELECT shapes. *@
 @using Honua.Admin.Models.SpatialSql
 
 <div class="sql-table-results" data-testid="sql-table-results">
@@ -47,31 +49,37 @@
         }
         else
         {
-            <MudTable T="SqlRow" Items="@Result.Rows" Hover="true" Dense="true" Striped="true" data-testid="sql-table-grid">
-                <HeaderContent>
-                    @for (var i = 0; i < Result.Columns.Count; i++)
-                    {
-                        var column = Result.Columns[i];
-                        <MudTh>
-                            <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.body2"><strong>@column.Name</strong></MudText>
-                                @if (column.IsGeometry)
-                                {
-                                    <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Small">geom</MudChip>
-                                }
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">@column.Type</MudText>
-                            </MudStack>
-                        </MudTh>
-                    }
-                </HeaderContent>
-                <RowTemplate>
+            <MudDataGrid T="SqlRow"
+                         Items="@Result.Rows"
+                         Hover="true"
+                         Dense="true"
+                         Striped="true"
+                         data-testid="sql-table-grid">
+                <Columns>
                     @for (var i = 0; i < Result.Columns.Count; i++)
                     {
                         var index = i;
-                        <MudTd data-testid="@($"sql-table-cell-{index}")">@(index < context.Cells.Count ? context.Cells[index] ?? string.Empty : string.Empty)</MudTd>
+                        var column = Result.Columns[i];
+                        <TemplateColumn T="SqlRow" Title="@column.Name" Sortable="false" Filterable="false">
+                            <HeaderTemplate>
+                                <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+                                    <MudText Typo="Typo.body2"><strong>@column.Name</strong></MudText>
+                                    @if (column.IsGeometry)
+                                    {
+                                        <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Small">geom</MudChip>
+                                    }
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@column.Type</MudText>
+                                </MudStack>
+                            </HeaderTemplate>
+                            <CellTemplate>
+                                <span data-testid="@($"sql-table-cell-{index}")">
+                                    @(index < context.Item.Cells.Count ? context.Item.Cells[index] ?? string.Empty : string.Empty)
+                                </span>
+                            </CellTemplate>
+                        </TemplateColumn>
                     }
-                </RowTemplate>
-            </MudTable>
+                </Columns>
+            </MudDataGrid>
         }
     }
 </div>

--- a/src/Honua.Admin/Components/SpatialSql/SqlTableResults.razor
+++ b/src/Honua.Admin/Components/SpatialSql/SqlTableResults.razor
@@ -1,0 +1,81 @@
+@* Tabular renderer for SQL results. Columns and types come from the server-supplied
+   metadata so the geometry column can be marked without client-side guessing. *@
+@using Honua.Admin.Models.SpatialSql
+
+<div class="sql-table-results" data-testid="sql-table-results">
+    @if (Result is null)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text" data-testid="sql-table-empty">
+            Run a SELECT to populate results here.
+        </MudAlert>
+    }
+    else if (Result.IsError)
+    {
+        <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" data-testid="sql-table-error">
+            <strong>@Result.Error!.Code</strong>: @Result.Error.Message
+        </MudAlert>
+    }
+    else
+    {
+        @if (Result.Truncated)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" Class="mb-2" data-testid="sql-table-truncated">
+                Result was truncated at the @Result.RowLimit-row server cap. Refine the query or raise the cap.
+            </MudAlert>
+        }
+
+        <MudStack Row Spacing="2" AlignItems="AlignItems.Center" Class="mb-2">
+            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" data-testid="sql-table-rowcount">
+                @Result.Rows.Count rows
+            </MudChip>
+            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" data-testid="sql-table-elapsed">
+                @Result.ElapsedMs ms
+            </MudChip>
+            @if (!string.IsNullOrWhiteSpace(Result.AuditEntryId))
+            {
+                <MudChip T="string" Color="Color.Warning" Variant="Variant.Filled" Size="Size.Small" data-testid="sql-table-audit">
+                    audit @Result.AuditEntryId
+                </MudChip>
+            }
+        </MudStack>
+
+        @if (Result.Columns.Count == 0 || Result.Rows.Count == 0)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text">
+                No rows returned.
+            </MudAlert>
+        }
+        else
+        {
+            <MudTable T="SqlRow" Items="@Result.Rows" Hover="true" Dense="true" Striped="true" data-testid="sql-table-grid">
+                <HeaderContent>
+                    @for (var i = 0; i < Result.Columns.Count; i++)
+                    {
+                        var column = Result.Columns[i];
+                        <MudTh>
+                            <MudStack Row Spacing="1" AlignItems="AlignItems.Center">
+                                <MudText Typo="Typo.body2"><strong>@column.Name</strong></MudText>
+                                @if (column.IsGeometry)
+                                {
+                                    <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Small">geom</MudChip>
+                                }
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@column.Type</MudText>
+                            </MudStack>
+                        </MudTh>
+                    }
+                </HeaderContent>
+                <RowTemplate>
+                    @for (var i = 0; i < Result.Columns.Count; i++)
+                    {
+                        var index = i;
+                        <MudTd data-testid="@($"sql-table-cell-{index}")">@(index < context.Cells.Count ? context.Cells[index] ?? string.Empty : string.Empty)</MudTd>
+                    }
+                </RowTemplate>
+            </MudTable>
+        }
+    }
+</div>
+
+@code {
+    [Parameter] public SqlExecuteResult? Result { get; set; }
+}

--- a/src/Honua.Admin/Models/SpatialSql/ExplainPlan.cs
+++ b/src/Honua.Admin/Models/SpatialSql/ExplainPlan.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+/// <summary>
+/// EXPLAIN (ANALYZE, FORMAT JSON) projection. <see cref="Root"/> mirrors the server's
+/// top-level plan node; the admin renders the tree under <see cref="ExplainNode.Children"/>
+/// without re-deriving timing or row counts.
+/// </summary>
+public sealed record ExplainPlan
+{
+    [JsonPropertyName("root")]
+    public required ExplainNode Root { get; init; }
+
+    [JsonPropertyName("totalElapsedMs")]
+    public double TotalElapsedMs { get; init; }
+
+    [JsonPropertyName("planningMs")]
+    public double PlanningMs { get; init; }
+
+    [JsonPropertyName("error")]
+    public SqlExecuteError? Error { get; init; }
+
+    [JsonIgnore]
+    public bool IsError => Error is not null;
+}
+
+public sealed record ExplainNode
+{
+    [JsonPropertyName("nodeType")]
+    public required string NodeType { get; init; }
+
+    [JsonPropertyName("relation")]
+    public string? Relation { get; init; }
+
+    [JsonPropertyName("actualRows")]
+    public double ActualRows { get; init; }
+
+    [JsonPropertyName("planRows")]
+    public double PlanRows { get; init; }
+
+    [JsonPropertyName("actualTotalMs")]
+    public double ActualTotalMs { get; init; }
+
+    [JsonPropertyName("totalCost")]
+    public double TotalCost { get; init; }
+
+    [JsonPropertyName("children")]
+    public IReadOnlyList<ExplainNode> Children { get; init; } = System.Array.Empty<ExplainNode>();
+
+    /// <summary>
+    /// True when the planner's row estimate differs from the actual row count by 10x
+    /// or more in either direction. Drives the misestimate badge in the tree view.
+    /// </summary>
+    [JsonIgnore]
+    public bool RowEstimateOff =>
+        PlanRows > 0
+        && ActualRows > 0
+        && (ActualRows / PlanRows >= 10d || PlanRows / ActualRows >= 10d);
+}

--- a/src/Honua.Admin/Models/SpatialSql/ExplainPlanParser.cs
+++ b/src/Honua.Admin/Models/SpatialSql/ExplainPlanParser.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+/// <summary>
+/// Projects PostgreSQL's <c>EXPLAIN (ANALYZE, FORMAT JSON)</c> document into the
+/// admin's <see cref="ExplainPlan"/> tree. The server returns the plan unmodified;
+/// this parser is reflection-free so it stays AOT/trim friendly.
+/// </summary>
+public static class ExplainPlanParser
+{
+    /// <summary>
+    /// Parse the full Postgres EXPLAIN JSON envelope (an array containing one object
+    /// with a top-level "Plan" property).
+    /// </summary>
+    public static ExplainPlan Parse(string explainJson)
+    {
+        if (string.IsNullOrWhiteSpace(explainJson))
+        {
+            throw new ArgumentException("EXPLAIN JSON cannot be empty.", nameof(explainJson));
+        }
+
+        using var doc = JsonDocument.Parse(explainJson);
+        return ParseInternal(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Parse from a pre-deserialized <see cref="JsonElement"/>. Useful when the
+    /// server hands back the EXPLAIN payload nested in a larger envelope.
+    /// </summary>
+    public static ExplainPlan Parse(JsonElement element) => ParseInternal(element);
+
+    private static ExplainPlan ParseInternal(JsonElement element)
+    {
+        JsonElement payload = element;
+        if (payload.ValueKind == JsonValueKind.Array)
+        {
+            var found = false;
+            foreach (var entry in payload.EnumerateArray())
+            {
+                payload = entry;
+                found = true;
+                break;
+            }
+
+            if (!found)
+            {
+                throw new InvalidOperationException("EXPLAIN JSON array was empty.");
+            }
+        }
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException("EXPLAIN JSON envelope must be an object.");
+        }
+
+        if (!payload.TryGetProperty("Plan", out var plan) || plan.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException("EXPLAIN JSON envelope is missing a Plan node.");
+        }
+
+        var totalElapsedMs = ReadDouble(payload, "Execution Time");
+        var planningMs = ReadDouble(payload, "Planning Time");
+
+        return new ExplainPlan
+        {
+            Root = ParseNode(plan),
+            TotalElapsedMs = totalElapsedMs,
+            PlanningMs = planningMs
+        };
+    }
+
+    private static ExplainNode ParseNode(JsonElement node)
+    {
+        var nodeType = node.TryGetProperty("Node Type", out var nt) && nt.ValueKind == JsonValueKind.String
+            ? nt.GetString() ?? "Unknown"
+            : "Unknown";
+
+        var relation = node.TryGetProperty("Relation Name", out var rel) && rel.ValueKind == JsonValueKind.String
+            ? rel.GetString()
+            : null;
+
+        var children = new List<ExplainNode>();
+        if (node.TryGetProperty("Plans", out var plans) && plans.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var child in plans.EnumerateArray())
+            {
+                if (child.ValueKind == JsonValueKind.Object)
+                {
+                    children.Add(ParseNode(child));
+                }
+            }
+        }
+
+        return new ExplainNode
+        {
+            NodeType = nodeType,
+            Relation = relation,
+            ActualRows = ReadDouble(node, "Actual Rows"),
+            PlanRows = ReadDouble(node, "Plan Rows"),
+            ActualTotalMs = ReadDouble(node, "Actual Total Time"),
+            TotalCost = ReadDouble(node, "Total Cost"),
+            Children = children
+        };
+    }
+
+    private static double ReadDouble(JsonElement element, string property)
+    {
+        if (!element.TryGetProperty(property, out var value))
+        {
+            return 0d;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetDouble(out var d) => d,
+            JsonValueKind.String when double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var s) => s,
+            _ => 0d
+        };
+    }
+}

--- a/src/Honua.Admin/Models/SpatialSql/MutationGuard.cs
+++ b/src/Honua.Admin/Models/SpatialSql/MutationGuard.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Text.RegularExpressions;
+using System.Text;
 
 namespace Honua.Admin.Models.SpatialSql;
 
@@ -30,11 +30,6 @@ public static class MutationGuard
         "MERGE"
     };
 
-    private static readonly Regex BlockComment = new(@"/\*[\s\S]*?\*/", RegexOptions.Compiled);
-    private static readonly Regex LineComment = new(@"--[^\r\n]*", RegexOptions.Compiled);
-    private static readonly Regex SingleQuoted = new(@"'(?:''|[^'])*'", RegexOptions.Compiled);
-    private static readonly Regex DoubleQuoted = new(@"""(?:""""|[^""])*""", RegexOptions.Compiled);
-
     /// <summary>
     /// True when the SQL appears to mutate data or schema. False for SELECT, WITH-only,
     /// EXPLAIN, and SHOW statements. Whitespace-only SQL is treated as non-mutating
@@ -59,13 +54,153 @@ public static class MutationGuard
         return false;
     }
 
+    /// <summary>
+    /// Single-pass scanner that drops the contents of comments and string literals
+    /// before keyword detection so the guard does not trip on benign mentions
+    /// inside <c>'...'</c>, <c>"..."</c>, <c>--</c> / <c>/*...*/</c> comments, or
+    /// PostgreSQL dollar-quoted string constants (<c>$$...$$</c> /
+    /// <c>$tag$...$tag$</c>). A scanner is used over a stack of regex passes so
+    /// that quote/comment regions are recognized in source order — otherwise a
+    /// dollar-quoted body could leak its contents back into a later pass and a
+    /// quoted-string body could swallow a real comment opener.
+    /// </summary>
     internal static string StripCommentsAndLiterals(string sql)
     {
-        var pass1 = BlockComment.Replace(sql, " ");
-        var pass2 = LineComment.Replace(pass1, " ");
-        var pass3 = SingleQuoted.Replace(pass2, " ");
-        return DoubleQuoted.Replace(pass3, " ");
+        var sb = new StringBuilder(sql.Length);
+        var i = 0;
+        while (i < sql.Length)
+        {
+            var c = sql[i];
+
+            // Block comment: /* ... */
+            if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < sql.Length && !(sql[i] == '*' && sql[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(i + 2, sql.Length);
+                sb.Append(' ');
+                continue;
+            }
+
+            // Line comment: -- ...
+            if (c == '-' && i + 1 < sql.Length && sql[i + 1] == '-')
+            {
+                while (i < sql.Length && sql[i] != '\n' && sql[i] != '\r')
+                {
+                    i++;
+                }
+                sb.Append(' ');
+                continue;
+            }
+
+            // Single-quoted string literal (with '' escape).
+            if (c == '\'')
+            {
+                i++;
+                while (i < sql.Length)
+                {
+                    if (sql[i] == '\'')
+                    {
+                        if (i + 1 < sql.Length && sql[i + 1] == '\'')
+                        {
+                            i += 2;
+                            continue;
+                        }
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                sb.Append(' ');
+                continue;
+            }
+
+            // Double-quoted identifier (with "" escape).
+            if (c == '"')
+            {
+                i++;
+                while (i < sql.Length)
+                {
+                    if (sql[i] == '"')
+                    {
+                        if (i + 1 < sql.Length && sql[i + 1] == '"')
+                        {
+                            i += 2;
+                            continue;
+                        }
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                sb.Append(' ');
+                continue;
+            }
+
+            // PostgreSQL dollar-quoted string: $$...$$ or $tag$...$tag$.
+            // The tag follows identifier rules (starts with letter or underscore,
+            // then letter/underscore/digit). If the sequence after $ does not form
+            // a valid opener (e.g. positional parameter $1), the $ is treated as a
+            // literal character.
+            if (c == '$' && TryConsumeDollarQuote(sql, ref i))
+            {
+                sb.Append(' ');
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+        return sb.ToString();
     }
+
+    private static bool TryConsumeDollarQuote(string sql, ref int i)
+    {
+        // i points at the opening '$'. The opener is $tag$ where tag is empty or
+        // starts with a letter/underscore followed by letter/underscore/digit.
+        var tagEnd = i + 1;
+        if (tagEnd < sql.Length && IsTagStartChar(sql[tagEnd]))
+        {
+            tagEnd++;
+            while (tagEnd < sql.Length && IsTagChar(sql[tagEnd]))
+            {
+                tagEnd++;
+            }
+        }
+
+        if (tagEnd >= sql.Length || sql[tagEnd] != '$')
+        {
+            // Not a dollar-quote opener (e.g. $1 positional parameter, or stray $).
+            return false;
+        }
+
+        var tagLength = tagEnd - i + 1; // includes both surrounding $ chars
+        var openerStart = i;
+        var bodyStart = tagEnd + 1;
+        var scan = bodyStart;
+        while (scan + tagLength <= sql.Length)
+        {
+            if (sql[scan] == '$' &&
+                string.CompareOrdinal(sql, scan, sql, openerStart, tagLength) == 0)
+            {
+                i = scan + tagLength;
+                return true;
+            }
+            scan++;
+        }
+
+        // Unterminated dollar-quote — consume to end of string so trailing
+        // keywords inside an unclosed body are not falsely flagged.
+        i = sql.Length;
+        return true;
+    }
+
+    private static bool IsTagStartChar(char c) => char.IsLetter(c) || c == '_';
+
+    private static bool IsTagChar(char c) => char.IsLetterOrDigit(c) || c == '_';
 
     private static bool HasKeyword(string sql, string keyword)
     {

--- a/src/Honua.Admin/Models/SpatialSql/MutationGuard.cs
+++ b/src/Honua.Admin/Models/SpatialSql/MutationGuard.cs
@@ -27,13 +27,30 @@ public static class MutationGuard
         "REINDEX",
         "CLUSTER",
         "COMMENT",
-        "MERGE"
+        "MERGE",
+        // SELECT ... INTO target FROM source creates a new table and fills it
+        // (https://www.postgresql.org/docs/current/sql-selectinto.html); the
+        // bare INTO keyword catches that. INSERT INTO and MERGE INTO are
+        // already flagged via INSERT/MERGE so the additional keyword does
+        // not affect them.
+        "INTO",
+        // EXECUTE runs a previously prepared statement whose body is opaque
+        // to the client, and is also the PL/pgSQL dynamic-SQL primitive.
+        // EXPLAIN ANALYZE EXECUTE actually executes the prepared statement
+        // (https://www.postgresql.org/docs/current/sql-explain.html), so
+        // the client guard rejects it conservatively; the per-query
+        // operator override remains available on the Run path.
+        "EXECUTE"
     };
 
     /// <summary>
     /// True when the SQL appears to mutate data or schema. False for SELECT, WITH-only,
     /// EXPLAIN, and SHOW statements. Whitespace-only SQL is treated as non-mutating
-    /// since the server will reject it on its own grounds.
+    /// since the server will reject it on its own grounds. Also flags
+    /// <c>SELECT ... INTO</c> (creates a table) and <c>EXECUTE</c> (opaque
+    /// prepared-statement / dynamic-SQL execution) — both forms run as writes
+    /// under <c>EXPLAIN ANALYZE</c>, so the conservative check applies on both
+    /// the Run and EXPLAIN paths.
     /// </summary>
     public static bool IsMutating(string? sql)
     {

--- a/src/Honua.Admin/Models/SpatialSql/MutationGuard.cs
+++ b/src/Honua.Admin/Models/SpatialSql/MutationGuard.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+/// <summary>
+/// Best-effort client-side detection of mutating SQL verbs. The server is the
+/// source of truth — this is purely UX so the operator gets an immediate prompt
+/// rather than a round-trip rejection. Comments and string literals are stripped
+/// before keyword scanning so the guard does not trip on benign content.
+/// </summary>
+public static class MutationGuard
+{
+    private static readonly string[] MutatingKeywords = new[]
+    {
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "TRUNCATE",
+        "DROP",
+        "CREATE",
+        "ALTER",
+        "GRANT",
+        "REVOKE",
+        "COPY",
+        "VACUUM",
+        "REINDEX",
+        "CLUSTER",
+        "COMMENT",
+        "MERGE"
+    };
+
+    private static readonly Regex BlockComment = new(@"/\*[\s\S]*?\*/", RegexOptions.Compiled);
+    private static readonly Regex LineComment = new(@"--[^\r\n]*", RegexOptions.Compiled);
+    private static readonly Regex SingleQuoted = new(@"'(?:''|[^'])*'", RegexOptions.Compiled);
+    private static readonly Regex DoubleQuoted = new(@"""(?:""""|[^""])*""", RegexOptions.Compiled);
+
+    /// <summary>
+    /// True when the SQL appears to mutate data or schema. False for SELECT, WITH-only,
+    /// EXPLAIN, and SHOW statements. Whitespace-only SQL is treated as non-mutating
+    /// since the server will reject it on its own grounds.
+    /// </summary>
+    public static bool IsMutating(string? sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            return false;
+        }
+
+        var stripped = StripCommentsAndLiterals(sql);
+        foreach (var keyword in MutatingKeywords)
+        {
+            if (HasKeyword(stripped, keyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static string StripCommentsAndLiterals(string sql)
+    {
+        var pass1 = BlockComment.Replace(sql, " ");
+        var pass2 = LineComment.Replace(pass1, " ");
+        var pass3 = SingleQuoted.Replace(pass2, " ");
+        return DoubleQuoted.Replace(pass3, " ");
+    }
+
+    private static bool HasKeyword(string sql, string keyword)
+    {
+        var index = 0;
+        while (index < sql.Length)
+        {
+            var hit = sql.IndexOf(keyword, index, StringComparison.OrdinalIgnoreCase);
+            if (hit < 0)
+            {
+                return false;
+            }
+
+            var leftOk = hit == 0 || !IsWordChar(sql[hit - 1]);
+            var rightOk = hit + keyword.Length >= sql.Length || !IsWordChar(sql[hit + keyword.Length]);
+            if (leftOk && rightOk)
+            {
+                return true;
+            }
+
+            index = hit + 1;
+        }
+        return false;
+    }
+
+    private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+}

--- a/src/Honua.Admin/Models/SpatialSql/NamedView.cs
+++ b/src/Honua.Admin/Models/SpatialSql/NamedView.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+public sealed record SaveViewRequest
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("sql")]
+    public required string Sql { get; init; }
+
+    [JsonPropertyName("parameters")]
+    public IReadOnlyList<SqlParameter> Parameters { get; init; } = System.Array.Empty<SqlParameter>();
+
+    [JsonPropertyName("geometryColumn")]
+    public string? GeometryColumn { get; init; }
+
+    [JsonPropertyName("srid")]
+    public int? Srid { get; init; }
+}
+
+/// <summary>
+/// Server response for a saved query. The three protocol URLs come back as the
+/// server has them — the admin treats them as opaque copy-to-clipboard chips.
+/// </summary>
+public sealed record NamedViewRegistration
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("featureServerUrl")]
+    public string? FeatureServerUrl { get; init; }
+
+    [JsonPropertyName("ogcFeaturesUrl")]
+    public string? OgcFeaturesUrl { get; init; }
+
+    [JsonPropertyName("oDataUrl")]
+    public string? ODataUrl { get; init; }
+
+    [JsonPropertyName("error")]
+    public SqlExecuteError? Error { get; init; }
+
+    [JsonIgnore]
+    public bool IsError => Error is not null;
+}

--- a/src/Honua.Admin/Models/SpatialSql/SpatialSqlJsonContext.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SpatialSqlJsonContext.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+/// <summary>
+/// Source-generated serializer context for spatial-SQL DTOs. Mirrors the
+/// SpecWorkspace approach so admin can publish AOT/trim-friendly without
+/// reflection-based JSON.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(SchemaSnapshot))]
+[JsonSerializable(typeof(SqlExecuteRequest))]
+[JsonSerializable(typeof(SqlExecuteResult))]
+[JsonSerializable(typeof(SqlExplainRequest))]
+[JsonSerializable(typeof(ExplainPlan))]
+[JsonSerializable(typeof(ExplainNode))]
+[JsonSerializable(typeof(SaveViewRequest))]
+[JsonSerializable(typeof(NamedViewRegistration))]
+public sealed partial class SpatialSqlJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Admin/Models/SpatialSql/SpatialSqlJsonContext.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SpatialSqlJsonContext.cs
@@ -1,11 +1,13 @@
 using System.Text.Json.Serialization;
+using Honua.Admin.Services.SpatialSql;
 
 namespace Honua.Admin.Models.SpatialSql;
 
 /// <summary>
 /// Source-generated serializer context for spatial-SQL DTOs. Mirrors the
 /// SpecWorkspace approach so admin can publish AOT/trim-friendly without
-/// reflection-based JSON.
+/// reflection-based JSON. Includes <see cref="MapPreviewFeature"/> so the
+/// JS interop boundary stays trim-safe alongside the network DTOs.
 /// </summary>
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
@@ -19,6 +21,8 @@ namespace Honua.Admin.Models.SpatialSql;
 [JsonSerializable(typeof(ExplainNode))]
 [JsonSerializable(typeof(SaveViewRequest))]
 [JsonSerializable(typeof(NamedViewRegistration))]
+[JsonSerializable(typeof(MapPreviewFeature))]
+[JsonSerializable(typeof(System.Collections.Generic.IReadOnlyList<MapPreviewFeature>))]
 public sealed partial class SpatialSqlJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Admin/Models/SpatialSql/SqlExecution.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SqlExecution.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+public sealed record SqlExecuteRequest
+{
+    [JsonPropertyName("sql")]
+    public required string Sql { get; init; }
+
+    [JsonPropertyName("parameters")]
+    public IReadOnlyList<SqlParameter> Parameters { get; init; } = System.Array.Empty<SqlParameter>();
+
+    [JsonPropertyName("allowMutation")]
+    public bool AllowMutation { get; init; }
+
+    [JsonPropertyName("rowLimit")]
+    public int? RowLimit { get; init; }
+
+    [JsonPropertyName("timeoutMs")]
+    public int? TimeoutMs { get; init; }
+}
+
+public sealed record SqlParameter(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("value")] string Value);
+
+/// <summary>
+/// Result of a SQL execution. <see cref="Truncated"/> reflects the server-applied row
+/// cap; <see cref="RowLimit"/> echoes the cap in effect so the UI can show it. Mutation
+/// requests that succeed populate <see cref="AuditEntryId"/>.
+/// </summary>
+public sealed record SqlExecuteResult
+{
+    [JsonPropertyName("columns")]
+    public IReadOnlyList<SqlColumn> Columns { get; init; } = System.Array.Empty<SqlColumn>();
+
+    [JsonPropertyName("rows")]
+    public IReadOnlyList<SqlRow> Rows { get; init; } = System.Array.Empty<SqlRow>();
+
+    [JsonPropertyName("truncated")]
+    public bool Truncated { get; init; }
+
+    [JsonPropertyName("rowLimit")]
+    public int RowLimit { get; init; }
+
+    [JsonPropertyName("timeoutMs")]
+    public int TimeoutMs { get; init; }
+
+    [JsonPropertyName("elapsedMs")]
+    public long ElapsedMs { get; init; }
+
+    [JsonPropertyName("geometryColumnIndex")]
+    public int? GeometryColumnIndex { get; init; }
+
+    [JsonPropertyName("geometrySrid")]
+    public int? GeometrySrid { get; init; }
+
+    [JsonPropertyName("auditEntryId")]
+    public string? AuditEntryId { get; init; }
+
+    [JsonPropertyName("error")]
+    public SqlExecuteError? Error { get; init; }
+
+    [JsonIgnore]
+    public bool HasGeometry => GeometryColumnIndex is int idx && idx >= 0 && idx < Columns.Count;
+
+    [JsonIgnore]
+    public bool IsError => Error is not null;
+}
+
+public sealed record SqlColumn(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("isGeometry")] bool IsGeometry = false);
+
+/// <summary>
+/// One result row. Cells are stored as a nullable-string list so SQL <c>NULL</c>s
+/// stay distinguishable from empty strings, while the wrapper itself is a
+/// non-nullable type — keeping it usable as a Razor generic parameter where
+/// <c>IReadOnlyList&lt;string?&gt;</c> would trip nullable-context source-generation.
+/// </summary>
+public sealed record SqlRow([property: JsonPropertyName("cells")] IReadOnlyList<string?> Cells)
+{
+    public int Count => Cells.Count;
+
+    public string? this[int index] => Cells[index];
+}
+
+public sealed record SqlExecuteError(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("message")] string Message);
+
+public sealed record SqlExplainRequest
+{
+    [JsonPropertyName("sql")]
+    public required string Sql { get; init; }
+
+    [JsonPropertyName("parameters")]
+    public IReadOnlyList<SqlParameter> Parameters { get; init; } = System.Array.Empty<SqlParameter>();
+}

--- a/src/Honua.Admin/Models/SpatialSql/SqlResultExporter.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SqlResultExporter.cs
@@ -46,8 +46,13 @@ public static class SqlResultExporter
     }
 
     /// <summary>
-    /// GeoJSON FeatureCollection. Geometry cells are passed through verbatim — the
-    /// server returns geometry columns as already-serialized GeoJSON strings.
+    /// GeoJSON FeatureCollection per RFC 7946. Geometry cells are passed through
+    /// verbatim — the server returns geometry columns as already-serialized
+    /// GeoJSON strings in WGS84/EPSG:4326. RFC 7946 §4 mandates WGS84 longitude
+    /// and latitude and removed the legacy <c>crs</c> member, so this exporter
+    /// emits no <c>crs</c> envelope. If <see cref="SqlExecuteResult.GeometrySrid"/>
+    /// is set to anything other than 4326 the exporter throws — reprojection is
+    /// the server's responsibility, not the admin's.
     /// </summary>
     public static string ToGeoJson(SqlExecuteResult result)
     {
@@ -55,6 +60,14 @@ public static class SqlResultExporter
         if (!result.HasGeometry)
         {
             throw new InvalidOperationException("Result has no geometry column to export as GeoJSON.");
+        }
+
+        if (result.GeometrySrid is int srid && srid != Wgs84Srid)
+        {
+            throw new InvalidOperationException(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"GeoJSON export requires WGS84 (SRID 4326); got SRID {srid}. Reproject server-side before export."));
         }
 
         var geometryIndex = result.GeometryColumnIndex!.Value;
@@ -106,20 +119,12 @@ public static class SqlResultExporter
 
             writer.WriteEndArray();
 
-            if (result.GeometrySrid is int srid)
-            {
-                writer.WriteStartObject("crs");
-                writer.WriteString("type", "name");
-                writer.WriteStartObject("properties");
-                writer.WriteString("name", string.Create(CultureInfo.InvariantCulture, $"EPSG:{srid}"));
-                writer.WriteEndObject();
-                writer.WriteEndObject();
-            }
-
             writer.WriteEndObject();
         }
         return Encoding.UTF8.GetString(stream.ToArray());
     }
+
+    private const int Wgs84Srid = 4326;
 
     public static string ToClipboardText(SqlExecuteResult result) => ToCsv(result);
 

--- a/src/Honua.Admin/Models/SpatialSql/SqlResultExporter.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SqlResultExporter.cs
@@ -124,7 +124,13 @@ public static class SqlResultExporter
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 
-    private const int Wgs84Srid = 4326;
+    /// <summary>
+    /// SRID 4326 — the WGS84 geographic coordinate system. RFC 7946 §4 mandates
+    /// this for GeoJSON output, and MapLibre expects WGS84 lng/lat for the in-page
+    /// preview, so both the exporter and <c>SpatialSqlPlaygroundState</c> guard
+    /// against non-4326 results using this single constant.
+    /// </summary>
+    internal const int Wgs84Srid = 4326;
 
     public static string ToClipboardText(SqlExecuteResult result) => ToCsv(result);
 

--- a/src/Honua.Admin/Models/SpatialSql/SqlResultExporter.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SqlResultExporter.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+/// <summary>
+/// Serializes <see cref="SqlExecuteResult"/> into the three supported export formats.
+/// All exporters refuse to walk a result that has no rows; callers are expected to
+/// guard the truncation override before invoking the GeoJSON or CSV paths.
+/// </summary>
+public static class SqlResultExporter
+{
+    public static string ToCsv(SqlExecuteResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var sb = new StringBuilder();
+        for (var i = 0; i < result.Columns.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+            sb.Append(QuoteCsv(result.Columns[i].Name));
+        }
+        sb.Append("\r\n");
+
+        foreach (var row in result.Rows)
+        {
+            for (var i = 0; i < result.Columns.Count; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+                var cell = i < row.Cells.Count ? row.Cells[i] : null;
+                sb.Append(QuoteCsv(cell));
+            }
+            sb.Append("\r\n");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// GeoJSON FeatureCollection. Geometry cells are passed through verbatim — the
+    /// server returns geometry columns as already-serialized GeoJSON strings.
+    /// </summary>
+    public static string ToGeoJson(SqlExecuteResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        if (!result.HasGeometry)
+        {
+            throw new InvalidOperationException("Result has no geometry column to export as GeoJSON.");
+        }
+
+        var geometryIndex = result.GeometryColumnIndex!.Value;
+
+        using var stream = new System.IO.MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false }))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "FeatureCollection");
+            writer.WriteStartArray("features");
+
+            foreach (var row in result.Rows)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("type", "Feature");
+
+                writer.WritePropertyName("geometry");
+                var geometryCell = geometryIndex < row.Cells.Count ? row.Cells[geometryIndex] : null;
+                if (geometryCell is null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    if (TryWriteRawJson(writer, geometryCell))
+                    {
+                        // value already written
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(geometryCell);
+                    }
+                }
+
+                writer.WriteStartObject("properties");
+                for (var i = 0; i < result.Columns.Count; i++)
+                {
+                    if (i == geometryIndex)
+                    {
+                        continue;
+                    }
+                    var cell = i < row.Cells.Count ? row.Cells[i] : null;
+                    writer.WriteString(result.Columns[i].Name, cell);
+                }
+                writer.WriteEndObject();
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+
+            if (result.GeometrySrid is int srid)
+            {
+                writer.WriteStartObject("crs");
+                writer.WriteString("type", "name");
+                writer.WriteStartObject("properties");
+                writer.WriteString("name", string.Create(CultureInfo.InvariantCulture, $"EPSG:{srid}"));
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    public static string ToClipboardText(SqlExecuteResult result) => ToCsv(result);
+
+    private static bool TryWriteRawJson(Utf8JsonWriter writer, string candidate)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(candidate);
+            doc.RootElement.WriteTo(writer);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string QuoteCsv(string? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        var needsQuoting = false;
+        foreach (var ch in value)
+        {
+            if (ch is ',' or '"' or '\n' or '\r')
+            {
+                needsQuoting = true;
+                break;
+            }
+        }
+
+        if (!needsQuoting)
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (var ch in value)
+        {
+            if (ch == '"')
+            {
+                sb.Append('"').Append('"');
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+        sb.Append('"');
+        return sb.ToString();
+    }
+}

--- a/src/Honua.Admin/Models/SpatialSql/SqlSchema.cs
+++ b/src/Honua.Admin/Models/SpatialSql/SqlSchema.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.SpatialSql;
+
+/// <summary>
+/// Schema snapshot fed to the SQL editor for autocomplete. Tables and columns come
+/// from the server's published-layer view; PostGIS functions/operators come from a
+/// curated reference list shipped alongside the snapshot.
+/// </summary>
+public sealed record SchemaSnapshot
+{
+    [JsonPropertyName("tables")]
+    public IReadOnlyList<SchemaTable> Tables { get; init; } = System.Array.Empty<SchemaTable>();
+
+    [JsonPropertyName("functions")]
+    public IReadOnlyList<PostGisFunction> Functions { get; init; } = System.Array.Empty<PostGisFunction>();
+
+    [JsonPropertyName("operators")]
+    public IReadOnlyList<PostGisOperator> Operators { get; init; } = System.Array.Empty<PostGisOperator>();
+
+    [JsonPropertyName("fetchedAt")]
+    public string FetchedAt { get; init; } = string.Empty;
+}
+
+public sealed record SchemaTable
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("geometryColumn")]
+    public string? GeometryColumn { get; init; }
+
+    [JsonPropertyName("srid")]
+    public int? Srid { get; init; }
+
+    [JsonPropertyName("columns")]
+    public IReadOnlyList<SchemaColumn> Columns { get; init; } = System.Array.Empty<SchemaColumn>();
+}
+
+public sealed record SchemaColumn(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("description")] string? Description = null);
+
+public sealed record PostGisFunction(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("signature")] string Signature,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("documentation")] string Documentation);
+
+public sealed record PostGisOperator(
+    [property: JsonPropertyName("symbol")] string Symbol,
+    [property: JsonPropertyName("description")] string Description);

--- a/src/Honua.Admin/Pages/Operator/SpatialSqlPlayground.razor
+++ b/src/Honua.Admin/Pages/Operator/SpatialSqlPlayground.razor
@@ -1,0 +1,9 @@
+@page "/operator/sql"
+@using Microsoft.AspNetCore.Authorization
+@using Honua.Admin.Components.SpatialSql
+@using Honua.Admin.Services.SpatialSql
+@attribute [Authorize]
+
+<PageTitle>Spatial SQL</PageTitle>
+
+<SpatialSqlPlaygroundBody />

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -1,6 +1,7 @@
 using Honua.Admin;
 using Honua.Admin.Services.Identity;
 using Honua.Admin.Services.LicenseWorkspace;
+using Honua.Admin.Services.SpatialSql;
 using Honua.Admin.Services.SpecWorkspace;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
@@ -22,6 +23,12 @@ builder.Services.AddScoped<IBrowserStorageService, BrowserStorageService>();
 builder.Services.AddScoped<ISpecWorkspaceTelemetry, LoggingSpecWorkspaceTelemetry>();
 builder.Services.AddScoped<ISpecWorkspaceClient, StubSpecWorkspaceClient>();
 builder.Services.AddScoped<SpecWorkspaceState>();
+
+// Spatial SQL playground (ticket #1 — admin-side S1 stub; HTTP client lands once the
+// server child tickets ship the /api/v1/admin/sql endpoints).
+builder.Services.AddScoped<ISpatialSqlTelemetry, LoggingSpatialSqlTelemetry>();
+builder.Services.AddScoped<ISpatialSqlClient, StubSpatialSqlClient>();
+builder.Services.AddScoped<SpatialSqlPlaygroundState>();
 
 // Identity admin services (ticket #22).
 builder.Services.AddScoped<IIdentityAdminTelemetry, LoggingIdentityAdminTelemetry>();

--- a/src/Honua.Admin/Services/SpatialSql/ISpatialSqlClient.cs
+++ b/src/Honua.Admin/Services/SpatialSql/ISpatialSqlClient.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.SpatialSql;
+
+namespace Honua.Admin.Services.SpatialSql;
+
+/// <summary>
+/// Seam between the admin SQL playground and the server-side SQL endpoints.
+/// S1 ships <see cref="StubSpatialSqlClient"/>; the HTTP-backed implementation lands
+/// once the server child tickets (<c>POST /api/v1/admin/sql/execute</c>,
+/// <c>/explain</c>, <c>/schema</c>, <c>/views</c>) are merged.
+/// </summary>
+public interface ISpatialSqlClient
+{
+    Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken);
+
+    Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken);
+
+    Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken);
+
+    Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken);
+}

--- a/src/Honua.Admin/Services/SpatialSql/ISpatialSqlTelemetry.cs
+++ b/src/Honua.Admin/Services/SpatialSql/ISpatialSqlTelemetry.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Honua.Admin.Services.SpatialSql;
+
+/// <summary>
+/// Telemetry adapter for SQL playground events. Mirrors
+/// <see cref="Honua.Admin.Services.SpecWorkspace.ISpecWorkspaceTelemetry"/> so a
+/// single shared admin sink can replace both implementations once it lands.
+/// </summary>
+public interface ISpatialSqlTelemetry
+{
+    void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null);
+
+    void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null);
+}

--- a/src/Honua.Admin/Services/SpatialSql/LoggingSpatialSqlTelemetry.cs
+++ b/src/Honua.Admin/Services/SpatialSql/LoggingSpatialSqlTelemetry.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Admin.Services.SpatialSql;
+
+public sealed class LoggingSpatialSqlTelemetry : ISpatialSqlTelemetry
+{
+    private readonly ILogger<LoggingSpatialSqlTelemetry> _logger;
+
+    public LoggingSpatialSqlTelemetry(ILogger<LoggingSpatialSqlTelemetry> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null)
+    {
+        if (properties is null || properties.Count == 0)
+        {
+            _logger.LogInformation("spatial_sql event={Event}", eventName);
+            return;
+        }
+        _logger.LogInformation("spatial_sql event={Event} props={@Props}", eventName, properties);
+    }
+
+    public void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null)
+    {
+        if (properties is null || properties.Count == 0)
+        {
+            _logger.LogInformation("spatial_sql event={Event} elapsed_ms={Elapsed}", eventName, elapsedMillis);
+            return;
+        }
+        _logger.LogInformation("spatial_sql event={Event} elapsed_ms={Elapsed} props={@Props}", eventName, elapsedMillis, properties);
+    }
+}

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -199,6 +199,12 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         }
 
         var allowMutation = MutationOverrideArmed;
+        // Consume the override the moment we snapshot it so a single armed
+        // confirmation is single-shot regardless of how this attempt terminates
+        // (success, server error, transport error, cancellation). Without this
+        // consumption, a transport failure would leak the armed state into the
+        // next click of Run and silently re-submit with allowMutation=true.
+        MutationOverrideArmed = false;
 
         if (!allowMutation && MutationGuard.IsMutating(Sql))
         {
@@ -301,9 +307,9 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
                 }
             }
 
-            // Reset override after each submit so the next mutation requires a fresh
-            // confirmation. The audit log on the server records this single statement.
-            MutationOverrideArmed = false;
+            // Override consumption already happened up front (before the request was
+            // submitted) so cancellation / transport failures cannot leak the armed
+            // state into a follow-up click of Run.
             notify = true;
         }
         catch (OperationCanceledException)
@@ -363,6 +369,22 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
     {
         if (string.IsNullOrWhiteSpace(Sql))
         {
+            return;
+        }
+
+        // EXPLAIN ANALYZE actually executes the statement on the server, and the
+        // server-side EXPLAIN endpoint has no AllowMutation contract or audit
+        // hook. Reject mutating SQL outright — the per-query override on the Run
+        // path is the only audited mutation channel, EXPLAIN is not.
+        if (MutationGuard.IsMutating(Sql))
+        {
+            LastError = "EXPLAIN is rejected for mutating SQL — EXPLAIN ANALYZE would execute the statement outside the audited mutation-override flow.";
+            Status = SpatialSqlPaneStatus.Error;
+            _telemetry.Record("explain_rejected", new Dictionary<string, object?>
+            {
+                ["reason"] = "mutation_blocked"
+            });
+            Notify();
             return;
         }
 

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -43,6 +43,15 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
 
     public SqlExecuteResult? LastResult { get; private set; }
 
+    /// <summary>
+    /// SQL text that produced <see cref="LastResult"/>. Snapshotted at the moment
+    /// the result is stored so <see cref="SaveViewAsync"/> registers the view
+    /// against the executed SQL (and its derived geometry metadata) instead of
+    /// whatever the operator has typed since. Distinct from <see cref="Sql"/>,
+    /// which tracks the live editor buffer.
+    /// </summary>
+    public string? LastResultSql { get; private set; }
+
     public ExplainPlan? LastPlan { get; private set; }
 
     public NamedViewRegistration? LastSavedView { get; private set; }
@@ -201,6 +210,7 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
                 TimeoutMs = 0,
                 Error = new SqlExecuteError("mutation_blocked", LastError)
             };
+            LastResultSql = Sql;
             _telemetry.Record("query_rejected", new Dictionary<string, object?>
             {
                 ["reason"] = "mutation_blocked"
@@ -223,24 +233,40 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         ExportTruncatedConfirmed = false;
         Notify();
 
+        // Snapshot the SQL that this execution submitted so the success path can
+        // pair LastResult with the exact text that produced it — even if the
+        // operator edits the editor while the query is in flight.
+        var submittedSql = Sql;
         var watch = Stopwatch.StartNew();
+        var notify = false;
         try
         {
             _telemetry.Record("query_submitted", new Dictionary<string, object?>
             {
-                ["sql_length"] = Sql.Length,
+                ["sql_length"] = submittedSql.Length,
                 ["allow_mutation"] = allowMutation
             });
 
             var request = new SqlExecuteRequest
             {
-                Sql = Sql,
+                Sql = submittedSql,
                 AllowMutation = allowMutation
             };
 
             var result = await _client.ExecuteAsync(request, cts.Token).ConfigureAwait(false);
             watch.Stop();
+
+            // Ownership gate: a newer RunQueryAsync may have superseded this one
+            // (cancelled our cts, replaced _executeCts) while the await was in
+            // flight. The newer call already wrote its own Status/LastError/Notify;
+            // overwriting state here would race with it and undo those writes.
+            if (!IsActiveExecution(cts))
+            {
+                return;
+            }
+
             LastResult = result;
+            LastResultSql = submittedSql;
             if (result.IsError)
             {
                 Status = SpatialSqlPaneStatus.Error;
@@ -278,13 +304,26 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
             // Reset override after each submit so the next mutation requires a fresh
             // confirmation. The audit log on the server records this single statement.
             MutationOverrideArmed = false;
+            notify = true;
         }
         catch (OperationCanceledException)
         {
+            // Same ownership gate as the success path: if we were superseded, the
+            // newer query already owns Status — do not stomp it back to Idle while
+            // the newer query is mid-flight.
+            if (!IsActiveExecution(cts))
+            {
+                return;
+            }
             Status = SpatialSqlPaneStatus.Idle;
+            notify = true;
         }
         catch (Exception ex)
         {
+            if (!IsActiveExecution(cts))
+            {
+                return;
+            }
             Status = SpatialSqlPaneStatus.Error;
             LastError = ex.Message;
             _telemetry.Record("query_rejected", new Dictionary<string, object?>
@@ -292,6 +331,7 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
                 ["reason"] = "transport_error",
                 ["message"] = ex.Message
             });
+            notify = true;
         }
         finally
         {
@@ -305,7 +345,18 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
             }
         }
 
-        Notify();
+        if (notify)
+        {
+            Notify();
+        }
+    }
+
+    private bool IsActiveExecution(CancellationTokenSource cts)
+    {
+        lock (_sync)
+        {
+            return ReferenceEquals(_executeCts, cts);
+        }
     }
 
     public async Task RunExplainAsync(CancellationToken cancellationToken = default)
@@ -362,6 +413,22 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         Notify();
     }
 
+    /// <summary>
+    /// True when the editor's current SQL still matches the SQL that produced
+    /// <see cref="LastResult"/> and the result has rows the operator could turn
+    /// into a named view. The Save toolbar binds to this so an edited buffer
+    /// cannot register a view against stale geometry metadata pulled from
+    /// <see cref="LastResult"/>.
+    /// </summary>
+    public bool CanSaveCurrentResult()
+    {
+        if (LastResult is null || LastResult.IsError || LastResult.Rows.Count == 0)
+        {
+            return false;
+        }
+        return string.Equals(Sql, LastResultSql, StringComparison.Ordinal);
+    }
+
     public async Task<NamedViewRegistration> SaveViewAsync(string name, string? description, CancellationToken cancellationToken = default)
     {
         Status = SpatialSqlPaneStatus.Saving;
@@ -370,11 +437,15 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
 
         try
         {
+            // Build the request from the SQL that produced LastResult, not the live
+            // editor buffer. The geometry column / SRID we pass through were derived
+            // from that execution; pairing them with whatever the operator typed
+            // since would register a view against mismatched SQL+metadata.
             var request = new SaveViewRequest
             {
                 Name = name,
                 Description = description,
-                Sql = Sql,
+                Sql = LastResultSql ?? Sql,
                 GeometryColumn = LastResult?.HasGeometry == true && LastResult.GeometryColumnIndex is int idx
                     ? LastResult.Columns[idx].Name
                     : null,

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -99,6 +99,12 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
     /// Surfaces a client-side export failure (e.g. non-WGS84 SRID) on the toolbar
     /// banner without disturbing the underlying result. Telemetry records the
     /// rejection so the operator-visible error has a paired log entry.
+    ///
+    /// Deliberate exception to the LastError-implies-Error invariant: the query
+    /// itself succeeded — only the export action failed — so <see cref="Status"/>
+    /// stays at its prior value (typically Idle) while the banner communicates the
+    /// rejection. The next state-changing call (re-Run, EXPLAIN, save) clears
+    /// <see cref="LastError"/>.
     /// </summary>
     public void SetExportError(string message)
     {
@@ -108,6 +114,31 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
             ["message"] = message
         });
         Notify();
+    }
+
+    /// <summary>
+    /// Reason the map preview cannot be rendered for the current result, or
+    /// <c>null</c> when the preview is renderable. Mirrors the SRID guard the
+    /// GeoJSON exporter enforces so both surfaces refuse the same inputs —
+    /// MapLibre expects WGS84 longitude/latitude, so a non-4326 result would
+    /// silently put markers off-map.
+    /// </summary>
+    public string? MapPreviewBlockedReason
+    {
+        get
+        {
+            if (LastResult is not { HasGeometry: true } result)
+            {
+                return null;
+            }
+            if (result.GeometrySrid is int srid && srid != SqlResultExporter.Wgs84Srid)
+            {
+                return string.Create(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    $"Map preview requires WGS84 (SRID 4326); result is SRID {srid}. Reproject server-side to preview.");
+            }
+            return null;
+        }
     }
 
     public async Task LoadSchemaAsync(CancellationToken cancellationToken = default)
@@ -128,7 +159,11 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         }
         catch (OperationCanceledException)
         {
+            // Notify before re-throwing so subscribers observing the Loading state
+            // see the Idle terminal state — RunQueryAsync / RunExplainAsync make
+            // the same guarantee via their trailing Notify().
             Status = SpatialSqlPaneStatus.Idle;
+            Notify();
             throw;
         }
         catch (Exception ex)
@@ -219,14 +254,10 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
             else
             {
                 Status = SpatialSqlPaneStatus.Idle;
-                if (result.HasGeometry)
-                {
-                    ResultsTab = "map";
-                }
-                else
-                {
-                    ResultsTab = "table";
-                }
+                // Auto-switch to the map tab only when the geometry can actually be
+                // previewed — non-WGS84 results would mis-render on MapLibre, so leave
+                // the operator on the table view with the blocked-reason banner.
+                ResultsTab = result.HasGeometry && IsRenderableSrid(result.GeometrySrid) ? "map" : "table";
                 _telemetry.RecordLatency("query_completed", watch.ElapsedMilliseconds, new Dictionary<string, object?>
                 {
                     ["rows"] = result.Rows.Count,
@@ -372,6 +403,16 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
             Notify();
             return registration;
         }
+        catch (OperationCanceledException)
+        {
+            // Match the cancellation contract used by LoadSchemaAsync /
+            // RunQueryAsync / RunExplainAsync: cancellation lands in Idle, not in
+            // the Error/transport_error bucket, and subscribers are notified before
+            // the exception propagates so any 'Saving' spinner can clear.
+            Status = SpatialSqlPaneStatus.Idle;
+            Notify();
+            throw;
+        }
         catch (Exception ex)
         {
             Status = SpatialSqlPaneStatus.Error;
@@ -438,6 +479,12 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         {
             return Array.Empty<MapPreviewFeature>();
         }
+        // Mirror the GeoJSON exporter's WGS84 guard so non-4326 SRIDs never reach
+        // MapLibre — see <see cref="MapPreviewBlockedReason"/> for the surfaced text.
+        if (!IsRenderableSrid(LastResult.GeometrySrid))
+        {
+            return Array.Empty<MapPreviewFeature>();
+        }
         var geometryIndex = LastResult.GeometryColumnIndex!.Value;
         var idIndex = FindIdColumn(LastResult.Columns);
         var labelIndex = FindLabelColumn(LastResult.Columns, idIndex);
@@ -488,6 +535,8 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         }
         return -1;
     }
+
+    private static bool IsRenderableSrid(int? srid) => srid is null || srid == SqlResultExporter.Wgs84Srid;
 
     private static int FindLabelColumn(IReadOnlyList<SqlColumn> columns, int idIndex)
     {

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -193,6 +193,7 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
     {
         if (string.IsNullOrWhiteSpace(Sql))
         {
+            SupersedeActiveExecution();
             LastError = "Enter a SQL statement to run.";
             Status = SpatialSqlPaneStatus.Error;
             Notify();
@@ -209,6 +210,7 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
 
         if (!allowMutation && MutationGuard.IsMutating(Sql))
         {
+            SupersedeActiveExecution();
             LastError = "Mutating SQL is rejected by default. Use the override dialog to confirm and resubmit.";
             Status = SpatialSqlPaneStatus.Error;
             LastResult = new SqlExecuteResult
@@ -355,6 +357,16 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         if (notify)
         {
             Notify();
+        }
+    }
+
+    private void SupersedeActiveExecution()
+    {
+        lock (_sync)
+        {
+            _executeCts?.Cancel();
+            _executeCts?.Dispose();
+            _executeCts = null;
         }
     }
 

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -29,6 +29,7 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
     private readonly ISpatialSqlTelemetry _telemetry;
     private readonly object _sync = new();
     private CancellationTokenSource? _executeCts;
+    private CancellationTokenSource? _explainCts;
     private bool _disposed;
 
     public SpatialSqlPlaygroundState(ISpatialSqlClient client, ISpatialSqlTelemetry telemetry)
@@ -365,10 +366,47 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         }
     }
 
+    private bool IsActiveExplain(CancellationTokenSource cts)
+    {
+        lock (_sync)
+        {
+            return ReferenceEquals(_explainCts, cts);
+        }
+    }
+
+    private void SupersedeActiveExplain()
+    {
+        lock (_sync)
+        {
+            _explainCts?.Cancel();
+            _explainCts?.Dispose();
+            _explainCts = null;
+        }
+    }
+
+    private CancellationTokenSource StartExplainExecution(CancellationToken cancellationToken)
+    {
+        lock (_sync)
+        {
+            _explainCts?.Cancel();
+            _explainCts?.Dispose();
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _explainCts = cts;
+            return cts;
+        }
+    }
+
     public async Task RunExplainAsync(CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(Sql))
+        var submittedSql = Sql;
+
+        if (string.IsNullOrWhiteSpace(submittedSql))
         {
+            SupersedeActiveExplain();
+            LastPlan = null;
+            LastError = null;
+            Status = SpatialSqlPaneStatus.Idle;
+            Notify();
             return;
         }
 
@@ -376,8 +414,10 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         // server-side EXPLAIN endpoint has no AllowMutation contract or audit
         // hook. Reject mutating SQL outright — the per-query override on the Run
         // path is the only audited mutation channel, EXPLAIN is not.
-        if (MutationGuard.IsMutating(Sql))
+        if (MutationGuard.IsMutating(submittedSql))
         {
+            SupersedeActiveExplain();
+            LastPlan = null;
             LastError = "EXPLAIN is rejected for mutating SQL — EXPLAIN ANALYZE would execute the statement outside the audited mutation-override flow.";
             Status = SpatialSqlPaneStatus.Error;
             _telemetry.Record("explain_rejected", new Dictionary<string, object?>
@@ -388,15 +428,27 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
             return;
         }
 
+        var cts = StartExplainExecution(cancellationToken);
+
+        LastPlan = null;
         Status = SpatialSqlPaneStatus.Explaining;
         LastError = null;
         Notify();
 
         var watch = Stopwatch.StartNew();
+        var notify = false;
         try
         {
-            var plan = await _client.ExplainAsync(new SqlExplainRequest { Sql = Sql }, cancellationToken).ConfigureAwait(false);
+            var plan = await _client.ExplainAsync(new SqlExplainRequest { Sql = submittedSql }, cts.Token).ConfigureAwait(false);
             watch.Stop();
+
+            // Same ownership invariant as query execution: a later EXPLAIN attempt
+            // owns the plan pane, even if this client call completes afterwards.
+            if (!IsActiveExplain(cts))
+            {
+                return;
+            }
+
             LastPlan = plan;
             Status = plan.IsError ? SpatialSqlPaneStatus.Error : SpatialSqlPaneStatus.Idle;
             if (plan.IsError)
@@ -416,13 +468,23 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
                     ["root_node"] = plan.Root.NodeType
                 });
             }
+            notify = true;
         }
         catch (OperationCanceledException)
         {
+            if (!IsActiveExplain(cts))
+            {
+                return;
+            }
             Status = SpatialSqlPaneStatus.Idle;
+            notify = true;
         }
         catch (Exception ex)
         {
+            if (!IsActiveExplain(cts))
+            {
+                return;
+            }
             Status = SpatialSqlPaneStatus.Error;
             LastError = ex.Message;
             _telemetry.Record("explain_rejected", new Dictionary<string, object?>
@@ -430,9 +492,24 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
                 ["reason"] = "transport_error",
                 ["message"] = ex.Message
             });
+            notify = true;
+        }
+        finally
+        {
+            lock (_sync)
+            {
+                if (ReferenceEquals(_explainCts, cts))
+                {
+                    _explainCts.Dispose();
+                    _explainCts = null;
+                }
+            }
         }
 
-        Notify();
+        if (notify)
+        {
+            Notify();
+        }
     }
 
     /// <summary>
@@ -658,11 +735,13 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         try
         {
             _executeCts?.Cancel();
+            _explainCts?.Cancel();
         }
         catch (ObjectDisposedException)
         {
         }
         _executeCts?.Dispose();
+        _explainCts?.Dispose();
     }
 
     private void Notify() => OnChanged?.Invoke();

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -1,0 +1,514 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.SpatialSql;
+
+namespace Honua.Admin.Services.SpatialSql;
+
+public enum SpatialSqlPaneStatus
+{
+    Idle,
+    Loading,
+    Executing,
+    Explaining,
+    Saving,
+    Error
+}
+
+/// <summary>
+/// Scoped observable store backing the SQL playground. All mutations route through
+/// explicit methods so telemetry, cancellation, and persistence stay single-origin
+/// — the same pattern used by <see cref="Honua.Admin.Services.SpecWorkspace.SpecWorkspaceState"/>.
+/// </summary>
+public sealed class SpatialSqlPlaygroundState : IDisposable
+{
+    private readonly ISpatialSqlClient _client;
+    private readonly ISpatialSqlTelemetry _telemetry;
+    private readonly object _sync = new();
+    private CancellationTokenSource? _executeCts;
+    private bool _disposed;
+
+    public SpatialSqlPlaygroundState(ISpatialSqlClient client, ISpatialSqlTelemetry telemetry)
+    {
+        _client = client;
+        _telemetry = telemetry;
+    }
+
+    public string Sql { get; private set; } = string.Empty;
+
+    public SchemaSnapshot? Schema { get; private set; }
+
+    public SqlExecuteResult? LastResult { get; private set; }
+
+    public ExplainPlan? LastPlan { get; private set; }
+
+    public NamedViewRegistration? LastSavedView { get; private set; }
+
+    public string? LastError { get; private set; }
+
+    public SpatialSqlPaneStatus Status { get; private set; } = SpatialSqlPaneStatus.Idle;
+
+    public bool MutationOverrideArmed { get; private set; }
+
+    public bool ExportTruncatedConfirmed { get; private set; }
+
+    public string ResultsTab { get; private set; } = "table";
+
+    public event Action? OnChanged;
+
+    public void SetSql(string? value)
+    {
+        Sql = value ?? string.Empty;
+        // Disarm any previous mutation override the moment the operator edits the SQL —
+        // a confirmation must apply only to the exact statement the operator approved.
+        MutationOverrideArmed = false;
+        Notify();
+    }
+
+    public void SetResultsTab(string tab)
+    {
+        if (tab != "table" && tab != "map")
+        {
+            return;
+        }
+        ResultsTab = tab;
+        _telemetry.Record("results_tab_changed", new Dictionary<string, object?> { ["tab"] = tab });
+        Notify();
+    }
+
+    public void ArmMutationOverride()
+    {
+        MutationOverrideArmed = true;
+        _telemetry.Record("mutation_override_accepted", new Dictionary<string, object?>
+        {
+            ["sql_length"] = Sql.Length
+        });
+        Notify();
+    }
+
+    public void ConfirmTruncatedExport()
+    {
+        ExportTruncatedConfirmed = true;
+        Notify();
+    }
+
+    public async Task LoadSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        Status = SpatialSqlPaneStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            Schema = await _client.GetSchemaAsync(cancellationToken).ConfigureAwait(false);
+            Status = SpatialSqlPaneStatus.Idle;
+            _telemetry.Record("schema_loaded", new Dictionary<string, object?>
+            {
+                ["tables"] = Schema?.Tables.Count ?? 0,
+                ["functions"] = Schema?.Functions.Count ?? 0
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            Status = SpatialSqlPaneStatus.Idle;
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Status = SpatialSqlPaneStatus.Error;
+            LastError = ex.Message;
+            _telemetry.Record("schema_load_failed", new Dictionary<string, object?>
+            {
+                ["message"] = ex.Message
+            });
+        }
+
+        Notify();
+    }
+
+    public async Task RunQueryAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(Sql))
+        {
+            LastError = "Enter a SQL statement to run.";
+            Status = SpatialSqlPaneStatus.Error;
+            Notify();
+            return;
+        }
+
+        var allowMutation = MutationOverrideArmed;
+
+        if (!allowMutation && MutationGuard.IsMutating(Sql))
+        {
+            LastError = "Mutating SQL is rejected by default. Use the override dialog to confirm and resubmit.";
+            Status = SpatialSqlPaneStatus.Error;
+            LastResult = new SqlExecuteResult
+            {
+                RowLimit = 0,
+                TimeoutMs = 0,
+                Error = new SqlExecuteError("mutation_blocked", LastError)
+            };
+            _telemetry.Record("query_rejected", new Dictionary<string, object?>
+            {
+                ["reason"] = "mutation_blocked"
+            });
+            Notify();
+            return;
+        }
+
+        CancellationTokenSource cts;
+        lock (_sync)
+        {
+            _executeCts?.Cancel();
+            _executeCts?.Dispose();
+            cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _executeCts = cts;
+        }
+
+        Status = SpatialSqlPaneStatus.Executing;
+        LastError = null;
+        ExportTruncatedConfirmed = false;
+        Notify();
+
+        var watch = Stopwatch.StartNew();
+        try
+        {
+            _telemetry.Record("query_submitted", new Dictionary<string, object?>
+            {
+                ["sql_length"] = Sql.Length,
+                ["allow_mutation"] = allowMutation
+            });
+
+            var request = new SqlExecuteRequest
+            {
+                Sql = Sql,
+                AllowMutation = allowMutation
+            };
+
+            var result = await _client.ExecuteAsync(request, cts.Token).ConfigureAwait(false);
+            watch.Stop();
+            LastResult = result;
+            if (result.IsError)
+            {
+                Status = SpatialSqlPaneStatus.Error;
+                LastError = result.Error?.Message;
+                _telemetry.Record("query_rejected", new Dictionary<string, object?>
+                {
+                    ["reason"] = result.Error?.Code,
+                    ["message"] = result.Error?.Message
+                });
+            }
+            else
+            {
+                Status = SpatialSqlPaneStatus.Idle;
+                if (result.HasGeometry)
+                {
+                    ResultsTab = "map";
+                }
+                else
+                {
+                    ResultsTab = "table";
+                }
+                _telemetry.RecordLatency("query_completed", watch.ElapsedMilliseconds, new Dictionary<string, object?>
+                {
+                    ["rows"] = result.Rows.Count,
+                    ["truncated"] = result.Truncated,
+                    ["has_geometry"] = result.HasGeometry,
+                    ["audit_entry_id"] = result.AuditEntryId
+                });
+
+                if (result.Truncated)
+                {
+                    _telemetry.Record("cap_reached", new Dictionary<string, object?>
+                    {
+                        ["row_limit"] = result.RowLimit
+                    });
+                }
+            }
+
+            // Reset override after each submit so the next mutation requires a fresh
+            // confirmation. The audit log on the server records this single statement.
+            MutationOverrideArmed = false;
+        }
+        catch (OperationCanceledException)
+        {
+            Status = SpatialSqlPaneStatus.Idle;
+        }
+        catch (Exception ex)
+        {
+            Status = SpatialSqlPaneStatus.Error;
+            LastError = ex.Message;
+            _telemetry.Record("query_rejected", new Dictionary<string, object?>
+            {
+                ["reason"] = "transport_error",
+                ["message"] = ex.Message
+            });
+        }
+        finally
+        {
+            lock (_sync)
+            {
+                if (ReferenceEquals(_executeCts, cts))
+                {
+                    _executeCts.Dispose();
+                    _executeCts = null;
+                }
+            }
+        }
+
+        Notify();
+    }
+
+    public async Task RunExplainAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(Sql))
+        {
+            return;
+        }
+
+        Status = SpatialSqlPaneStatus.Explaining;
+        LastError = null;
+        Notify();
+
+        var watch = Stopwatch.StartNew();
+        try
+        {
+            var plan = await _client.ExplainAsync(new SqlExplainRequest { Sql = Sql }, cancellationToken).ConfigureAwait(false);
+            watch.Stop();
+            LastPlan = plan;
+            Status = plan.IsError ? SpatialSqlPaneStatus.Error : SpatialSqlPaneStatus.Idle;
+            if (plan.IsError)
+            {
+                LastError = plan.Error?.Message;
+                _telemetry.Record("explain_rejected", new Dictionary<string, object?>
+                {
+                    ["reason"] = plan.Error?.Code,
+                    ["message"] = plan.Error?.Message
+                });
+            }
+            else
+            {
+                _telemetry.RecordLatency("explain_completed", watch.ElapsedMilliseconds, new Dictionary<string, object?>
+                {
+                    ["total_elapsed_ms"] = plan.TotalElapsedMs,
+                    ["root_node"] = plan.Root.NodeType
+                });
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            Status = SpatialSqlPaneStatus.Idle;
+        }
+        catch (Exception ex)
+        {
+            Status = SpatialSqlPaneStatus.Error;
+            LastError = ex.Message;
+            _telemetry.Record("explain_rejected", new Dictionary<string, object?>
+            {
+                ["reason"] = "transport_error",
+                ["message"] = ex.Message
+            });
+        }
+
+        Notify();
+    }
+
+    public async Task<NamedViewRegistration> SaveViewAsync(string name, string? description, CancellationToken cancellationToken = default)
+    {
+        Status = SpatialSqlPaneStatus.Saving;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var request = new SaveViewRequest
+            {
+                Name = name,
+                Description = description,
+                Sql = Sql,
+                GeometryColumn = LastResult?.HasGeometry == true && LastResult.GeometryColumnIndex is int idx
+                    ? LastResult.Columns[idx].Name
+                    : null,
+                Srid = LastResult?.GeometrySrid
+            };
+
+            var registration = await _client.SaveViewAsync(request, cancellationToken).ConfigureAwait(false);
+            LastSavedView = registration;
+            Status = registration.IsError ? SpatialSqlPaneStatus.Error : SpatialSqlPaneStatus.Idle;
+            if (registration.IsError)
+            {
+                LastError = registration.Error?.Message;
+                _telemetry.Record("view_save_rejected", new Dictionary<string, object?>
+                {
+                    ["reason"] = registration.Error?.Code,
+                    ["message"] = registration.Error?.Message
+                });
+            }
+            else
+            {
+                _telemetry.Record("view_saved", new Dictionary<string, object?>
+                {
+                    ["name"] = registration.Name
+                });
+            }
+            Notify();
+            return registration;
+        }
+        catch (Exception ex)
+        {
+            Status = SpatialSqlPaneStatus.Error;
+            LastError = ex.Message;
+            _telemetry.Record("view_save_rejected", new Dictionary<string, object?>
+            {
+                ["reason"] = "transport_error",
+                ["message"] = ex.Message
+            });
+            Notify();
+            throw;
+        }
+    }
+
+    public bool CanExportRows()
+    {
+        if (LastResult is null || LastResult.IsError || LastResult.Rows.Count == 0)
+        {
+            return false;
+        }
+        return !LastResult.Truncated || ExportTruncatedConfirmed;
+    }
+
+    public string ExportCsv()
+    {
+        var result = RequireExportableResult();
+        _telemetry.Record("export_triggered", new Dictionary<string, object?>
+        {
+            ["format"] = "csv",
+            ["rows"] = result.Rows.Count
+        });
+        return SqlResultExporter.ToCsv(result);
+    }
+
+    public string ExportGeoJson()
+    {
+        var result = RequireExportableResult();
+        if (!result.HasGeometry)
+        {
+            throw new InvalidOperationException("Result has no geometry column to export.");
+        }
+        _telemetry.Record("export_triggered", new Dictionary<string, object?>
+        {
+            ["format"] = "geojson",
+            ["rows"] = result.Rows.Count
+        });
+        return SqlResultExporter.ToGeoJson(result);
+    }
+
+    public string ExportClipboard()
+    {
+        var result = RequireExportableResult();
+        _telemetry.Record("export_triggered", new Dictionary<string, object?>
+        {
+            ["format"] = "clipboard",
+            ["rows"] = result.Rows.Count
+        });
+        return SqlResultExporter.ToClipboardText(result);
+    }
+
+    public IReadOnlyList<MapPreviewFeature> BuildMapFeatures()
+    {
+        if (LastResult is null || !LastResult.HasGeometry)
+        {
+            return Array.Empty<MapPreviewFeature>();
+        }
+        var geometryIndex = LastResult.GeometryColumnIndex!.Value;
+        var idIndex = FindIdColumn(LastResult.Columns);
+        var labelIndex = FindLabelColumn(LastResult.Columns, idIndex);
+
+        var features = new List<MapPreviewFeature>(LastResult.Rows.Count);
+        var fallback = 0;
+        foreach (var row in LastResult.Rows)
+        {
+            if (geometryIndex >= row.Cells.Count)
+            {
+                continue;
+            }
+
+            var geometry = row.Cells[geometryIndex];
+            if (string.IsNullOrWhiteSpace(geometry))
+            {
+                continue;
+            }
+
+            var id = idIndex >= 0 && idIndex < row.Cells.Count ? row.Cells[idIndex] : null;
+            var label = labelIndex >= 0 && labelIndex < row.Cells.Count ? row.Cells[labelIndex] : null;
+            features.Add(new MapPreviewFeature(
+                id ?? $"row-{fallback}",
+                label ?? id ?? $"row-{fallback}",
+                geometry!));
+            fallback++;
+        }
+        return features;
+    }
+
+    private SqlExecuteResult RequireExportableResult()
+    {
+        if (!CanExportRows())
+        {
+            throw new InvalidOperationException("Result is not exportable in its current state.");
+        }
+        return LastResult!;
+    }
+
+    private static int FindIdColumn(IReadOnlyList<SqlColumn> columns)
+    {
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (columns[i].Name.Equals("id", StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int FindLabelColumn(IReadOnlyList<SqlColumn> columns, int idIndex)
+    {
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (i == idIndex)
+            {
+                continue;
+            }
+            if (columns[i].IsGeometry)
+            {
+                continue;
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        try
+        {
+            _executeCts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        _executeCts?.Dispose();
+    }
+
+    private void Notify() => OnChanged?.Invoke();
+}
+
+public sealed record MapPreviewFeature(string Id, string Label, string GeoJson);

--- a/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
+++ b/src/Honua.Admin/Services/SpatialSql/SpatialSqlPlaygroundState.cs
@@ -95,6 +95,21 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
         Notify();
     }
 
+    /// <summary>
+    /// Surfaces a client-side export failure (e.g. non-WGS84 SRID) on the toolbar
+    /// banner without disturbing the underlying result. Telemetry records the
+    /// rejection so the operator-visible error has a paired log entry.
+    /// </summary>
+    public void SetExportError(string message)
+    {
+        LastError = message;
+        _telemetry.Record("export_rejected", new Dictionary<string, object?>
+        {
+            ["message"] = message
+        });
+        Notify();
+    }
+
     public async Task LoadSchemaAsync(CancellationToken cancellationToken = default)
     {
         Status = SpatialSqlPaneStatus.Loading;
@@ -511,4 +526,7 @@ public sealed class SpatialSqlPlaygroundState : IDisposable
     private void Notify() => OnChanged?.Invoke();
 }
 
-public sealed record MapPreviewFeature(string Id, string Label, string GeoJson);
+public sealed record MapPreviewFeature(
+    [property: System.Text.Json.Serialization.JsonPropertyName("id")] string Id,
+    [property: System.Text.Json.Serialization.JsonPropertyName("label")] string Label,
+    [property: System.Text.Json.Serialization.JsonPropertyName("geoJson")] string GeoJson);

--- a/src/Honua.Admin/Services/SpatialSql/StubSpatialSqlClient.cs
+++ b/src/Honua.Admin/Services/SpatialSql/StubSpatialSqlClient.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.SpatialSql;
+
+namespace Honua.Admin.Services.SpatialSql;
+
+/// <summary>
+/// In-process stub used while the server SQL playground endpoints are still in
+/// flight. Honours the same safety contract the HTTP backend will enforce —
+/// reads succeed, mutations need <see cref="SqlExecuteRequest.AllowMutation"/>,
+/// the row cap surfaces through <see cref="SqlExecuteResult.Truncated"/>, and the
+/// stub returns realistic geometry rows so the map preview path is exercisable
+/// end-to-end.
+/// </summary>
+public sealed class StubSpatialSqlClient : ISpatialSqlClient
+{
+    private const int DefaultRowLimit = 1000;
+    private const int DefaultTimeoutMs = 30_000;
+
+    private static readonly Regex FromTableRegex = new(
+        @"\bfrom\s+(?<table>[a-zA-Z_][\w]*)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly Dictionary<string, StubTable> _tables;
+    private readonly HashSet<string> _registeredViewNames = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _viewSync = new();
+    private int _auditSequence;
+
+    public StubSpatialSqlClient()
+    {
+        _tables = BuildSeed();
+    }
+
+    public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var snapshot = new SchemaSnapshot
+        {
+            Tables = _tables.Values.Select(t => new SchemaTable
+            {
+                Name = t.Name,
+                Description = t.Description,
+                GeometryColumn = t.GeometryColumn,
+                Srid = t.Srid,
+                Columns = t.Columns
+            }).ToArray(),
+            Functions = PostGisReference.Functions,
+            Operators = PostGisReference.Operators,
+            FetchedAt = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture)
+        };
+        return Task.FromResult(snapshot);
+    }
+
+    public async Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sql = request.Sql ?? string.Empty;
+        var rowLimit = request.RowLimit is int rl && rl > 0 ? Math.Min(rl, DefaultRowLimit) : DefaultRowLimit;
+        var timeoutMs = request.TimeoutMs is int t && t > 0 ? t : DefaultTimeoutMs;
+
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            return new SqlExecuteResult
+            {
+                RowLimit = rowLimit,
+                TimeoutMs = timeoutMs,
+                Error = new SqlExecuteError("empty_sql", "SQL text is empty.")
+            };
+        }
+
+        var mutating = MutationGuard.IsMutating(sql);
+        if (mutating && !request.AllowMutation)
+        {
+            return new SqlExecuteResult
+            {
+                RowLimit = rowLimit,
+                TimeoutMs = timeoutMs,
+                Error = new SqlExecuteError(
+                    "mutation_blocked",
+                    "Mutating SQL is rejected by default. Re-submit with the per-query override to run it.")
+            };
+        }
+
+        if (mutating && request.AllowMutation)
+        {
+            var auditId = $"audit-{Interlocked.Increment(ref _auditSequence):D6}";
+            return new SqlExecuteResult
+            {
+                Columns = new[] { new SqlColumn("status", "text") },
+                Rows = new[] { new SqlRow(new string?[] { "ok" }) },
+                RowLimit = rowLimit,
+                TimeoutMs = timeoutMs,
+                ElapsedMs = 12,
+                AuditEntryId = auditId
+            };
+        }
+
+        var table = ResolveTable(sql);
+        if (table is null)
+        {
+            return new SqlExecuteResult
+            {
+                Columns = new[] { new SqlColumn("note", "text") },
+                Rows = new[] { new SqlRow(new string?[] { "Stub: query parsed but no FROM table recognised." }) },
+                RowLimit = rowLimit,
+                TimeoutMs = timeoutMs,
+                ElapsedMs = 4
+            };
+        }
+
+        IReadOnlyList<SqlRow> rows = table.Rows;
+        var truncated = false;
+        if (rows.Count > rowLimit)
+        {
+            rows = rows.Take(rowLimit).ToArray();
+            truncated = true;
+        }
+
+        var columns = table.SelectSqlColumns();
+        var geometryIndex = columns.FindIndex(c => c.IsGeometry);
+
+        return new SqlExecuteResult
+        {
+            Columns = columns,
+            Rows = rows,
+            RowLimit = rowLimit,
+            TimeoutMs = timeoutMs,
+            Truncated = truncated,
+            GeometryColumnIndex = geometryIndex >= 0 ? geometryIndex : null,
+            GeometrySrid = geometryIndex >= 0 ? table.Srid : null,
+            ElapsedMs = 38
+        };
+    }
+
+    public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(request.Sql))
+        {
+            return Task.FromResult(new ExplainPlan
+            {
+                Root = new ExplainNode { NodeType = "Empty" },
+                Error = new SqlExecuteError("empty_sql", "SQL text is empty.")
+            });
+        }
+
+        var table = ResolveTable(request.Sql);
+        var relationName = table?.Name ?? "unknown";
+        var rowEstimate = table?.Rows.Count ?? 100;
+
+        var scan = new ExplainNode
+        {
+            NodeType = "Seq Scan",
+            Relation = relationName,
+            ActualRows = rowEstimate,
+            PlanRows = rowEstimate,
+            ActualTotalMs = 12.4,
+            TotalCost = 32.5
+        };
+
+        var aggregate = new ExplainNode
+        {
+            NodeType = "Aggregate",
+            ActualRows = 1,
+            PlanRows = 1,
+            ActualTotalMs = 14.1,
+            TotalCost = 38.7,
+            Children = new[] { scan }
+        };
+
+        return Task.FromResult(new ExplainPlan
+        {
+            Root = aggregate,
+            TotalElapsedMs = 18.3,
+            PlanningMs = 0.7
+        });
+    }
+
+    public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            return Task.FromResult(new NamedViewRegistration
+            {
+                Name = string.Empty,
+                Error = new SqlExecuteError("invalid_name", "Named views require a non-empty name.")
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Sql))
+        {
+            return Task.FromResult(new NamedViewRegistration
+            {
+                Name = request.Name,
+                Error = new SqlExecuteError("empty_sql", "Cannot save an empty query.")
+            });
+        }
+
+        if (MutationGuard.IsMutating(request.Sql))
+        {
+            return Task.FromResult(new NamedViewRegistration
+            {
+                Name = request.Name,
+                Error = new SqlExecuteError("mutation_blocked", "Named views must be read-only queries.")
+            });
+        }
+
+        lock (_viewSync)
+        {
+            if (!_registeredViewNames.Add(request.Name))
+            {
+                return Task.FromResult(new NamedViewRegistration
+                {
+                    Name = request.Name,
+                    Error = new SqlExecuteError("duplicate_name", $"A named view called '{request.Name}' already exists.")
+                });
+            }
+        }
+
+        return Task.FromResult(new NamedViewRegistration
+        {
+            Name = request.Name,
+            FeatureServerUrl = $"/services/featureserver/views/{request.Name}/FeatureServer/0",
+            OgcFeaturesUrl = $"/ogc/features/v1/collections/{request.Name}",
+            ODataUrl = $"/odata/views/{request.Name}"
+        });
+    }
+
+    private StubTable? ResolveTable(string sql)
+    {
+        var stripped = MutationGuard.StripCommentsAndLiterals(sql);
+        var match = FromTableRegex.Match(stripped);
+        if (!match.Success)
+        {
+            return null;
+        }
+        return _tables.TryGetValue(match.Groups["table"].Value, out var table) ? table : null;
+    }
+
+    private static Dictionary<string, StubTable> BuildSeed()
+    {
+        var parcels = new StubTable(
+            Name: "parcels",
+            Description: "Statewide parcel polygons.",
+            GeometryColumn: "geom",
+            Srid: 4326,
+            Columns: new[]
+            {
+                new SchemaColumn("id", "uuid", "primary key"),
+                new SchemaColumn("county", "text", "county name"),
+                new SchemaColumn("acreage", "double precision", "parcel acreage"),
+                new SchemaColumn("geom", "geometry(Polygon,4326)", "parcel polygon")
+            },
+            Rows: new[]
+            {
+                new SqlRow(new string?[]
+                {
+                    "11111111-1111-1111-1111-111111111111",
+                    "Alpha",
+                    "12.4",
+                    "{\"type\":\"Polygon\",\"coordinates\":[[[-122.42,37.77],[-122.42,37.78],[-122.41,37.78],[-122.41,37.77],[-122.42,37.77]]]}"
+                }),
+                new SqlRow(new string?[]
+                {
+                    "22222222-2222-2222-2222-222222222222",
+                    "Beta",
+                    "5.2",
+                    "{\"type\":\"Polygon\",\"coordinates\":[[[-122.40,37.79],[-122.40,37.80],[-122.39,37.80],[-122.39,37.79],[-122.40,37.79]]]}"
+                })
+            });
+
+        var wells = new StubTable(
+            Name: "wells",
+            Description: "Licensed water wells with annual production.",
+            GeometryColumn: "geom",
+            Srid: 4326,
+            Columns: new[]
+            {
+                new SchemaColumn("id", "text", "well id"),
+                new SchemaColumn("depth_m", "double precision", "depth in metres"),
+                new SchemaColumn("basin", "text", "basin name"),
+                new SchemaColumn("geom", "geometry(Point,4326)", "well point")
+            },
+            Rows: new[]
+            {
+                new SqlRow(new string?[]
+                {
+                    "W-12",
+                    "30",
+                    "North",
+                    "{\"type\":\"Point\",\"coordinates\":[-122.40,37.76]}"
+                }),
+                new SqlRow(new string?[]
+                {
+                    "W-33",
+                    "90",
+                    "South",
+                    "{\"type\":\"Point\",\"coordinates\":[-122.45,37.80]}"
+                })
+            });
+
+        return new Dictionary<string, StubTable>(StringComparer.OrdinalIgnoreCase)
+        {
+            [parcels.Name] = parcels,
+            [wells.Name] = wells
+        };
+    }
+
+    private sealed record StubTable(
+        string Name,
+        string Description,
+        string GeometryColumn,
+        int Srid,
+        IReadOnlyList<SchemaColumn> Columns,
+        IReadOnlyList<SqlRow> Rows)
+    {
+        public List<SqlColumn> SelectSqlColumns() => Columns
+            .Select(c => new SqlColumn(c.Name, c.Type, IsGeometry: c.Name == GeometryColumn))
+            .ToList();
+    }
+
+    private static class PostGisReference
+    {
+        public static IReadOnlyList<PostGisFunction> Functions { get; } = new[]
+        {
+            new PostGisFunction("ST_Area", "ST_Area(geometry)", "measurement", "Returns the area of a polygon."),
+            new PostGisFunction("ST_AsGeoJSON", "ST_AsGeoJSON(geometry)", "format", "Returns GeoJSON for a geometry."),
+            new PostGisFunction("ST_Buffer", "ST_Buffer(geometry, distance)", "geometry", "Returns a geometry buffered by the given distance."),
+            new PostGisFunction("ST_Centroid", "ST_Centroid(geometry)", "geometry", "Returns the geometric centre of a geometry."),
+            new PostGisFunction("ST_Contains", "ST_Contains(a, b)", "predicate", "True when a fully contains b."),
+            new PostGisFunction("ST_DWithin", "ST_DWithin(a, b, distance)", "predicate", "True when a is within distance of b."),
+            new PostGisFunction("ST_GeomFromText", "ST_GeomFromText(wkt, srid)", "constructor", "Parses WKT into a geometry."),
+            new PostGisFunction("ST_Intersects", "ST_Intersects(a, b)", "predicate", "True when a and b share any point."),
+            new PostGisFunction("ST_Transform", "ST_Transform(geometry, srid)", "geometry", "Reprojects geometry to a target SRID."),
+            new PostGisFunction("ST_Within", "ST_Within(a, b)", "predicate", "True when a is fully within b.")
+        };
+
+        public static IReadOnlyList<PostGisOperator> Operators { get; } = new[]
+        {
+            new PostGisOperator("&&", "Bounding boxes intersect."),
+            new PostGisOperator("@>", "Geometry A contains geometry B."),
+            new PostGisOperator("<@", "Geometry A is contained by geometry B."),
+            new PostGisOperator("~=", "Geometries are equal.")
+        };
+    }
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -19,6 +19,9 @@
     <MudNavLink Href="/operator/license" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.VerifiedUser">
         License workspace
     </MudNavLink>
+    <MudNavLink Href="/operator/sql" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Storage">
+        Spatial SQL
+    </MudNavLink>
     <MudNavGroup Title="Identity" Icon="@Icons.Material.Filled.VpnKey" Expanded="true">
         <MudNavLink Href="/admin/identity/providers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AccountCircle">
             Providers

--- a/src/Honua.Admin/_Imports.razor
+++ b/src/Honua.Admin/_Imports.razor
@@ -12,10 +12,13 @@
 @using Honua.Admin.Components.Identity
 @using Honua.Admin.Components.LicenseWorkspace
 @using Honua.Admin.Components.SpecWorkspace
+@using Honua.Admin.Components.SpatialSql
 @using Honua.Admin.Models.Identity
 @using Honua.Admin.Models.LicenseWorkspace
+@using Honua.Admin.Models.SpatialSql
 @using Honua.Admin.Models.SpecWorkspace
 @using Honua.Admin.Services.Identity
 @using Honua.Admin.Services.LicenseWorkspace
+@using Honua.Admin.Services.SpatialSql
 @using Honua.Admin.Services.SpecWorkspace
 @using MudBlazor

--- a/src/Honua.Admin/wwwroot/css/spatial-sql.css
+++ b/src/Honua.Admin/wwwroot/css/spatial-sql.css
@@ -1,0 +1,90 @@
+.spatial-sql-root {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 128px);
+    min-height: 480px;
+    gap: 8px;
+}
+
+.spatial-sql-toolbar {
+    flex: 0 0 auto;
+}
+
+.spatial-sql-grid {
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: 1fr 1.4fr;
+    grid-template-rows: 1fr 1fr;
+    gap: 8px;
+    min-height: 0;
+}
+
+.spatial-sql-cell {
+    min-height: 0;
+    min-width: 0;
+    overflow: auto;
+}
+
+.spatial-sql-editor-cell {
+    grid-column: 1 / span 1;
+    grid-row: 1 / span 2;
+}
+
+.spatial-sql-results-cell {
+    grid-column: 2 / span 1;
+    grid-row: 1 / span 1;
+}
+
+.spatial-sql-plan-cell {
+    grid-column: 2 / span 1;
+    grid-row: 2 / span 1;
+}
+
+.spatial-sql-schema {
+    border-top: 1px solid var(--mud-palette-divider, #e0e0e0);
+    padding-top: 8px;
+    overflow-y: auto;
+    max-height: 280px;
+}
+
+.spatial-sql-map {
+    flex: 1 1 auto;
+    min-height: 240px;
+    display: flex;
+    flex-direction: column;
+}
+
+.sql-keyword {
+    color: #4527a0;
+    font-weight: 600;
+}
+
+.sql-postgis {
+    color: #006d77;
+    font-weight: 600;
+}
+
+.sql-literal {
+    color: #b71c1c;
+}
+
+.sql-comment {
+    color: #6b7280;
+    font-style: italic;
+}
+
+.explain-node {
+    padding: 4px 0 4px 0;
+    border-left: 2px solid transparent;
+}
+
+.explain-children {
+    margin-left: 20px;
+    border-left: 2px dashed var(--mud-palette-divider, #cfd8dc);
+    padding-left: 8px;
+}
+
+.explain-node-spacer {
+    display: inline-block;
+    width: 32px;
+}

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -11,6 +11,7 @@
     <link href="lib/maplibre/maplibre-gl.css" rel="stylesheet" />
     <link href="css/spec-workspace.css" rel="stylesheet" />
     <link href="css/license-workspace.css" rel="stylesheet" />
+    <link href="css/spatial-sql.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -36,6 +37,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="lib/maplibre/maplibre-gl.js"></script>
     <script src="js/spec-workspace-interop.js"></script>
+    <script src="js/spatial-sql-interop.js"></script>
 </body>
 
 </html>

--- a/src/Honua.Admin/wwwroot/js/spatial-sql-interop.js
+++ b/src/Honua.Admin/wwwroot/js/spatial-sql-interop.js
@@ -1,0 +1,209 @@
+// Spatial SQL playground interop. Exposes window.spatialSql for the Blazor
+// components. The map helpers reuse the same MapLibre bootstrap as the spec
+// workspace; the export helper streams a generated file via an anchor tag.
+(function () {
+    const state = {
+        maps: new Map()
+    };
+
+    function initializeMap(elementId) {
+        const container = document.getElementById(elementId);
+        if (!container) {
+            return;
+        }
+        let mapInstance = null;
+        if (window.maplibregl && window.maplibregl.Map) {
+            try {
+                mapInstance = new window.maplibregl.Map({
+                    container,
+                    style: {
+                        version: 8,
+                        sources: {},
+                        layers: [
+                            { id: 'bg', type: 'background', paint: { 'background-color': '#eef3f5' } }
+                        ]
+                    },
+                    center: [-157.8583, 21.3069],
+                    zoom: 5
+                });
+            } catch (err) {
+                mapInstance = null;
+            }
+        }
+
+        const entry = {
+            container,
+            mapInstance,
+            features: [],
+            loaded: false
+        };
+
+        if (mapInstance) {
+            mapInstance.on('load', function () {
+                entry.loaded = true;
+                renderMaplibre(entry);
+            });
+        }
+
+        state.maps.set(elementId, entry);
+    }
+
+    function setMapFeatures(elementId, features) {
+        const entry = state.maps.get(elementId);
+        if (!entry) {
+            return;
+        }
+        entry.features = features || [];
+        if (entry.mapInstance) {
+            renderMaplibre(entry);
+        } else {
+            renderFallback(entry);
+        }
+    }
+
+    function renderFallback(entry) {
+        if (entry.mapInstance) {
+            return;
+        }
+        entry.container.innerHTML = '';
+        const list = document.createElement('ul');
+        list.className = 'spec-map-fallback-list';
+        (entry.features || []).forEach(function (feat) {
+            const li = document.createElement('li');
+            li.dataset.featureId = feat.id;
+            li.textContent = feat.label || feat.id;
+            list.appendChild(li);
+        });
+        entry.container.appendChild(list);
+    }
+
+    function renderMaplibre(entry) {
+        if (!entry.mapInstance || !entry.loaded) {
+            return;
+        }
+
+        const featureCollection = {
+            type: 'FeatureCollection',
+            features: (entry.features || [])
+                .map(function (feature) {
+                    let geometry;
+                    try {
+                        geometry = JSON.parse(feature.geoJson);
+                    } catch (err) {
+                        return null;
+                    }
+                    return {
+                        type: 'Feature',
+                        geometry: geometry,
+                        properties: {
+                            id: feature.id,
+                            label: feature.label
+                        }
+                    };
+                })
+                .filter(function (f) { return f !== null; })
+        };
+
+        const map = entry.mapInstance;
+        const existingSource = map.getSource('sql-results');
+        if (existingSource) {
+            existingSource.setData(featureCollection);
+        } else {
+            map.addSource('sql-results', { type: 'geojson', data: featureCollection });
+            map.addLayer({
+                id: 'sql-results-fill',
+                type: 'fill',
+                source: 'sql-results',
+                filter: ['==', '$type', 'Polygon'],
+                paint: {
+                    'fill-color': '#006d77',
+                    'fill-opacity': 0.32,
+                    'fill-outline-color': '#003c43'
+                }
+            });
+            map.addLayer({
+                id: 'sql-results-line',
+                type: 'line',
+                source: 'sql-results',
+                filter: ['any', ['==', '$type', 'LineString'], ['==', '$type', 'Polygon']],
+                paint: {
+                    'line-color': '#003c43',
+                    'line-width': 1.5
+                }
+            });
+            map.addLayer({
+                id: 'sql-results-point',
+                type: 'circle',
+                source: 'sql-results',
+                filter: ['==', '$type', 'Point'],
+                paint: {
+                    'circle-radius': 6,
+                    'circle-color': '#006d77',
+                    'circle-stroke-color': '#ffffff',
+                    'circle-stroke-width': 2
+                }
+            });
+        }
+
+        try {
+            const bounds = new window.maplibregl.LngLatBounds();
+            featureCollection.features.forEach(function (feature) {
+                if (!feature.geometry) {
+                    return;
+                }
+                if (feature.geometry.type === 'Point') {
+                    bounds.extend(feature.geometry.coordinates);
+                } else if (Array.isArray(feature.geometry.coordinates)) {
+                    feature.geometry.coordinates.flat(Infinity).forEach(function (value, idx, arr) {
+                        if (idx % 2 === 1) {
+                            bounds.extend([arr[idx - 1], value]);
+                        }
+                    });
+                }
+            });
+            if (!bounds.isEmpty()) {
+                map.fitBounds(bounds, { padding: 32, maxZoom: 12, duration: 0 });
+            }
+        } catch (err) {
+            // bounds extension is best-effort; ignore malformed geometry rows
+        }
+    }
+
+    function disposeMap(elementId) {
+        const entry = state.maps.get(elementId);
+        if (!entry) {
+            return;
+        }
+        if (entry.mapInstance && typeof entry.mapInstance.remove === 'function') {
+            entry.mapInstance.remove();
+        }
+        state.maps.delete(elementId);
+    }
+
+    function downloadFile(filename, mimeType, content) {
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    function copyToClipboard(text) {
+        if (!navigator || !navigator.clipboard) {
+            return Promise.reject(new Error('clipboard unavailable'));
+        }
+        return navigator.clipboard.writeText(text);
+    }
+
+    window.spatialSql = {
+        initializeMap,
+        setMapFeatures,
+        disposeMap,
+        downloadFile,
+        copyToClipboard
+    };
+})();

--- a/src/Honua.Admin/wwwroot/js/spatial-sql-interop.js
+++ b/src/Honua.Admin/wwwroot/js/spatial-sql-interop.js
@@ -151,21 +151,61 @@
                 if (!feature.geometry) {
                     return;
                 }
-                if (feature.geometry.type === 'Point') {
-                    bounds.extend(feature.geometry.coordinates);
-                } else if (Array.isArray(feature.geometry.coordinates)) {
-                    feature.geometry.coordinates.flat(Infinity).forEach(function (value, idx, arr) {
-                        if (idx % 2 === 1) {
-                            bounds.extend([arr[idx - 1], value]);
-                        }
-                    });
-                }
+                extendBoundsFromGeometry(bounds, feature.geometry);
             });
             if (!bounds.isEmpty()) {
                 map.fitBounds(bounds, { padding: 32, maxZoom: 12, duration: 0 });
             }
         } catch (err) {
             // bounds extension is best-effort; ignore malformed geometry rows
+        }
+    }
+
+    // Walk a GeoJSON geometry by type, extending the bounds with each (lng, lat)
+    // pair. Type-aware so 3D coordinates ([lng, lat, elev]) keep elevation out of
+    // the bounding-box math instead of mis-pairing it as latitude.
+    function extendBoundsFromGeometry(bounds, geometry) {
+        if (!geometry || !geometry.coordinates) {
+            return;
+        }
+        const coords = geometry.coordinates;
+        switch (geometry.type) {
+            case 'Point':
+                extendPoint(bounds, coords);
+                break;
+            case 'MultiPoint':
+            case 'LineString':
+                coords.forEach(function (p) { extendPoint(bounds, p); });
+                break;
+            case 'MultiLineString':
+            case 'Polygon':
+                coords.forEach(function (ring) {
+                    ring.forEach(function (p) { extendPoint(bounds, p); });
+                });
+                break;
+            case 'MultiPolygon':
+                coords.forEach(function (polygon) {
+                    polygon.forEach(function (ring) {
+                        ring.forEach(function (p) { extendPoint(bounds, p); });
+                    });
+                });
+                break;
+            case 'GeometryCollection':
+                if (Array.isArray(geometry.geometries)) {
+                    geometry.geometries.forEach(function (g) {
+                        extendBoundsFromGeometry(bounds, g);
+                    });
+                }
+                break;
+            default:
+                // Unknown geometry type — skip rather than throwing.
+                break;
+        }
+    }
+
+    function extendPoint(bounds, point) {
+        if (Array.isArray(point) && typeof point[0] === 'number' && typeof point[1] === 'number') {
+            bounds.extend([point[0], point[1]]);
         }
     }
 

--- a/tests/Honua.Admin.Tests/ExplainPlanParserTests.cs
+++ b/tests/Honua.Admin.Tests/ExplainPlanParserTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Honua.Admin.Models.SpatialSql;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class ExplainPlanParserTests
+{
+    [Fact]
+    public void Parse_projects_postgres_explain_envelope_into_node_tree()
+    {
+        var json = """
+            [
+              {
+                "Plan": {
+                  "Node Type": "Aggregate",
+                  "Actual Rows": 1,
+                  "Plan Rows": 1,
+                  "Actual Total Time": 14.2,
+                  "Total Cost": 38.7,
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Relation Name": "parcels",
+                      "Actual Rows": 12000,
+                      "Plan Rows": 100,
+                      "Actual Total Time": 12.4,
+                      "Total Cost": 32.5
+                    }
+                  ]
+                },
+                "Planning Time": 0.4,
+                "Execution Time": 16.1
+              }
+            ]
+            """;
+
+        var plan = ExplainPlanParser.Parse(json);
+
+        Assert.False(plan.IsError);
+        Assert.Equal("Aggregate", plan.Root.NodeType);
+        Assert.Equal(16.1, plan.TotalElapsedMs, 1);
+        Assert.Equal(0.4, plan.PlanningMs, 1);
+
+        var child = Assert.Single(plan.Root.Children);
+        Assert.Equal("Seq Scan", child.NodeType);
+        Assert.Equal("parcels", child.Relation);
+        Assert.Equal(12000, child.ActualRows);
+        Assert.Equal(100, child.PlanRows);
+        Assert.True(child.RowEstimateOff);
+    }
+
+    [Fact]
+    public void Parse_handles_object_envelope_without_outer_array()
+    {
+        var json = """
+            {
+              "Plan": { "Node Type": "Result", "Actual Rows": 1, "Plan Rows": 1 },
+              "Execution Time": 0.3
+            }
+            """;
+
+        var plan = ExplainPlanParser.Parse(json);
+
+        Assert.Equal("Result", plan.Root.NodeType);
+        Assert.Empty(plan.Root.Children);
+    }
+
+    [Fact]
+    public void Parse_throws_when_envelope_is_missing_plan()
+    {
+        var json = """[ { "Planning Time": 1.0 } ]""";
+        Assert.Throws<System.InvalidOperationException>(() => ExplainPlanParser.Parse(json));
+    }
+
+    [Fact]
+    public void Row_estimate_off_marks_dramatic_misestimates_in_either_direction()
+    {
+        var underEstimate = new ExplainNode { NodeType = "Seq Scan", PlanRows = 10, ActualRows = 200 };
+        var overEstimate = new ExplainNode { NodeType = "Seq Scan", PlanRows = 200, ActualRows = 10 };
+        var close = new ExplainNode { NodeType = "Seq Scan", PlanRows = 100, ActualRows = 130 };
+
+        Assert.True(underEstimate.RowEstimateOff);
+        Assert.True(overEstimate.RowEstimateOff);
+        Assert.False(close.RowEstimateOff);
+    }
+
+    [Fact]
+    public void Parse_accepts_jsonelement_overload()
+    {
+        var json = """[ { "Plan": { "Node Type": "X", "Actual Rows": 0, "Plan Rows": 0 } } ]""";
+        using var doc = JsonDocument.Parse(json);
+        var plan = ExplainPlanParser.Parse(doc.RootElement);
+        Assert.Equal("X", plan.Root.NodeType);
+    }
+}

--- a/tests/Honua.Admin.Tests/MutationGuardTests.cs
+++ b/tests/Honua.Admin.Tests/MutationGuardTests.cs
@@ -40,4 +40,47 @@ public sealed class MutationGuardTests
     {
         Assert.False(MutationGuard.IsMutating("SELECT updates_count FROM stats"));
     }
+
+    [Theory]
+    [InlineData("SELECT $$DELETE FROM x$$ AS payload FROM parcels")]
+    [InlineData("SELECT $tag$DROP TABLE wells$tag$ AS payload")]
+    [InlineData("SELECT $body$ INSERT INTO logs VALUES (1) $body$ FROM parcels")]
+    [InlineData("SELECT $$ /* DELETE */ -- DROP\n DROP $$ FROM parcels")]
+    public void Mutation_keyword_inside_dollar_quoted_literal_is_not_flagged(string sql)
+    {
+        // PostgreSQL dollar-quoted strings: $$...$$ and $tag$...$tag$. Their bodies
+        // are arbitrary text and must be skipped before keyword scanning, otherwise
+        // a benign read-only SELECT carrying mutation keywords inside a literal
+        // would trigger the override dialog.
+        Assert.False(MutationGuard.IsMutating(sql));
+    }
+
+    [Theory]
+    [InlineData("DELETE FROM parcels WHERE name = $$bob$$")]
+    [InlineData("UPDATE parcels SET note = $note$some text$note$ WHERE id = 1")]
+    public void Mutating_sql_with_dollar_quoted_arguments_is_still_flagged(string sql)
+    {
+        // The dollar-quoted body is stripped, but the surrounding mutation verb
+        // remains and must still trip the guard.
+        Assert.True(MutationGuard.IsMutating(sql));
+    }
+
+    [Fact]
+    public void Positional_parameter_dollar_n_is_not_treated_as_dollar_quote_opener()
+    {
+        // $1, $2, … are PostgreSQL positional parameters, not dollar-quote openers
+        // (the tag rule forbids a leading digit). The guard must not over-consume
+        // and accidentally swallow a real DELETE/INSERT that follows.
+        Assert.True(MutationGuard.IsMutating("DELETE FROM parcels WHERE id = $1"));
+        Assert.False(MutationGuard.IsMutating("SELECT $1, $2 FROM parcels"));
+    }
+
+    [Fact]
+    public void Unterminated_dollar_quote_consumes_to_end_so_trailing_keywords_are_not_flagged()
+    {
+        // A buffer mid-edit may have an opener with no closer. Treating the
+        // unterminated body as quoted matches PostgreSQL's lex behavior and
+        // prevents a false positive while the operator is still typing.
+        Assert.False(MutationGuard.IsMutating("SELECT $$incomplete body DELETE FROM parcels"));
+    }
 }

--- a/tests/Honua.Admin.Tests/MutationGuardTests.cs
+++ b/tests/Honua.Admin.Tests/MutationGuardTests.cs
@@ -1,0 +1,43 @@
+using Honua.Admin.Models.SpatialSql;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class MutationGuardTests
+{
+    [Theory]
+    [InlineData("SELECT * FROM parcels")]
+    [InlineData("WITH t AS (SELECT 1) SELECT * FROM t")]
+    [InlineData("EXPLAIN ANALYZE SELECT * FROM wells")]
+    [InlineData("SELECT ST_Area(geom) FROM parcels WHERE county = 'Big Island'")]
+    [InlineData("SELECT 'INSERT INTO not really' AS note FROM parcels")]
+    [InlineData("-- DELETE FROM parcels\nSELECT 1")]
+    [InlineData("/* DROP TABLE parcels */ SELECT 1")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Read_only_or_empty_sql_is_not_flagged(string? sql)
+    {
+        Assert.False(MutationGuard.IsMutating(sql));
+    }
+
+    [Theory]
+    [InlineData("INSERT INTO parcels(id) VALUES('x')")]
+    [InlineData("UPDATE parcels SET county='X'")]
+    [InlineData("DELETE FROM parcels")]
+    [InlineData("DROP TABLE parcels")]
+    [InlineData("CREATE INDEX ON parcels(geom)")]
+    [InlineData("ALTER TABLE parcels ADD COLUMN foo text")]
+    [InlineData("TRUNCATE parcels")]
+    [InlineData("MERGE INTO parcels USING staging ON true")]
+    [InlineData("  insert into parcels values(1)  ")]
+    public void Mutating_sql_is_flagged_independent_of_case(string sql)
+    {
+        Assert.True(MutationGuard.IsMutating(sql));
+    }
+
+    [Fact]
+    public void Mutating_keyword_inside_an_identifier_is_not_flagged()
+    {
+        Assert.False(MutationGuard.IsMutating("SELECT updates_count FROM stats"));
+    }
+}

--- a/tests/Honua.Admin.Tests/MutationGuardTests.cs
+++ b/tests/Honua.Admin.Tests/MutationGuardTests.cs
@@ -83,4 +83,49 @@ public sealed class MutationGuardTests
         // prevents a false positive while the operator is still typing.
         Assert.False(MutationGuard.IsMutating("SELECT $$incomplete body DELETE FROM parcels"));
     }
+
+    [Theory]
+    [InlineData("SELECT * INTO new_table FROM parcels")]
+    [InlineData("SELECT id, geom INTO archived FROM parcels WHERE retired_at IS NOT NULL")]
+    [InlineData("SELECT * INTO TEMP scratch FROM parcels")]
+    [InlineData("SELECT * INTO TEMPORARY scratch FROM parcels")]
+    [InlineData("SELECT * INTO UNLOGGED bulk FROM parcels")]
+    [InlineData("SELECT * INTO TABLE archived FROM parcels")]
+    [InlineData("select * into new_table from parcels")]
+    public void Select_into_creates_a_table_and_must_be_flagged(string sql)
+    {
+        // EXPLAIN ANALYZE on SELECT ... INTO actually creates and fills the
+        // target table — it is a write under the EXPLAIN endpoint just like
+        // INSERT/UPDATE. The bare INTO keyword is sufficient because INSERT
+        // INTO and MERGE INTO are already flagged by their primary verbs.
+        // https://www.postgresql.org/docs/current/sql-selectinto.html
+        Assert.True(MutationGuard.IsMutating(sql));
+    }
+
+    [Theory]
+    [InlineData("EXECUTE my_prepared_statement")]
+    [InlineData("EXECUTE my_prepared_statement(1, 'foo')")]
+    [InlineData("execute my_prepared_statement")]
+    public void Execute_runs_an_opaque_prepared_statement_and_must_be_flagged(string sql)
+    {
+        // EXECUTE invokes a previously prepared statement whose body the
+        // client cannot inspect; under EXPLAIN ANALYZE it actually runs
+        // the prepared statement, so the conservative guard rejects all
+        // EXECUTE forms. https://www.postgresql.org/docs/current/sql-execute.html
+        Assert.True(MutationGuard.IsMutating(sql));
+    }
+
+    [Theory]
+    [InlineData("SELECT 'INTO' AS note FROM parcels")]
+    [InlineData("SELECT 'going INTO production' AS note FROM logs")]
+    [InlineData("SELECT into_col FROM stats")]
+    [InlineData("SELECT executions FROM stats")]
+    [InlineData("SELECT col_into_x FROM stats")]
+    public void Into_or_execute_inside_literal_or_identifier_is_not_flagged(string sql)
+    {
+        // String literals are stripped before keyword scanning; identifier
+        // word-boundary rules prevent `into_col`, `col_into_x`, and
+        // `executions` from matching the new INTO/EXECUTE keywords.
+        Assert.False(MutationGuard.IsMutating(sql));
+    }
 }

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+/// <summary>
+/// Light text-based assertions on NavMenu.razor — confirms the spatial SQL entry
+/// lives in the same shared shell as the spec workspace, satisfying the contract
+/// constraint that the page registers in the spec-editor shell rather than a
+/// parallel layout.
+/// </summary>
+public sealed class NavMenuTests
+{
+    private const string NavMenuPath = "../../../../../src/Honua.Admin/Shared/NavMenu.razor";
+
+    [Fact]
+    public void NavMenu_registers_spatial_sql_entry_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/sql", contents, System.StringComparison.Ordinal);
+        Assert.Contains("Spatial SQL", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NavMenu_uses_a_single_MudNavMenu_so_sql_page_lives_in_the_shared_shell()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        // The contract requires the page to live in the shared spec-editor shell,
+        // not a parallel layout — this asserts there's only one MudNavMenu in the
+        // shared NavMenu, with both spec workspace and spatial SQL inside it.
+        var open = System.Text.RegularExpressions.Regex.Matches(contents, "<MudNavMenu").Count;
+        Assert.Equal(1, open);
+
+        var operatorSpec = contents.IndexOf("/operator/spec", System.StringComparison.Ordinal);
+        var operatorSql = contents.IndexOf("/operator/sql", System.StringComparison.Ordinal);
+        var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
+
+        Assert.True(operatorSpec > 0);
+        Assert.True(operatorSql > 0);
+        Assert.True(operatorSql < menuClose);
+    }
+}

--- a/tests/Honua.Admin.Tests/SpatialSqlEndToEndFlowTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlEndToEndFlowTests.cs
@@ -1,0 +1,59 @@
+using Honua.Admin.Models.SpatialSql;
+using Honua.Admin.Services.SpatialSql;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+/// <summary>
+/// Stand-in for the bUnit-style end-to-end exercising the headline flow on the
+/// playground page: load schema → run a geometry query → assert table + map are
+/// renderable → save as named view → assert protocol URLs come back. Drives the
+/// state store directly so the test stays AOT/trim-friendly without taking on a
+/// bUnit dependency that admin does not yet ship.
+/// </summary>
+public sealed class SpatialSqlEndToEndFlowTests
+{
+    [Fact]
+    public async Task Query_preview_save_view_round_trip_through_state_and_stub_client()
+    {
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new NullSpatialSqlTelemetry());
+
+        await state.LoadSchemaAsync();
+        Assert.NotNull(state.Schema);
+
+        state.SetSql("SELECT id, county, geom FROM parcels");
+        await state.RunQueryAsync();
+
+        var result = state.LastResult;
+        Assert.NotNull(result);
+        Assert.False(result!.IsError);
+        Assert.True(result.HasGeometry);
+        Assert.Equal("map", state.ResultsTab);
+        Assert.NotEmpty(state.BuildMapFeatures());
+
+        await state.RunExplainAsync();
+        Assert.NotNull(state.LastPlan);
+
+        var registration = await state.SaveViewAsync("active_parcels_e2e", "demo flow", default);
+
+        Assert.False(registration.IsError);
+        Assert.False(string.IsNullOrEmpty(registration.FeatureServerUrl));
+        Assert.False(string.IsNullOrEmpty(registration.OgcFeaturesUrl));
+        Assert.False(string.IsNullOrEmpty(registration.ODataUrl));
+    }
+
+    [Fact]
+    public void Page_is_routable_at_operator_sql()
+    {
+        var pageType = typeof(Honua.Admin.Pages.Operator.SpatialSqlPlayground);
+        var routes = (RouteAttribute[])pageType.GetCustomAttributes(typeof(RouteAttribute), inherit: false);
+        Assert.Contains(routes, r => r.Template == "/operator/sql");
+    }
+
+    private sealed class NullSpatialSqlTelemetry : ISpatialSqlTelemetry
+    {
+        public void Record(string eventName, System.Collections.Generic.IReadOnlyDictionary<string, object?>? properties = null) { }
+        public void RecordLatency(string eventName, long elapsedMillis, System.Collections.Generic.IReadOnlyDictionary<string, object?>? properties = null) { }
+    }
+}

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -364,6 +364,95 @@ public sealed class SpatialSqlPlaygroundStateTests
     }
 
     [Fact]
+    public async Task RunExplainAsync_rejected_sql_clears_previous_plan()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+
+        state.SetSql("SELECT count(*) FROM wells");
+        await state.RunExplainAsync();
+        Assert.NotNull(state.LastPlan);
+
+        state.SetSql("DELETE FROM parcels");
+        await state.RunExplainAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.Null(state.LastPlan);
+        Assert.NotNull(state.LastError);
+        Assert.Contains(telemetry.Events, e => e.Event == "explain_rejected" &&
+            e.Properties is not null &&
+            e.Properties.TryGetValue("reason", out var r) &&
+            string.Equals(r as string, "mutation_blocked", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunExplainAsync_transport_error_clears_previous_plan()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new SecondExplainThrowsClient(), telemetry);
+
+        state.SetSql("SELECT count(*) FROM wells");
+        await state.RunExplainAsync();
+        Assert.NotNull(state.LastPlan);
+
+        state.SetSql("SELECT * FROM parcels");
+        await state.RunExplainAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.Null(state.LastPlan);
+        Assert.Contains("simulated explain failure", state.LastError, System.StringComparison.Ordinal);
+        Assert.Contains(telemetry.Events, e => e.Event == "explain_rejected" &&
+            e.Properties is not null &&
+            e.Properties.TryGetValue("reason", out var r) &&
+            string.Equals(r as string, "transport_error", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunExplainAsync_empty_sql_clears_previous_plan()
+    {
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new RecordingTelemetry());
+
+        state.SetSql("SELECT count(*) FROM wells");
+        await state.RunExplainAsync();
+        Assert.NotNull(state.LastPlan);
+
+        state.SetSql(string.Empty);
+        await state.RunExplainAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.Null(state.LastPlan);
+        Assert.Null(state.LastError);
+    }
+
+    [Fact]
+    public async Task RunExplainAsync_superseded_completion_does_not_overwrite_active_plan()
+    {
+        // Same ownership contract as RunQueryAsync: a slow EXPLAIN can be
+        // superseded by a later one, and its late completion must not replace the
+        // active plan pane.
+        var slowGate = new TaskCompletionSource<ExplainPlan>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new GatedExplainClient(firstAttempt: () => slowGate.Task, fallback: Plan("Fast Plan"));
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(client, telemetry);
+
+        state.SetSql("SELECT * FROM slow");
+        var slowTask = state.RunExplainAsync();
+
+        state.SetSql("SELECT * FROM fast");
+        await state.RunExplainAsync();
+
+        Assert.Equal("Fast Plan", state.LastPlan!.Root.NodeType);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+
+        slowGate.SetResult(Plan("Slow Plan"));
+        await slowTask;
+
+        Assert.Equal("Fast Plan", state.LastPlan!.Root.NodeType);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.Single(telemetry.Events, e => e.Event == "explain_completed");
+    }
+
+    [Fact]
     public async Task SaveViewAsync_uses_LastResultSql_not_the_live_editor_buffer()
     {
         var capture = new RequestCapturingClient();
@@ -383,6 +472,12 @@ public sealed class SpatialSqlPlaygroundStateTests
         Assert.Equal(executedSql, capture.LastSaveRequest!.Sql);
         Assert.Equal("geom", capture.LastSaveRequest.GeometryColumn);
     }
+
+    private static ExplainPlan Plan(string rootNodeType) => new()
+    {
+        Root = new ExplainNode { NodeType = rootNodeType },
+        TotalElapsedMs = 1
+    };
 
     private sealed class NonWgs84Client : ISpatialSqlClient
     {
@@ -413,6 +508,29 @@ public sealed class SpatialSqlPlaygroundStateTests
 
         public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
             _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
+    }
+
+    private sealed class SecondExplainThrowsClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+        private int _calls;
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            _inner.ExecuteAsync(request, cancellationToken);
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken)
+        {
+            var index = System.Threading.Interlocked.Increment(ref _calls);
+            return index == 1
+                ? _inner.ExplainAsync(request, cancellationToken)
+                : Task.FromException<ExplainPlan>(new System.InvalidOperationException("simulated explain failure"));
+        }
 
         public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
             _inner.SaveViewAsync(request, cancellationToken);
@@ -508,6 +626,35 @@ public sealed class SpatialSqlPlaygroundStateTests
 
         public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
             _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
+    }
+
+    private sealed class GatedExplainClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+        private readonly System.Func<Task<ExplainPlan>> _firstAttempt;
+        private readonly ExplainPlan _fallback;
+        private int _calls;
+
+        public GatedExplainClient(System.Func<Task<ExplainPlan>> firstAttempt, ExplainPlan fallback)
+        {
+            _firstAttempt = firstAttempt;
+            _fallback = fallback;
+        }
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            _inner.ExecuteAsync(request, cancellationToken);
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken)
+        {
+            var index = System.Threading.Interlocked.Increment(ref _calls);
+            return index == 1 ? _firstAttempt() : Task.FromResult(_fallback);
+        }
 
         public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
             _inner.SaveViewAsync(request, cancellationToken);

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -234,6 +234,92 @@ public sealed class SpatialSqlPlaygroundStateTests
         Assert.Equal(SpatialSqlPaneStatus.Idle, observed[^1]);
     }
 
+    [Fact]
+    public async Task RunQueryAsync_superseded_completion_does_not_overwrite_active_query_state()
+    {
+        // A slow query starts, a fast query supersedes it. When the slow query's
+        // await finally resolves it must NOT write LastResult/Status/telemetry —
+        // otherwise it races with the active query's terminal state and undoes it.
+        var slowGate = new TaskCompletionSource<SqlExecuteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fastResult = new SqlExecuteResult
+        {
+            Columns = new[] { new SqlColumn("payload", "text") },
+            Rows = new[] { new SqlRow(new string?[] { "fast-result" }) }
+        };
+        var client = new GatedExecuteClient(firstAttempt: () => slowGate.Task, fallback: fastResult);
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(client, telemetry);
+
+        state.SetSql("SELECT * FROM slow");
+        var slowTask = state.RunQueryAsync();
+
+        // Now run a second query; it cancels the slow one's cts and, since the
+        // gated client's first attempt is already pending, this call hits the
+        // fallback path and completes synchronously.
+        state.SetSql("SELECT * FROM fast");
+        await state.RunQueryAsync();
+
+        // Active state must reflect the fast query.
+        Assert.Equal("fast-result", state.LastResult!.Rows[0].Cells[0]);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+
+        // Now release the superseded slow query — its post-await writes must be
+        // discarded by the IsActiveExecution gate.
+        slowGate.SetResult(new SqlExecuteResult
+        {
+            Columns = new[] { new SqlColumn("payload", "text") },
+            Rows = new[] { new SqlRow(new string?[] { "slow-result" }) }
+        });
+        await slowTask;
+
+        Assert.Equal("fast-result", state.LastResult!.Rows[0].Cells[0]);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        // Only one query_completed should have fired — the superseded one is silent.
+        Assert.Single(telemetry.Events, e => e.Event == "query_completed");
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_pairs_LastResult_with_the_SQL_that_produced_it()
+    {
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new RecordingTelemetry());
+        await state.LoadSchemaAsync();
+
+        const string executedSql = "SELECT id, county, geom FROM parcels";
+        state.SetSql(executedSql);
+        await state.RunQueryAsync();
+
+        Assert.Equal(executedSql, state.LastResultSql);
+        Assert.True(state.CanSaveCurrentResult());
+
+        // Edit the editor buffer; CanSaveCurrentResult must drop until the operator
+        // re-runs the query. Otherwise Save would register the edited SQL with the
+        // executed result's geometry metadata.
+        state.SetSql(executedSql + "  -- adding a comment");
+        Assert.False(state.CanSaveCurrentResult());
+        Assert.Equal(executedSql, state.LastResultSql);
+    }
+
+    [Fact]
+    public async Task SaveViewAsync_uses_LastResultSql_not_the_live_editor_buffer()
+    {
+        var capture = new RequestCapturingClient();
+        var state = new SpatialSqlPlaygroundState(capture, new RecordingTelemetry());
+        await state.LoadSchemaAsync();
+
+        const string executedSql = "SELECT id, county, geom FROM parcels";
+        state.SetSql(executedSql);
+        await state.RunQueryAsync();
+
+        // Operator drifts the buffer before opening the dialog.
+        state.SetSql("SELECT id FROM parcels WHERE county='OOPS'");
+
+        await state.SaveViewAsync("active_parcels_drifted", "still ok", default);
+
+        Assert.NotNull(capture.LastSaveRequest);
+        Assert.Equal(executedSql, capture.LastSaveRequest!.Sql);
+        Assert.Equal("geom", capture.LastSaveRequest.GeometryColumn);
+    }
+
     private sealed class NonWgs84Client : ISpatialSqlClient
     {
         private readonly StubSpatialSqlClient _inner = new();
@@ -298,6 +384,56 @@ public sealed class SpatialSqlPlaygroundStateTests
 
         public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
             throw new System.NotSupportedException();
+    }
+
+    private sealed class GatedExecuteClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+        private readonly System.Func<Task<SqlExecuteResult>> _firstAttempt;
+        private readonly SqlExecuteResult _fallback;
+        private int _calls;
+
+        public GatedExecuteClient(System.Func<Task<SqlExecuteResult>> firstAttempt, SqlExecuteResult fallback)
+        {
+            _firstAttempt = firstAttempt;
+            _fallback = fallback;
+        }
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken)
+        {
+            var index = System.Threading.Interlocked.Increment(ref _calls);
+            return index == 1 ? _firstAttempt() : Task.FromResult(_fallback);
+        }
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
+    }
+
+    private sealed class RequestCapturingClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+        public SaveViewRequest? LastSaveRequest { get; private set; }
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            _inner.ExecuteAsync(request, cancellationToken);
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken)
+        {
+            LastSaveRequest = request;
+            return _inner.SaveViewAsync(request, cancellationToken);
+        }
     }
 
     private sealed class CappingClient : ISpatialSqlClient

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -300,6 +300,70 @@ public sealed class SpatialSqlPlaygroundStateTests
     }
 
     [Fact]
+    public async Task RunQueryAsync_clears_mutation_override_when_execute_throws()
+    {
+        // Without consuming the override at snapshot, a transport failure leaves
+        // MutationOverrideArmed=true; the next click of Run silently resubmits
+        // with allowMutation=true. Pin the consumption-on-failure contract.
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new ThrowingExecuteClient(), telemetry);
+
+        state.SetSql("DELETE FROM parcels");
+        state.ArmMutationOverride();
+        Assert.True(state.MutationOverrideArmed);
+
+        await state.RunQueryAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.False(state.MutationOverrideArmed);
+        Assert.Contains(telemetry.Events, e => e.Event == "query_rejected" &&
+            e.Properties is not null &&
+            e.Properties.TryGetValue("reason", out var r) &&
+            string.Equals(r as string, "transport_error", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_clears_mutation_override_when_execute_is_cancelled()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new CancellingExecuteClient(), telemetry);
+
+        state.SetSql("DELETE FROM parcels");
+        state.ArmMutationOverride();
+
+        await state.RunQueryAsync();
+
+        // OCE path lands in Idle (not Error), but the override must still be
+        // consumed — otherwise a cancelled mutation re-arms invisibly.
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.False(state.MutationOverrideArmed);
+    }
+
+    [Fact]
+    public async Task RunExplainAsync_rejects_mutating_sql_with_mutation_blocked_reason()
+    {
+        // EXPLAIN ANALYZE actually runs the statement; the server's EXPLAIN
+        // endpoint has no AllowMutation contract or audit hook, so mutating SQL
+        // must be rejected outright on the EXPLAIN path even when the operator
+        // armed the per-query Run override.
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+
+        state.SetSql("DELETE FROM parcels");
+        state.ArmMutationOverride();
+        await state.RunExplainAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.NotNull(state.LastError);
+        Assert.Null(state.LastPlan);
+        Assert.Contains(telemetry.Events, e => e.Event == "explain_rejected" &&
+            e.Properties is not null &&
+            e.Properties.TryGetValue("reason", out var r) &&
+            string.Equals(r as string, "mutation_blocked", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(telemetry.Events, e => e.Event == "explain_completed");
+    }
+
+    [Fact]
     public async Task SaveViewAsync_uses_LastResultSql_not_the_live_editor_buffer()
     {
         var capture = new RequestCapturingClient();
@@ -384,6 +448,40 @@ public sealed class SpatialSqlPlaygroundStateTests
 
         public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
             throw new System.NotSupportedException();
+    }
+
+    private sealed class ThrowingExecuteClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            Task.FromException<SqlExecuteResult>(new System.InvalidOperationException("simulated transport failure"));
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
+    }
+
+    private sealed class CancellingExecuteClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            Task.FromException<SqlExecuteResult>(new OperationCanceledException());
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
     }
 
     private sealed class GatedExecuteClient : ISpatialSqlClient

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -122,6 +122,10 @@ public sealed class SpatialSqlPlaygroundStateTests
         Assert.NotNull(registration.OgcFeaturesUrl);
         Assert.NotNull(registration.ODataUrl);
         Assert.Contains(telemetry.Events, e => e.Event == "view_saved");
+        // LastSavedView is the surface the dialog uses to render the URL chips
+        // and copy buttons; the dialog now stays open on success and reads from
+        // this property rather than auto-closing and dropping the URLs.
+        Assert.Same(registration, state.LastSavedView);
     }
 
     [Fact]
@@ -136,6 +140,19 @@ public sealed class SpatialSqlPlaygroundStateTests
         var csv = state.ExportCsv();
         Assert.Contains("id,county", csv, System.StringComparison.Ordinal);
         Assert.Contains(telemetry.Events, e => e.Event == "export_triggered");
+    }
+
+    [Fact]
+    public void SetExportError_surfaces_message_and_emits_export_rejected_event()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+
+        state.SetExportError("GeoJSON export requires WGS84 (SRID 4326); got SRID 3857.");
+
+        Assert.NotNull(state.LastError);
+        Assert.Contains("WGS84", state.LastError!, System.StringComparison.Ordinal);
+        Assert.Contains(telemetry.Events, e => e.Event == "export_rejected");
     }
 
     private sealed class CappingClient : ISpatialSqlClient

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -122,9 +122,10 @@ public sealed class SpatialSqlPlaygroundStateTests
         Assert.NotNull(registration.OgcFeaturesUrl);
         Assert.NotNull(registration.ODataUrl);
         Assert.Contains(telemetry.Events, e => e.Event == "view_saved");
-        // LastSavedView is the surface the dialog uses to render the URL chips
-        // and copy buttons; the dialog now stays open on success and reads from
-        // this property rather than auto-closing and dropping the URLs.
+        // LastSavedView mirrors the registration on the state store so external
+        // observers (tests, future surfaces such as a saved-views list) can recover
+        // the URLs after the dialog closes. The dialog itself renders from its own
+        // local `Registration` field captured from SaveViewAsync's return value.
         Assert.Same(registration, state.LastSavedView);
     }
 
@@ -147,12 +148,156 @@ public sealed class SpatialSqlPlaygroundStateTests
     {
         var telemetry = new RecordingTelemetry();
         var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+        // Status is intentionally preserved: the underlying query result is still
+        // valid — only the export action failed — so the chip stays at its prior
+        // value while the banner communicates the rejection.
+        var preStatus = state.Status;
 
         state.SetExportError("GeoJSON export requires WGS84 (SRID 4326); got SRID 3857.");
 
         Assert.NotNull(state.LastError);
         Assert.Contains("WGS84", state.LastError!, System.StringComparison.Ordinal);
         Assert.Contains(telemetry.Events, e => e.Event == "export_rejected");
+        Assert.Equal(preStatus, state.Status);
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_with_non_wgs84_geometry_blocks_map_preview_and_keeps_table_tab()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new NonWgs84Client(), telemetry);
+        await state.LoadSchemaAsync();
+
+        state.SetSql("SELECT id, geom FROM mercator");
+        await state.RunQueryAsync();
+
+        Assert.True(state.LastResult!.HasGeometry);
+        Assert.Equal(3857, state.LastResult.GeometrySrid);
+        // Auto-tab-switch must NOT promote the operator into a map view that would
+        // mis-render — keep them on the table with the blocked-reason banner.
+        Assert.Equal("table", state.ResultsTab);
+        Assert.NotNull(state.MapPreviewBlockedReason);
+        Assert.Contains("WGS84", state.MapPreviewBlockedReason!, System.StringComparison.Ordinal);
+        Assert.Contains("3857", state.MapPreviewBlockedReason!, System.StringComparison.Ordinal);
+        // BuildMapFeatures mirrors the SqlResultExporter guard: refuse to hand
+        // non-WGS84 coordinates to MapLibre even if the caller forces the tab.
+        Assert.Empty(state.BuildMapFeatures());
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_with_wgs84_geometry_leaves_blocked_reason_null()
+    {
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new RecordingTelemetry());
+        await state.LoadSchemaAsync();
+        state.SetSql("SELECT id, county, geom FROM parcels");
+        await state.RunQueryAsync();
+
+        Assert.True(state.LastResult!.HasGeometry);
+        Assert.Null(state.MapPreviewBlockedReason);
+        Assert.Equal("map", state.ResultsTab);
+    }
+
+    [Fact]
+    public async Task SaveViewAsync_routes_OperationCanceledException_through_idle_terminal_state()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new CancellingSaveClient(), telemetry);
+        var observed = new List<SpatialSqlPaneStatus>();
+        state.OnChanged += () => observed.Add(state.Status);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => state.SaveViewAsync("v", "d", default));
+
+        // Cancellation lands in Idle (matches LoadSchema/RunQuery/RunExplain), and
+        // is NOT misclassified as a transport_error in telemetry.
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.Null(state.LastError);
+        Assert.DoesNotContain(telemetry.Events, e => e.Event == "view_save_rejected");
+        // Subscribers must observe both the Saving and Idle transitions so any
+        // 'Saving…' spinner can clear.
+        Assert.Contains(SpatialSqlPaneStatus.Saving, observed);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, observed[^1]);
+    }
+
+    [Fact]
+    public async Task LoadSchemaAsync_notifies_subscribers_before_re_throwing_cancellation()
+    {
+        var state = new SpatialSqlPlaygroundState(new CancellingSchemaClient(), new RecordingTelemetry());
+        var observed = new List<SpatialSqlPaneStatus>();
+        state.OnChanged += () => observed.Add(state.Status);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => state.LoadSchemaAsync());
+
+        // The trailing Notify() is bypassed by the re-throw, so the OCE catch must
+        // notify before propagating — otherwise subscribers get stuck on Loading.
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.Contains(SpatialSqlPaneStatus.Loading, observed);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, observed[^1]);
+    }
+
+    private sealed class NonWgs84Client : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            Task.FromResult(new SqlExecuteResult
+            {
+                Columns = new[]
+                {
+                    new SqlColumn("id", "uuid"),
+                    new SqlColumn("geom", "geometry", IsGeometry: true)
+                },
+                Rows = new[]
+                {
+                    new SqlRow(new string?[]
+                    {
+                        "1",
+                        "{\"type\":\"Point\",\"coordinates\":[1000000,2000000]}"
+                    })
+                },
+                GeometryColumnIndex = 1,
+                GeometrySrid = 3857
+            });
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
+    }
+
+    private sealed class CancellingSaveClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            _inner.ExecuteAsync(request, cancellationToken);
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            Task.FromException<NamedViewRegistration>(new OperationCanceledException());
+    }
+
+    private sealed class CancellingSchemaClient : ISpatialSqlClient
+    {
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            Task.FromException<SchemaSnapshot>(new OperationCanceledException());
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            throw new System.NotSupportedException();
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            throw new System.NotSupportedException();
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            throw new System.NotSupportedException();
     }
 
     private sealed class CappingClient : ISpatialSqlClient

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -279,6 +279,67 @@ public sealed class SpatialSqlPlaygroundStateTests
     }
 
     [Fact]
+    public async Task RunQueryAsync_empty_sql_supersedes_active_execution()
+    {
+        var slowGate = new TaskCompletionSource<SqlExecuteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new GatedExecuteClient(firstAttempt: () => slowGate.Task, fallback: new SqlExecuteResult());
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(client, telemetry);
+
+        state.SetSql("SELECT * FROM slow");
+        var slowTask = state.RunQueryAsync();
+
+        state.SetSql("   ");
+        await state.RunQueryAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.Equal("Enter a SQL statement to run.", state.LastError);
+        Assert.Null(state.LastResult);
+
+        slowGate.SetResult(new SqlExecuteResult
+        {
+            Columns = new[] { new SqlColumn("payload", "text") },
+            Rows = new[] { new SqlRow(new string?[] { "slow-result" }) }
+        });
+        await slowTask;
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.Equal("Enter a SQL statement to run.", state.LastError);
+        Assert.Null(state.LastResult);
+        Assert.DoesNotContain(telemetry.Events, e => e.Event == "query_completed");
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_mutation_rejection_supersedes_active_execution()
+    {
+        var slowGate = new TaskCompletionSource<SqlExecuteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new GatedExecuteClient(firstAttempt: () => slowGate.Task, fallback: new SqlExecuteResult());
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(client, telemetry);
+
+        state.SetSql("SELECT * FROM slow");
+        var slowTask = state.RunQueryAsync();
+
+        state.SetSql("DELETE FROM parcels");
+        await state.RunQueryAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.Equal("mutation_blocked", state.LastResult!.Error!.Code);
+
+        slowGate.SetResult(new SqlExecuteResult
+        {
+            Columns = new[] { new SqlColumn("payload", "text") },
+            Rows = new[] { new SqlRow(new string?[] { "slow-result" }) }
+        });
+        await slowTask;
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.Equal("mutation_blocked", state.LastResult!.Error!.Code);
+        Assert.Equal("DELETE FROM parcels", state.LastResultSql);
+        Assert.DoesNotContain(telemetry.Events, e => e.Event == "query_completed");
+    }
+
+    [Fact]
     public async Task RunQueryAsync_pairs_LastResult_with_the_SQL_that_produced_it()
     {
         var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new RecordingTelemetry());

--- a/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpatialSqlPlaygroundStateTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using Honua.Admin.Models.SpatialSql;
+using Honua.Admin.Services.SpatialSql;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class SpatialSqlPlaygroundStateTests
+{
+    [Fact]
+    public async Task LoadSchemaAsync_populates_schema_and_records_telemetry_event()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+
+        await state.LoadSchemaAsync();
+
+        Assert.NotNull(state.Schema);
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.Contains(telemetry.Events, e => e.Event == "schema_loaded");
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_blocks_mutation_until_override_is_armed()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+        await state.LoadSchemaAsync();
+
+        state.SetSql("DELETE FROM parcels");
+        await state.RunQueryAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+        Assert.NotNull(state.LastResult?.Error);
+        Assert.Equal("mutation_blocked", state.LastResult!.Error!.Code);
+        Assert.Contains(telemetry.Events, e => e.Event == "query_rejected");
+
+        state.ArmMutationOverride();
+        await state.RunQueryAsync();
+
+        Assert.Equal(SpatialSqlPaneStatus.Idle, state.Status);
+        Assert.NotNull(state.LastResult?.AuditEntryId);
+        Assert.Contains(telemetry.Events, e => e.Event == "mutation_override_accepted");
+
+        // Override is single-shot — sending the same SQL again must require a fresh confirmation.
+        await state.RunQueryAsync();
+        Assert.Equal(SpatialSqlPaneStatus.Error, state.Status);
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_with_geometry_result_switches_to_map_tab_and_builds_features()
+    {
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new RecordingTelemetry());
+        await state.LoadSchemaAsync();
+
+        state.SetSql("SELECT id, county, geom FROM parcels");
+        await state.RunQueryAsync();
+
+        Assert.False(state.LastResult?.IsError);
+        Assert.True(state.LastResult!.HasGeometry);
+        Assert.Equal("map", state.ResultsTab);
+        var features = state.BuildMapFeatures();
+        Assert.Equal(2, features.Count);
+        Assert.All(features, f => Assert.Contains("\"type\"", f.GeoJson, System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunQueryAsync_truncated_result_blocks_export_until_confirmed()
+    {
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), new RecordingTelemetry());
+        await state.LoadSchemaAsync();
+        state.SetSql("SELECT * FROM parcels");
+        // Force a truncated result by running with row limit 1 via direct request.
+        var truncated = await new StubSpatialSqlClient().ExecuteAsync(new SqlExecuteRequest
+        {
+            Sql = "SELECT * FROM parcels",
+            RowLimit = 1
+        }, default);
+        Assert.True(truncated.Truncated);
+        // Replay the truncated result through the state via the standard path: re-run the query
+        // and override row limit through a fresh client wired into state.
+        var capStub = new CappingClient(rowLimit: 1);
+        var cappedState = new SpatialSqlPlaygroundState(capStub, new RecordingTelemetry());
+        await cappedState.LoadSchemaAsync();
+        cappedState.SetSql("SELECT * FROM parcels");
+        await cappedState.RunQueryAsync();
+
+        Assert.True(cappedState.LastResult!.Truncated);
+        Assert.False(cappedState.CanExportRows());
+
+        cappedState.ConfirmTruncatedExport();
+        Assert.True(cappedState.CanExportRows());
+    }
+
+    [Fact]
+    public async Task RunExplainAsync_populates_LastPlan_and_records_completion_telemetry()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+
+        state.SetSql("SELECT count(*) FROM wells");
+        await state.RunExplainAsync();
+
+        Assert.NotNull(state.LastPlan);
+        Assert.Equal("Aggregate", state.LastPlan!.Root.NodeType);
+        Assert.Contains(telemetry.Events, e => e.Event == "explain_completed");
+    }
+
+    [Fact]
+    public async Task SaveViewAsync_records_view_saved_and_returns_protocol_urls()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+        await state.LoadSchemaAsync();
+        state.SetSql("SELECT id, county, geom FROM parcels");
+        await state.RunQueryAsync();
+
+        var registration = await state.SaveViewAsync("active_parcels", "polygons in active counties", default);
+
+        Assert.False(registration.IsError);
+        Assert.NotNull(registration.FeatureServerUrl);
+        Assert.NotNull(registration.OgcFeaturesUrl);
+        Assert.NotNull(registration.ODataUrl);
+        Assert.Contains(telemetry.Events, e => e.Event == "view_saved");
+    }
+
+    [Fact]
+    public async Task ExportCsv_records_export_triggered_event()
+    {
+        var telemetry = new RecordingTelemetry();
+        var state = new SpatialSqlPlaygroundState(new StubSpatialSqlClient(), telemetry);
+        await state.LoadSchemaAsync();
+        state.SetSql("SELECT id, county FROM parcels");
+        await state.RunQueryAsync();
+
+        var csv = state.ExportCsv();
+        Assert.Contains("id,county", csv, System.StringComparison.Ordinal);
+        Assert.Contains(telemetry.Events, e => e.Event == "export_triggered");
+    }
+
+    private sealed class CappingClient : ISpatialSqlClient
+    {
+        private readonly StubSpatialSqlClient _inner = new();
+        private readonly int _rowLimit;
+
+        public CappingClient(int rowLimit) => _rowLimit = rowLimit;
+
+        public Task<SchemaSnapshot> GetSchemaAsync(CancellationToken cancellationToken) =>
+            _inner.GetSchemaAsync(cancellationToken);
+
+        public Task<SqlExecuteResult> ExecuteAsync(SqlExecuteRequest request, CancellationToken cancellationToken) =>
+            _inner.ExecuteAsync(request with { RowLimit = _rowLimit }, cancellationToken);
+
+        public Task<ExplainPlan> ExplainAsync(SqlExplainRequest request, CancellationToken cancellationToken) =>
+            _inner.ExplainAsync(request, cancellationToken);
+
+        public Task<NamedViewRegistration> SaveViewAsync(SaveViewRequest request, CancellationToken cancellationToken) =>
+            _inner.SaveViewAsync(request, cancellationToken);
+    }
+
+    private sealed class RecordingTelemetry : ISpatialSqlTelemetry
+    {
+        public List<(string Event, IReadOnlyDictionary<string, object?>? Properties, long? ElapsedMs)> Events { get; } = new();
+
+        public void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null) =>
+            Events.Add((eventName, properties, null));
+
+        public void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null) =>
+            Events.Add((eventName, properties, elapsedMillis));
+    }
+}

--- a/tests/Honua.Admin.Tests/SqlResultExporterTests.cs
+++ b/tests/Honua.Admin.Tests/SqlResultExporterTests.cs
@@ -34,7 +34,7 @@ public sealed class SqlResultExporterTests
     }
 
     [Fact]
-    public void ToGeoJson_emits_feature_collection_with_properties_excluding_geometry()
+    public void ToGeoJson_emits_rfc7946_feature_collection_without_legacy_crs_member()
     {
         var result = new SqlExecuteResult
         {
@@ -67,7 +67,36 @@ public sealed class SqlResultExporterTests
         var properties = feature.GetProperty("properties");
         Assert.Equal("Big Island", properties.GetProperty("county").GetString());
         Assert.False(properties.TryGetProperty("geom", out _));
-        Assert.Equal("EPSG:4326", root.GetProperty("crs").GetProperty("properties").GetProperty("name").GetString());
+        // RFC 7946 §4 removed the crs member — coordinates must be WGS84 implicitly.
+        Assert.False(root.TryGetProperty("crs", out _));
+    }
+
+    [Fact]
+    public void ToGeoJson_emits_feature_collection_when_geometry_srid_is_unspecified()
+    {
+        var result = new SqlExecuteResult
+        {
+            Columns = new[]
+            {
+                new SqlColumn("id", "uuid"),
+                new SqlColumn("geom", "geometry", IsGeometry: true)
+            },
+            Rows = new[]
+            {
+                new SqlRow(new string?[]
+                {
+                    "1",
+                    "{\"type\":\"Point\",\"coordinates\":[0,0]}"
+                })
+            },
+            GeometryColumnIndex = 1
+        };
+
+        var json = SqlResultExporter.ToGeoJson(result);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("FeatureCollection", doc.RootElement.GetProperty("type").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("crs", out _));
     }
 
     [Fact]
@@ -80,5 +109,32 @@ public sealed class SqlResultExporterTests
         };
 
         Assert.Throws<System.InvalidOperationException>(() => SqlResultExporter.ToGeoJson(result));
+    }
+
+    [Fact]
+    public void ToGeoJson_throws_when_geometry_srid_is_not_wgs84()
+    {
+        var result = new SqlExecuteResult
+        {
+            Columns = new[]
+            {
+                new SqlColumn("id", "uuid"),
+                new SqlColumn("geom", "geometry", IsGeometry: true)
+            },
+            Rows = new[]
+            {
+                new SqlRow(new string?[]
+                {
+                    "1",
+                    "{\"type\":\"Point\",\"coordinates\":[1000000,2000000]}"
+                })
+            },
+            GeometryColumnIndex = 1,
+            GeometrySrid = 3857
+        };
+
+        var ex = Assert.Throws<System.InvalidOperationException>(() => SqlResultExporter.ToGeoJson(result));
+        Assert.Contains("WGS84", ex.Message, System.StringComparison.Ordinal);
+        Assert.Contains("3857", ex.Message, System.StringComparison.Ordinal);
     }
 }

--- a/tests/Honua.Admin.Tests/SqlResultExporterTests.cs
+++ b/tests/Honua.Admin.Tests/SqlResultExporterTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Honua.Admin.Models.SpatialSql;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class SqlResultExporterTests
+{
+    [Fact]
+    public void ToCsv_quotes_cells_with_commas_quotes_or_newlines()
+    {
+        var result = new SqlExecuteResult
+        {
+            Columns = new[]
+            {
+                new SqlColumn("id", "uuid"),
+                new SqlColumn("county", "text"),
+                new SqlColumn("notes", "text")
+            },
+            Rows = new[]
+            {
+                new SqlRow(new string?[] { "1", "Big Island", "no, comments" }),
+                new SqlRow(new string?[] { "2", "Maui", "with \"quotes\"" }),
+                new SqlRow(new string?[] { "3", "Oahu", "line1\nline2" })
+            }
+        };
+
+        var csv = SqlResultExporter.ToCsv(result);
+
+        Assert.Contains("id,county,notes", csv, StringComparison.Ordinal);
+        Assert.Contains("\"no, comments\"", csv, StringComparison.Ordinal);
+        Assert.Contains("\"with \"\"quotes\"\"\"", csv, StringComparison.Ordinal);
+        Assert.Contains("\"line1\nline2\"", csv, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToGeoJson_emits_feature_collection_with_properties_excluding_geometry()
+    {
+        var result = new SqlExecuteResult
+        {
+            Columns = new[]
+            {
+                new SqlColumn("id", "uuid"),
+                new SqlColumn("county", "text"),
+                new SqlColumn("geom", "geometry", IsGeometry: true)
+            },
+            Rows = new[]
+            {
+                new SqlRow(new string?[]
+                {
+                    "1",
+                    "Big Island",
+                    "{\"type\":\"Point\",\"coordinates\":[-155.5,19.6]}"
+                })
+            },
+            GeometryColumnIndex = 2,
+            GeometrySrid = 4326
+        };
+
+        var json = SqlResultExporter.ToGeoJson(result);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("FeatureCollection", root.GetProperty("type").GetString());
+        var feature = root.GetProperty("features")[0];
+        Assert.Equal("Point", feature.GetProperty("geometry").GetProperty("type").GetString());
+        var properties = feature.GetProperty("properties");
+        Assert.Equal("Big Island", properties.GetProperty("county").GetString());
+        Assert.False(properties.TryGetProperty("geom", out _));
+        Assert.Equal("EPSG:4326", root.GetProperty("crs").GetProperty("properties").GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void ToGeoJson_throws_when_result_has_no_geometry_column()
+    {
+        var result = new SqlExecuteResult
+        {
+            Columns = new[] { new SqlColumn("id", "uuid") },
+            Rows = new[] { new SqlRow(new string?[] { "1" }) }
+        };
+
+        Assert.Throws<System.InvalidOperationException>(() => SqlResultExporter.ToGeoJson(result));
+    }
+}

--- a/tests/Honua.Admin.Tests/StubSpatialSqlClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpatialSqlClientTests.cs
@@ -1,0 +1,132 @@
+using Honua.Admin.Models.SpatialSql;
+using Honua.Admin.Services.SpatialSql;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class StubSpatialSqlClientTests
+{
+    private readonly StubSpatialSqlClient _client = new();
+
+    [Fact]
+    public async Task GetSchemaAsync_exposes_seeded_tables_with_geometry_columns()
+    {
+        var snapshot = await _client.GetSchemaAsync(CancellationToken.None);
+
+        Assert.Contains(snapshot.Tables, t => t.Name == "parcels" && t.GeometryColumn == "geom" && t.Srid == 4326);
+        Assert.Contains(snapshot.Tables, t => t.Name == "wells" && t.GeometryColumn == "geom");
+        Assert.NotEmpty(snapshot.Functions);
+        Assert.Contains(snapshot.Functions, f => f.Name == "ST_Buffer");
+        Assert.Contains(snapshot.Operators, o => o.Symbol == "&&");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_returns_geometry_metadata_and_rows_for_parcels()
+    {
+        var result = await _client.ExecuteAsync(new SqlExecuteRequest
+        {
+            Sql = "SELECT id, county, acreage, geom FROM parcels"
+        }, CancellationToken.None);
+
+        Assert.False(result.IsError);
+        Assert.True(result.HasGeometry);
+        Assert.Equal(4326, result.GeometrySrid);
+        Assert.Equal(2, result.Rows.Count);
+        Assert.Equal("geom", result.Columns[result.GeometryColumnIndex!.Value].Name);
+        Assert.False(result.Truncated);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_blocks_mutation_by_default_and_returns_an_error_payload()
+    {
+        var result = await _client.ExecuteAsync(new SqlExecuteRequest
+        {
+            Sql = "DELETE FROM parcels"
+        }, CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Equal("mutation_blocked", result.Error!.Code);
+        Assert.Empty(result.Rows);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_runs_mutation_and_assigns_audit_id_when_override_set()
+    {
+        var result = await _client.ExecuteAsync(new SqlExecuteRequest
+        {
+            Sql = "UPDATE parcels SET county='X' WHERE id IS NULL",
+            AllowMutation = true
+        }, CancellationToken.None);
+
+        Assert.False(result.IsError);
+        Assert.NotNull(result.AuditEntryId);
+        Assert.Equal("status", result.Columns[0].Name);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_caps_rows_at_request_limit_and_marks_truncated()
+    {
+        var result = await _client.ExecuteAsync(new SqlExecuteRequest
+        {
+            Sql = "SELECT * FROM parcels",
+            RowLimit = 1
+        }, CancellationToken.None);
+
+        Assert.False(result.IsError);
+        Assert.Single(result.Rows);
+        Assert.True(result.Truncated);
+        Assert.Equal(1, result.RowLimit);
+    }
+
+    [Fact]
+    public async Task ExplainAsync_builds_aggregate_over_table_when_table_resolves()
+    {
+        var plan = await _client.ExplainAsync(new SqlExplainRequest
+        {
+            Sql = "SELECT count(*) FROM wells"
+        }, CancellationToken.None);
+
+        Assert.False(plan.IsError);
+        Assert.Equal("Aggregate", plan.Root.NodeType);
+        var child = Assert.Single(plan.Root.Children);
+        Assert.Equal("Seq Scan", child.NodeType);
+        Assert.Equal("wells", child.Relation);
+    }
+
+    [Fact]
+    public async Task SaveViewAsync_returns_protocol_urls_and_rejects_duplicates()
+    {
+        var first = await _client.SaveViewAsync(new SaveViewRequest
+        {
+            Name = "active_parcels",
+            Sql = "SELECT * FROM parcels"
+        }, CancellationToken.None);
+
+        Assert.False(first.IsError);
+        Assert.NotNull(first.FeatureServerUrl);
+        Assert.NotNull(first.OgcFeaturesUrl);
+        Assert.NotNull(first.ODataUrl);
+
+        var dup = await _client.SaveViewAsync(new SaveViewRequest
+        {
+            Name = "active_parcels",
+            Sql = "SELECT 1"
+        }, CancellationToken.None);
+
+        Assert.True(dup.IsError);
+        Assert.Equal("duplicate_name", dup.Error!.Code);
+    }
+
+    [Fact]
+    public async Task SaveViewAsync_rejects_mutating_sql()
+    {
+        var result = await _client.SaveViewAsync(new SaveViewRequest
+        {
+            Name = "bad",
+            Sql = "DELETE FROM parcels"
+        }, CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Equal("mutation_blocked", result.Error!.Code);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #1
## Summary

Spatial SQL playground: interactive query editor in Admin UI
## Changes Made

- Spatial SQL playground: interactive query editor in Admin UI
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
Bounded sweep stayed in `SpatialSqlPlaygroundState` and its state tests. Checked sibling surfaces: valid query retry already cancels/replaces `_executeCts`; success/error/cancel paths already use `IsActiveExecution`; EXPLAIN already had `SupersedeActiveExplain` for invalid terminals; schema/save/export do not share query execution ownership; timeout remains server-enforced and surfaced through `SqlExecuteResult`.

I added a dedicated `SupersedeActiveExecution` helper matching the EXPLAIN pattern instead of refactoring broader state flow.

Follow-ons:
The existing `honua-server` child tickets for SQL execute/explain/schema/views plus audit-log surfacing remain pending and out of scope for this single-repo admin pass.

Code kaizen:
Auto-deferred by kaizen policy.
