### PR TITLE
feat: Data connection management workspace: provider capabilities, preflight, and managed Postgres checks (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,13 @@ Pages:
   delete a saved connection. Soft-disable maps to
   `PUT /api/v1/admin/connections/{id}` with `{ isActive: false }` (no
   dedicated disable endpoint); delete is gated behind a typed-name
-  confirm dialog and removes audit history server-side.
+  confirm dialog and removes audit history server-side. The edit form
+  is narrower than the create form: Display name and credential mode /
+  external secret reference are rendered read-only because the server's
+  `UpdateSecureConnectionRequest` has no slots for them — see gap #11.
+  Navigating between connection ids while editing clears the in-flight
+  draft so a Save never PUTs the prior connection's body against the new
+  route id.
 - `Pages/Operator/DataConnections/Diagnostics.razor`
   (`/operator/data-connections/{id}/diagnostics`) — six-row preflight
   grid (`Dns → Tcp → Auth → Ssl → Capability → Version`) plus a
@@ -450,7 +456,14 @@ duplicate the policy check; `401` / `403` map to a
 error kinds are `Network`, `Auth`, `Validation`, `Server`, `Conflict`,
 `NotFound`; the typed copy-keys it raises are `error.network`,
 `error.timeout`, `error.malformed_response`, `error.empty_response`,
-plus the kind-specific `error.{kind}` keys parsed from `ProblemDetails`.
+plus the kind-specific `error.{kind}` keys parsed from the response
+body. honua-server returns 4xx admin failures as
+`ApiResponse<object>.Failure(message)` (e.g., `"Invalid SSL mode"`,
+`"Connection is in use by services"`) rather than RFC7807
+`ProblemDetails`, so `HttpDataConnectionClient.ParseProblemAsync` reads
+the body once and tries both shapes — `ProblemDetails.Detail`/`.Title`
+first, then the failure-envelope `Message` — so the operator-actionable
+message survives into the banner alert.
 
 Diagnostic contract. Preflight always renders a six-row grid in
 deterministic order (`Dns → Tcp → Auth → Ssl → Capability → Version`).

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ This is the official admin UI for managing Honua Server instances:
 - **Identity Workspace**: OIDC provider lifecycle (list / create / edit / enable / delete), provider status, auth diagnostics, and API-key gap surface — see [Identity workspace](#identity-workspace) below
 - **License Workspace**: BYOL license status, entitlement inspection, expiry banding, replace flow, and operator-actionable diagnostics — see [License workspace](#license-workspace) below
 - **Spatial SQL Playground**: Browser-based PostGIS-aware SQL editor with schema autocomplete, MapLibre preview, EXPLAIN tree, and named-view save flow — see [Spatial SQL playground](#spatial-sql-playground) below
+- **Data Connections Workspace**: List / create / edit / soft-disable / delete / preflight data connections, with a structured diagnostic grid and a managed-Postgres capability matrix — see [Data connections workspace](#data-connections-workspace) below
 
 ## Architecture
 
 - **Frontend**: Blazor WebAssembly with MudBlazor components
-- **Backend Communication**: Operator S1 uses the in-repo `ISpecWorkspaceClient` and `ISpatialSqlClient` stubs; the [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) gRPC client and the SQL HTTP adapter swap in once the matching server endpoints land
+- **Backend Communication**: Operator S1 uses the in-repo `ISpecWorkspaceClient` and `ISpatialSqlClient` stubs; identity (`HttpIdentityAdminClient`) and data connections (`HttpDataConnectionClient`) call the honua-server admin REST surface directly through `HttpClient` + source-generated JSON. The [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) gRPC client and the SQL HTTP adapter swap in once the matching server endpoints land
 - **Deployment**: Static web app (can be hosted on CDN)
 
 ## Development
@@ -366,6 +367,155 @@ The S1 scope deliberately excludes Monaco / CodeMirror integration, write
 SQL beyond the per-query override, multi-database routing, query history
 sharing across operators, and live `pg_proc` introspection — each is
 tracked as a follow-on against `honua-server` or a future admin ticket.
+
+### Data connections workspace
+
+The data-connections workspace (ticket `#24`) lives under
+`/operator/data-connections/*` on the same shared shell as the spec and
+identity workspaces. It backs onto the `honua-server` admin endpoints
+under `/api/v1/admin/connections` through a typed seam at
+`src/Honua.Admin/Services/DataConnections/` so a different transport
+(gRPC, generated client) can be DI-swapped without touching the page
+layer.
+
+Pages:
+
+- `Pages/Operator/DataConnections/Index.razor`
+  (`/operator/data-connections`) — list view (provider, host, status,
+  last-checked) with a provider-aware "New connection" menu. The health
+  column normalizes case before mapping to MudBlazor chip colors. The
+  list endpoint hides disabled rows (server uses `WHERE is_active =
+  true`); the `disabled` chip in the row template only fires when a
+  future server filter surfaces them — see gap #9.
+- `Pages/Operator/DataConnections/Create.razor`
+  (`/operator/data-connections/new?provider={id}`) — provider-specific
+  create form, in-flight preflight test, and a confirmation gate before
+  save. Stub providers (e.g., SQL Server) reach this page but cannot
+  submit.
+- `Pages/Operator/DataConnections/Detail.razor`
+  (`/operator/data-connections/{id}`) — read / edit / soft-disable /
+  delete a saved connection. Soft-disable maps to
+  `PUT /api/v1/admin/connections/{id}` with `{ isActive: false }` (no
+  dedicated disable endpoint); delete is gated behind a typed-name
+  confirm dialog and removes audit history server-side.
+- `Pages/Operator/DataConnections/Diagnostics.razor`
+  (`/operator/data-connections/{id}/diagnostics`) — six-row preflight
+  grid (`Dns → Tcp → Auth → Ssl → Capability → Version`) plus a
+  managed-Postgres capability matrix.
+
+Wire contract. Every honua-server admin response is wrapped in the
+shared `ApiResponse<T>` envelope (`{ success, data, message, timestamp }`);
+`HttpDataConnectionClient` unwraps via `Data` exactly like the identity
+client. DTOs live in `src/Honua.Admin/Models/DataConnections/` and
+mirror the server shapes verbatim with `[JsonPropertyName]` attributes.
+Serialization runs through the source-generated
+`DataConnectionsJsonContext` (with both raw DTOs and `ApiResponse<T>`
+shapes registered) so the WASM build stays trim/AOT-safe. Every method
+funnels through a single `ExecuteRequestAsync<T>` helper so network
+(`HttpRequestException`), malformed-response (`JsonException`), and
+cancellation / timeout (`OperationCanceledException`) failures all land
+as typed `ConnectionOperationError` values rather than exceptions
+escaping to Razor.
+
+The HTTP client is registered via
+`builder.Services.AddHttpClient<IDataConnectionClient, HttpDataConnectionClient>(...)`
+in `Program.cs`, picking up `HonuaServer:BaseUrl` and the dev-only
+`X-API-Key` header through the same pattern as the identity client.
+
+The endpoint surface consumed by `IDataConnectionClient`:
+
+| Method | Route                                               | Purpose                                |
+| ------ | --------------------------------------------------- | -------------------------------------- |
+| GET    | `/api/v1/admin/connections`                         | List summaries                          |
+| GET    | `/api/v1/admin/connections/{id}`                    | Full detail                             |
+| POST   | `/api/v1/admin/connections`                         | Create (returns Summary)                |
+| PUT    | `/api/v1/admin/connections/{id}`                    | Edit / soft-disable / re-enable        |
+| DELETE | `/api/v1/admin/connections/{id}`                    | Hard delete (typed-name confirm)        |
+| POST   | `/api/v1/admin/connections/test`                    | Preflight a draft before save           |
+| POST   | `/api/v1/admin/connections/{id}/test`               | Preflight a saved record                |
+
+`DisableAsync` / `EnableAsync` on `IDataConnectionClient` are
+convenience wrappers around `UpdateAsync` and do not map to dedicated
+server routes. `CreateAsync` and `UpdateAsync` return
+`DataConnectionSummary` — the projection honua-server returns today —
+and `DataConnectionsState` issues a follow-up
+`GetAsync` via `TryRefreshSelectedDetailAsync` so Detail-only fields
+(`CredentialReference`, `EncryptionVersion`, `UpdatedAt`) are available
+to the page after a save. The extra round-trip is tracked as gap #8 in
+[`docs/data-connection-api-gaps.md`](docs/data-connection-api-gaps.md).
+
+Server policy: `RequireAdminAuthorization`. The admin UI does not
+duplicate the policy check; `401` / `403` map to a
+`ConnectionOperationError(Auth)` and a banner alert. The UI's typed
+error kinds are `Network`, `Auth`, `Validation`, `Server`, `Conflict`,
+`NotFound`; the typed copy-keys it raises are `error.network`,
+`error.timeout`, `error.malformed_response`, `error.empty_response`,
+plus the kind-specific `error.{kind}` keys parsed from `ProblemDetails`.
+
+Diagnostic contract. Preflight always renders a six-row grid in
+deterministic order (`Dns → Tcp → Auth → Ssl → Capability → Version`).
+The server today returns only `{ connectionId, connectionName,
+isHealthy, testedAt, message }`; `Services/DataConnections/DiagnosticMapper.cs`
+is the single seam that distributes the signal across cells via a
+narrow substring heuristic. Unmatched failure messages light only
+`Auth`; unrelated cells stay `NotAssessed` so the UI never produces
+false negatives. Pages never render the raw message as the primary
+signal. Per-step diagnostic codes are tracked as gap #1 in the gap
+report; the mapper becomes a pass-through once they ship.
+
+After a successful preflight against a saved connection,
+`DataConnectionsState.RunExistingPreflightAsync` patches the new
+`HealthStatus` ("Healthy"/"Unhealthy") and `LastHealthCheck` into both
+`SelectedDetail` and the corresponding list summary so Detail and Index
+chips reflect the latest test result without a manual refresh. The
+server's test endpoint does not persist the outcome to the row today
+(gap #10), so this local reconciliation is the only thing keeping the UI
+honest until that ships.
+
+Managed-Postgres capability matrix. Driven by
+`PostgresProviderRegistration.ManagedHostingChecks` (server version,
+SSL enforced, primary-vs-replica role, PostGIS, pgaudit, Aurora IAM,
+Azure AAD). Every cell renders `NotAssessed` with an
+"Awaiting honua-server#644" hover until the certification endpoint
+lands. The matrix carries `IsServerSourced=false` so renderers stay
+honest about provenance.
+
+Credential handling. Credentials only live in the in-memory
+`ConnectionDraft` for the lifetime of one submission. The state store
+(`DataConnectionsState`) clears the draft on save / cancel, never
+persists it to `localStorage`, and never accepts a credential back
+from the server. The detail view shows only `StorageType`
+(`managed` | `external`) plus `CredentialReference` for external
+secrets via `Components/Shared/MaskedSecretField` — no last-N-chars
+preview today (gap #4).
+
+Provider extensibility. `IProviderRegistration` (provider id, display
+name, default port, create form, capability renderer, managed-hosting
+check list) plus `IProviderRegistry` (DI-driven lookup by id) decouple
+the workspace shell from provider-specific UI. Postgres is concrete;
+SQL Server is the registered stub (`IsStub = true`, empty check list,
+"coming soon" placeholder form). Stubs are reachable from the New-connection
+menu but cannot submit. New providers ship by registering an additional
+`IProviderRegistration` — no workspace shell changes required. The
+load-bearing constraint is `honua-io/honua-server#362` (multi-database
+epic), which must surface a real `providerId` per connection before a
+second concrete provider can ship; tracked as gap #3.
+
+Telemetry. `LoggingDataConnectionTelemetry` is the default sink for
+`IDataConnectionTelemetry`. Events:
+`data_connections.list_loaded` / `list_failed`,
+`data_connections.create_submitted` / `create_succeeded` /
+`create_failed`, `data_connections.update_succeeded` / `update_failed`,
+`data_connections.test_started` / `test_completed` (`result_kind` is
+`healthy | failed | not_assessed | error`, `failed_step` is set on
+failures, latency in ms), `data_connections.enabled` / `disabled` /
+`deleted`, `data_connections.provider_stub_viewed`.
+
+The full set of server-side gaps surfaced while building this
+workspace lives in
+[`docs/data-connection-api-gaps.md`](docs/data-connection-api-gaps.md);
+each entry feeds the API audit matrix tracked in
+`honua-io/honua-server-admin#28`.
 
 ## Features
 

--- a/docs/data-connection-api-gaps.md
+++ b/docs/data-connection-api-gaps.md
@@ -128,3 +128,41 @@ typed `ConnectionOperationError(Auth)` and a banner alert.
 - **Server change wanted:** mutating endpoints should return
   `ApiResponse<SecureConnectionDetail>` (the same shape the GET endpoint
   emits), removing the need for a follow-up GET.
+
+### 9. `GET /connections` filters out disabled connections — no `?includeInactive`
+
+- **Today:** `PostgresSecureConnectionRegistry.GetActiveConnectionsAsync`
+  uses `WHERE is_active = true`, so the list endpoint never surfaces
+  disabled rows. `GET /connections/{id}` does *not* filter, so a disabled
+  connection is still retrievable by id. The admin UI's
+  `StubDataConnectionClient.ListAsync` was updated to mirror the same
+  filter for parity with production.
+- **Blocks:** operator UX after a soft-disable. Once `PUT … { isActive:
+  false }` succeeds, the row vanishes from `/operator/data-connections`;
+  there is no in-UI list pivot to "see disabled" or to re-enable from the
+  list view. The `disabled` chip on `Index.razor` is dead code under the
+  current contract — it only renders if a future server change surfaces
+  inactive rows.
+- **Server change wanted:** add an opt-in filter (`?includeInactive=true`
+  or a separate `is_active=any` enum) on the list endpoint so the admin
+  can render a "disabled" tab / chip filter without losing existing
+  callers' assumption that the default surface is active-only.
+
+### 10. `POST /connections/{id}/test` does not persist `HealthStatus` to the row
+
+- **Today:** `HandleTestConnection` runs the health probe, returns the
+  `ConnectionTestResult`, and never calls
+  `ISecureConnectionRegistry.UpdateHealthStatusAsync`. The next `GET`
+  returns the prior stored `HealthStatus` regardless of test outcome.
+- **Workaround:** `DataConnectionsState.RunExistingPreflightAsync`
+  derives the refreshed `HealthStatus` ("Healthy"/"Unhealthy", matching
+  the server's `enum.ToString()` casing) and `LastHealthCheck` locally
+  from the `ConnectionTestOutcome` and patches both `SelectedDetail` and
+  the corresponding list entry. Operator-visible chips and timestamps
+  refresh inside the workspace, but a fresh page load (re-fetching from
+  the server) reverts to the stale stored value.
+- **Server change wanted:** `HandleTestConnection` should write the
+  test outcome back to the row (`UpdateHealthStatusAsync(id,
+  isHealthy ? Healthy : Unhealthy, RequestAborted)`) plus update
+  `last_health_check`, so the wire-of-truth and the UI agree without
+  the workaround.

--- a/docs/data-connection-api-gaps.md
+++ b/docs/data-connection-api-gaps.md
@@ -166,3 +166,24 @@ typed `ConnectionOperationError(Auth)` and a banner alert.
   isHealthy ? Healthy : Unhealthy, RequestAborted)`) plus update
   `last_health_check`, so the wire-of-truth and the UI agree without
   the workaround.
+
+### 11. `UpdateSecureConnectionRequest` has no Name / SecretReference / SecretType slots
+
+- **Today:** the server's PUT contract only accepts `Description`,
+  `Host`, `Port`, `DatabaseName`, `Username`, `Password`, `SslRequired`,
+  `SslMode`, `IsActive`. Renaming a connection, switching credential
+  modes, or rotating an external secret reference are not addressable
+  through the existing endpoint.
+- **Workaround:** `PostgresConnectionForm` renders Display name and
+  the credential-mode radio group as read-only in edit mode (`IsEdit`),
+  hides the secret-type field, and surfaces a "Credential mode is fixed
+  after creation. Delete and recreate to switch." caption. The state
+  store's `SubmitEditAsync` already maps only the supported fields; the
+  form gating closes the operator-facing half so saves never appear to
+  succeed for fields the server would silently drop.
+- **Server change wanted:** broaden `UpdateSecureConnectionRequest` to
+  accept (at minimum) `Name`, and either add a separate "rotate
+  secret-reference" endpoint or extend PUT with `SecretReference` /
+  `SecretType` so external secrets can be re-pointed without a delete /
+  recreate cycle. Tracked alongside gap #4 since both want richer
+  credential-management on the wire.

--- a/docs/data-connection-api-gaps.md
+++ b/docs/data-connection-api-gaps.md
@@ -111,3 +111,20 @@ typed `ConnectionOperationError(Auth)` and a banner alert.
   health-check timestamp.
 - **Server change wanted:** `GET /api/v1/admin/connections/{id}/history`
   returning a paged audit log (actor, action, timestamp, before/after).
+
+### 8. `POST` / `PUT` return `SecureConnectionSummary` rather than `SecureConnectionDetail`
+
+- **Today:** the create and update endpoints return only the summary
+  projection. `CredentialReference`, `EncryptionVersion`, and `UpdatedAt`
+  are not in the response body, so the UI has to issue a follow-up
+  `GET /connections/{id}` to render the detail surface accurately after a
+  mutating call. `DataConnectionsState.SubmitDraftAsync` /
+  `SubmitEditAsync` / `SetActiveAsync` each fire that follow-up via
+  `TryRefreshSelectedDetailAsync`.
+- **Blocks:** the optimistic single-round-trip flow the rest of the
+  workspace assumes. Doubles the latency of every save before the page
+  shows accurate Detail-only fields (e.g., `CredentialReference` after the
+  operator switches credential mode).
+- **Server change wanted:** mutating endpoints should return
+  `ApiResponse<SecureConnectionDetail>` (the same shape the GET endpoint
+  emits), removing the need for a follow-up GET.

--- a/docs/data-connection-api-gaps.md
+++ b/docs/data-connection-api-gaps.md
@@ -1,0 +1,113 @@
+# Data connection API gap report
+
+This report enumerates server-side shortfalls discovered while building the
+admin-UI data-connection workspace (`honua-io/honua-server-admin#24`). Each
+entry names the DTO field or endpoint, the contract acceptance criterion it
+blocks, and the follow-up that would close it. The entries are ready to be
+folded into the API audit matrix tracked in `honua-io/honua-server-admin#28`.
+
+## Source endpoints inspected
+
+- `GET /api/v1/admin/connections`
+- `GET /api/v1/admin/connections/{id}`
+- `POST /api/v1/admin/connections`
+- `PUT /api/v1/admin/connections/{id}`
+- `DELETE /api/v1/admin/connections/{id}`
+- `POST /api/v1/admin/connections/test`
+- `POST /api/v1/admin/connections/{id}/test`
+
+Authority: `RequireAdminAuthorization` (the same Admin policy the server
+applies to every other admin endpoint). The admin UI does not duplicate this
+check; failed `401`/`403` responses surface through `ProblemDetails` into a
+typed `ConnectionOperationError(Auth)` and a banner alert.
+
+## Gaps
+
+### 1. `ConnectionTestResult` lacks per-step diagnostic codes
+
+- **Today:** the response is `{ connectionId, connectionName, isHealthy,
+  testedAt, message }`. `message` is free-form prose.
+- **Blocks:** AC "preflight test surfaces a structured diagnostic for every
+  common failure mode (DNS / TCP / auth / SSL / capability / version)".
+- **Workaround:** `Services/DataConnections/DiagnosticMapper.cs` distributes
+  the single `IsHealthy + Message` signal across six structured cells via a
+  narrow heuristic table. Unmatched messages land on `Auth` only; unrelated
+  cells render `NotAssessed` rather than `Failed` so we never produce false
+  negatives.
+- **Server change wanted:** add a `steps[]` collection to
+  `ConnectionTestResult` with one entry per `{ step, status, code, message }`.
+  The mapper then becomes a pass-through.
+
+### 2. No managed-Postgres certification endpoint (Aurora + Azure DB)
+
+- **Today:** there is no endpoint that reports per-check verdicts for a
+  managed-Postgres certification matrix. `honua-io/honua-server#644` tracks
+  the work.
+- **Blocks:** AC "managed-Postgres validation results (Aurora + Azure DB)
+  render with pass / fail per check + remediation copy on failures".
+- **Workaround:** the Postgres provider registration exposes a static list of
+  expected checks (server version, SSL enforcement, replication role,
+  PostGIS, pgaudit, IAM/AAD auth). Until the server endpoint lands, every
+  cell renders as `NotAssessed` with a "Awaiting honua-server#644" hover.
+- **Server change wanted:** `GET /api/v1/admin/connections/{id}/certification`
+  returning `{ providerId, checks[]: { id, status, detail, remediationKey } }`.
+
+### 3. No provider capability registry / `IDataProvider` server abstraction
+
+- **Today:** `DatabaseType="PostgreSQL"` is hard-coded on the server.
+  `honua-io/honua-server#362` tracks the multi-database epic.
+- **Blocks:** the admin UI registers a SQL Server stub provider to prove the
+  pluggable `IProviderRegistration` contract — but no concrete second
+  provider can ship until the server returns a `providerId` per
+  connection and accepts provider-specific create / update payloads.
+- **Server change wanted:** add `providerId` to `SecureConnectionSummary`
+  and `SecureConnectionDetail`; surface a `GET /providers` endpoint listing
+  the providers the server can actually talk to.
+
+### 4. No masked credential preview on the Summary / Detail DTOs
+
+- **Today:** neither DTO returns a hint for the stored credential. The UI
+  knows only `StorageType` (`managed` | `external`) and the optional
+  `CredentialReference` for external secrets.
+- **Blocks:** richer credential identification in the list view (e.g.,
+  "ends in 7af3" tooltip). Today's display is `●●●●●●●● (managed)` with no
+  per-record disambiguator.
+- **Server change wanted:** add a `maskedHint` field to
+  `SecureConnectionSummary` (last-N chars of the encrypted credential or a
+  stable derived suffix). Must be safe to expose — never the plaintext.
+
+### 5. DTOs are hand-rolled in the admin repo (no generated client)
+
+- **Today:** `Models/DataConnections/DataConnection.cs`,
+  `ConnectionDraft.cs`, and `ConnectionDiagnostic.cs` mirror the server's
+  OpenAPI contract bytes-for-bytes by hand. There is no codegen toolchain
+  in this repo.
+- **Blocks:** schema drift is caught only when the UI breaks at runtime. The
+  audit matrix in `#28` is the right home for this duplication concern.
+- **Server change wanted:** publish the OpenAPI contract for
+  `/api/v1/admin/connections` as part of the SDK package, and add a
+  generated-client step in `honua-server-admin` CI. Replace the hand-rolled
+  DTOs and the `HttpDataConnectionClient` with the generated client.
+
+### 6. `PUT` is the only path to soft-disable
+
+- **Today:** there is no dedicated `POST /connections/{id}/disable` endpoint;
+  the UI sends `PUT … { isActive: false }`. This is what the design brief
+  asks for, but it means audit logging on the server cannot distinguish
+  "operator disabled the connection" from "operator updated metadata that
+  happened to set isActive". Recorded for visibility — not necessarily a
+  bug.
+- **Blocks:** richer audit history copy on the detail page.
+- **Server change wanted:** consider a typed audit reason field on `PUT`,
+  or a dedicated disable / enable endpoint.
+
+### 7. No audit-history endpoint for a connection
+
+- **Today:** `Detail.razor` shows only the current-state fields. There is no
+  `GET /connections/{id}/history`, so the page cannot show "who created /
+  disabled / re-enabled the connection and when".
+- **Blocks:** complete answer to the operator question "who broke this and
+  when?" — currently the UI surfaces only the latest health status and last
+  health-check timestamp.
+- **Server change wanted:** `GET /api/v1/admin/connections/{id}/history`
+  returning a paged audit log (actor, action, timestamp, before/after).

--- a/src/Honua.Admin/Components/Shared/MaskedSecretField.razor
+++ b/src/Honua.Admin/Components/Shared/MaskedSecretField.razor
@@ -1,0 +1,22 @@
+@using MudBlazor
+
+<MudPaper Outlined="true" Class="pa-3 d-flex align-center" data-testid="@TestId">
+    <MudIcon Icon="@Icons.Material.Filled.Lock" Class="mr-2" />
+    <div class="flex-grow-1">
+        <MudText Typo="Typo.body2" Class="text-secondary">@Label</MudText>
+        <MudText Typo="Typo.body1">@Mask</MudText>
+        @if (!string.IsNullOrEmpty(Hint))
+        {
+            <MudText Typo="Typo.caption" Class="text-secondary">@Hint</MudText>
+        }
+    </div>
+</MudPaper>
+
+@code {
+    [Parameter] public string Label { get; set; } = "Stored credential";
+    [Parameter] public string StorageType { get; set; } = "managed";
+    [Parameter] public string? Hint { get; set; }
+    [Parameter] public string? TestId { get; set; }
+
+    private string Mask => $"●●●●●●●● ({StorageType})";
+}

--- a/src/Honua.Admin/Components/Shared/MaskedSecretInput.razor
+++ b/src/Honua.Admin/Components/Shared/MaskedSecretInput.razor
@@ -1,0 +1,30 @@
+@using MudBlazor
+
+<MudTextField T="string"
+              Label="@Label"
+              Value="@Value"
+              ValueChanged="HandleValueChanged"
+              InputType="@(_visible ? InputType.Text : InputType.Password)"
+              HelperText="@HelperText"
+              Required="@Required"
+              Disabled="@Disabled"
+              Adornment="Adornment.End"
+              AdornmentIcon="@(_visible ? Icons.Material.Filled.VisibilityOff : Icons.Material.Filled.Visibility)"
+              OnAdornmentClick="ToggleVisibility"
+              data-testid="@TestId" />
+
+@code {
+    private bool _visible;
+
+    [Parameter] public string? Value { get; set; }
+    [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+    [Parameter] public string Label { get; set; } = "Secret";
+    [Parameter] public string? HelperText { get; set; }
+    [Parameter] public bool Required { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public string? TestId { get; set; }
+
+    private Task HandleValueChanged(string? next) => ValueChanged.InvokeAsync(next);
+
+    private void ToggleVisibility() => _visible = !_visible;
+}

--- a/src/Honua.Admin/Models/DataConnections/ApiResponse.cs
+++ b/src/Honua.Admin/Models/DataConnections/ApiResponse.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// Mirrors <c>Honua.Server.Features.Infrastructure.Models.ApiResponse&lt;T&gt;</c>.
+/// honua-server admin endpoints wrap every payload in this envelope; the admin UI
+/// unwraps via <see cref="Data"/>. Duplicated locally to keep the data-connection
+/// module self-contained — the identity workspace owns its own mirror under
+/// <c>Models/Identity/IdentityModels.cs</c>; consolidate when a shared
+/// <c>Models/Common</c> namespace is introduced.
+/// </summary>
+public sealed class ApiResponse<T>
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    [JsonPropertyName("data")]
+    public T? Data { get; init; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; init; }
+}

--- a/src/Honua.Admin/Models/DataConnections/CapabilityCheck.cs
+++ b/src/Honua.Admin/Models/DataConnections/CapabilityCheck.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// One row in the managed-Postgres certification matrix (Aurora / Azure DB).
+/// The renderer pairs each row with remediation copy keyed by
+/// <see cref="RemediationKey"/>.
+/// </summary>
+public sealed record CapabilityCheck(
+    string CheckId,
+    string DisplayName,
+    string Category,
+    string RemediationKey)
+{
+    public DiagnosticStatus Status { get; init; } = DiagnosticStatus.NotAssessed;
+
+    public string? Detail { get; init; }
+}
+
+/// <summary>
+/// Provider-level matrix of expected checks; each provider returns its own
+/// list. Until <c>honua-server#644</c> lands an endpoint that drives these,
+/// rows render as <c>NotAssessed</c> with a "needs #644" hover. False
+/// negatives would erode trust, so the renderer never synthesizes a "fail".
+/// </summary>
+public sealed class ProviderCapabilityMatrix
+{
+    public required string ProviderId { get; init; }
+
+    public required IReadOnlyList<CapabilityCheck> Checks { get; init; }
+
+    /// <summary>
+    /// True when the matrix data came from a real server endpoint. Today this
+    /// is always false; once <c>#644</c> lands we flip it per-row.
+    /// </summary>
+    public bool IsServerSourced { get; init; }
+}

--- a/src/Honua.Admin/Models/DataConnections/ConnectionDiagnostic.cs
+++ b/src/Honua.Admin/Models/DataConnections/ConnectionDiagnostic.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// One of six fixed diagnostic steps rendered in deterministic order by the
+/// preflight surface. Adding a step would change the contract; the order and
+/// the set are intentionally frozen so the matcher and the renderer stay in
+/// sync.
+/// </summary>
+public enum DiagnosticStep
+{
+    Dns,
+    Tcp,
+    Auth,
+    Ssl,
+    Capability,
+    Version
+}
+
+public enum DiagnosticStatus
+{
+    NotAssessed,
+    Ok,
+    Failed
+}
+
+public sealed record DiagnosticCell(
+    DiagnosticStep Step,
+    DiagnosticStatus Status,
+    string? Detail = null,
+    string? RemediationKey = null);
+
+/// <summary>
+/// Full preflight result projected into the six-cell structured surface, plus
+/// the raw test outcome so callers can log / debug without re-fetching.
+/// </summary>
+public sealed class ConnectionDiagnostic
+{
+    public required IReadOnlyList<DiagnosticCell> Cells { get; init; }
+
+    public required ConnectionTestOutcome RawOutcome { get; init; }
+
+    public bool AnyFailed
+    {
+        get
+        {
+            foreach (var cell in Cells)
+            {
+                if (cell.Status == DiagnosticStatus.Failed)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    public DiagnosticCell GetCell(DiagnosticStep step)
+    {
+        foreach (var cell in Cells)
+        {
+            if (cell.Step == step)
+            {
+                return cell;
+            }
+        }
+        return new DiagnosticCell(step, DiagnosticStatus.NotAssessed);
+    }
+}
+
+/// <summary>
+/// Wire shape for <c>POST /api/v1/admin/connections/test</c> and
+/// <c>POST /api/v1/admin/connections/{id}/test</c>. Today the server returns
+/// only <c>IsHealthy + Message</c>; the diagnostic mapper distributes that
+/// signal across the six cells. Server gap recorded in the gap report.
+/// </summary>
+public sealed class ConnectionTestOutcome
+{
+    public required Guid ConnectionId { get; init; }
+
+    public required string ConnectionName { get; init; }
+
+    public bool IsHealthy { get; init; }
+
+    public DateTimeOffset TestedAt { get; init; }
+
+    public string? Message { get; init; }
+}

--- a/src/Honua.Admin/Models/DataConnections/ConnectionDraft.cs
+++ b/src/Honua.Admin/Models/DataConnections/ConnectionDraft.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// Working copy of a connection being created or edited. Credentials live here
+/// only for the duration of a single submission; the state store clears the
+/// draft as soon as the create / update returns. Never persisted to local
+/// storage and never round-tripped from the server.
+/// </summary>
+public sealed class ConnectionDraft
+{
+    public Guid? ConnectionId { get; init; }
+
+    public string ProviderId { get; init; } = "postgres";
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public string Host { get; set; } = string.Empty;
+
+    public int Port { get; set; } = 5432;
+
+    public string DatabaseName { get; set; } = string.Empty;
+
+    public string Username { get; set; } = string.Empty;
+
+    public string? Password { get; set; }
+
+    public string? SecretReference { get; set; }
+
+    public string? SecretType { get; set; }
+
+    public bool SslRequired { get; set; } = true;
+
+    public string SslMode { get; set; } = "Require";
+
+    public bool? IsActive { get; set; }
+
+    public CredentialMode CredentialMode { get; set; } = CredentialMode.Managed;
+}
+
+public enum CredentialMode
+{
+    Managed,
+    External
+}
+
+/// <summary>
+/// Wire shape for create. Mirrors <c>CreateSecureConnectionRequest</c> on the
+/// server bytes-for-bytes.
+/// </summary>
+public sealed class CreateConnectionRequest
+{
+    public required string Name { get; init; }
+
+    public string? Description { get; init; }
+
+    public required string Host { get; init; }
+
+    public int Port { get; init; } = 5432;
+
+    public required string DatabaseName { get; init; }
+
+    public required string Username { get; init; }
+
+    public string? Password { get; init; }
+
+    public string? SecretReference { get; init; }
+
+    public string? SecretType { get; init; }
+
+    public bool SslRequired { get; init; } = true;
+
+    public string SslMode { get; init; } = "Require";
+}
+
+/// <summary>
+/// Wire shape for update. Every field is nullable so the caller can pass a
+/// partial body — the server keeps prior values for fields left null.
+/// </summary>
+public sealed class UpdateConnectionRequest
+{
+    public string? Description { get; init; }
+
+    public string? Host { get; init; }
+
+    public int? Port { get; init; }
+
+    public string? DatabaseName { get; init; }
+
+    public string? Username { get; init; }
+
+    public string? Password { get; init; }
+
+    public bool? SslRequired { get; init; }
+
+    public string? SslMode { get; init; }
+
+    public bool? IsActive { get; init; }
+}

--- a/src/Honua.Admin/Models/DataConnections/ConnectionOperationError.cs
+++ b/src/Honua.Admin/Models/DataConnections/ConnectionOperationError.cs
@@ -1,0 +1,21 @@
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// Typed error funnel for every connection client call. Razor pages branch on
+/// <see cref="Kind"/> and render copy keyed by <see cref="CopyKey"/> — the
+/// raw server message is for debug, never the primary signal.
+/// </summary>
+public sealed record ConnectionOperationError(
+    ConnectionErrorKind Kind,
+    string CopyKey,
+    string? Detail = null);
+
+public enum ConnectionErrorKind
+{
+    Network,
+    Auth,
+    Validation,
+    Server,
+    Conflict,
+    NotFound
+}

--- a/src/Honua.Admin/Models/DataConnections/DataConnection.cs
+++ b/src/Honua.Admin/Models/DataConnections/DataConnection.cs
@@ -9,7 +9,7 @@ namespace Honua.Admin.Models.DataConnections;
 /// Property naming policy is inherited from the JSON context — server uses
 /// camelCase on the wire.
 /// </summary>
-public sealed class DataConnectionSummary
+public sealed record DataConnectionSummary
 {
     public required Guid ConnectionId { get; init; }
 

--- a/src/Honua.Admin/Models/DataConnections/DataConnection.cs
+++ b/src/Honua.Admin/Models/DataConnections/DataConnection.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// Mirror of <c>SecureConnectionSummary</c> on the server. Hand-rolled until the
+/// audit ticket (<c>#28</c>) replaces these DTOs with a generated client.
+/// Property naming policy is inherited from the JSON context — server uses
+/// camelCase on the wire.
+/// </summary>
+public sealed class DataConnectionSummary
+{
+    public required Guid ConnectionId { get; init; }
+
+    public required string Name { get; init; }
+
+    public string? Description { get; init; }
+
+    public required string Host { get; init; }
+
+    public int Port { get; init; }
+
+    public required string DatabaseName { get; init; }
+
+    public required string Username { get; init; }
+
+    public bool SslRequired { get; init; }
+
+    public required string SslMode { get; init; }
+
+    public required string StorageType { get; init; }
+
+    public bool IsActive { get; init; }
+
+    public required string HealthStatus { get; init; }
+
+    public DateTimeOffset? LastHealthCheck { get; init; }
+
+    public DateTimeOffset CreatedAt { get; init; }
+
+    public required string CreatedBy { get; init; }
+
+    [JsonIgnore]
+    public string ProviderId => "postgres";
+}
+
+public sealed record DataConnectionDetail
+{
+    public required Guid ConnectionId { get; init; }
+
+    public required string Name { get; init; }
+
+    public string? Description { get; init; }
+
+    public required string Host { get; init; }
+
+    public int Port { get; init; }
+
+    public required string DatabaseName { get; init; }
+
+    public required string Username { get; init; }
+
+    public bool SslRequired { get; init; }
+
+    public required string SslMode { get; init; }
+
+    public required string StorageType { get; init; }
+
+    public bool IsActive { get; init; }
+
+    public required string HealthStatus { get; init; }
+
+    public DateTimeOffset? LastHealthCheck { get; init; }
+
+    public DateTimeOffset CreatedAt { get; init; }
+
+    public required string CreatedBy { get; init; }
+
+    public string? CredentialReference { get; init; }
+
+    public int EncryptionVersion { get; init; }
+
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    [JsonIgnore]
+    public string ProviderId => "postgres";
+}

--- a/src/Honua.Admin/Models/DataConnections/DataConnectionsJsonContext.cs
+++ b/src/Honua.Admin/Models/DataConnections/DataConnectionsJsonContext.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// Source-generated serializer context for every data-connection DTO. Required
+/// for AOT / trim-friendly WebAssembly publishing — reflection-based JSON
+/// would break trimming.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(DataConnectionSummary))]
+[JsonSerializable(typeof(DataConnectionSummary[]))]
+[JsonSerializable(typeof(IReadOnlyList<DataConnectionSummary>))]
+[JsonSerializable(typeof(DataConnectionDetail))]
+[JsonSerializable(typeof(CreateConnectionRequest))]
+[JsonSerializable(typeof(UpdateConnectionRequest))]
+[JsonSerializable(typeof(ConnectionTestOutcome))]
+[JsonSerializable(typeof(ProblemDetailsPayload))]
+public sealed partial class DataConnectionsJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Admin/Models/DataConnections/DataConnectionsJsonContext.cs
+++ b/src/Honua.Admin/Models/DataConnections/DataConnectionsJsonContext.cs
@@ -6,19 +6,25 @@ namespace Honua.Admin.Models.DataConnections;
 /// <summary>
 /// Source-generated serializer context for every data-connection DTO. Required
 /// for AOT / trim-friendly WebAssembly publishing — reflection-based JSON
-/// would break trimming.
+/// would break trimming. Both raw DTOs (for request bodies) and
+/// <see cref="ApiResponse{T}"/>-wrapped responses are registered, since
+/// honua-server admin endpoints always wrap successful payloads in the
+/// envelope.
 /// </summary>
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(DataConnectionSummary))]
-[JsonSerializable(typeof(DataConnectionSummary[]))]
-[JsonSerializable(typeof(IReadOnlyList<DataConnectionSummary>))]
 [JsonSerializable(typeof(DataConnectionDetail))]
 [JsonSerializable(typeof(CreateConnectionRequest))]
 [JsonSerializable(typeof(UpdateConnectionRequest))]
 [JsonSerializable(typeof(ConnectionTestOutcome))]
 [JsonSerializable(typeof(ProblemDetailsPayload))]
+[JsonSerializable(typeof(ApiResponse<DataConnectionSummary>))]
+[JsonSerializable(typeof(ApiResponse<DataConnectionDetail>))]
+[JsonSerializable(typeof(ApiResponse<IReadOnlyList<DataConnectionSummary>>))]
+[JsonSerializable(typeof(ApiResponse<ConnectionTestOutcome>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
 public sealed partial class DataConnectionsJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Admin/Models/DataConnections/ProblemDetailsPayload.cs
+++ b/src/Honua.Admin/Models/DataConnections/ProblemDetailsPayload.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.DataConnections;
+
+/// <summary>
+/// Minimal RFC 7807 mirror used by the HTTP client to translate server error
+/// bodies into typed <see cref="ConnectionOperationError"/> values.
+/// </summary>
+public sealed class ProblemDetailsPayload
+{
+    public string? Type { get; init; }
+
+    public string? Title { get; init; }
+
+    public int? Status { get; init; }
+
+    public string? Detail { get; init; }
+
+    public string? Instance { get; init; }
+
+    public IReadOnlyDictionary<string, IReadOnlyList<string>>? Errors { get; init; }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Create.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Create.razor
@@ -1,0 +1,193 @@
+@page "/operator/data-connections/new"
+@using Microsoft.AspNetCore.Authorization
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+@using Honua.Admin.Services.DataConnections
+@using Honua.Admin.Services.DataConnections.Providers
+@attribute [Authorize]
+@inject DataConnectionsState State
+@inject NavigationManager Nav
+@implements IDisposable
+
+<PageTitle>New data connection</PageTitle>
+
+<MudStack Spacing="3">
+    <MudBreadcrumbs Items="_crumbs" />
+
+    @if (_provider is null)
+    {
+        <MudAlert Severity="Severity.Warning" data-testid="provider-missing">
+            Pick a provider from the list page to begin.
+        </MudAlert>
+    }
+    else
+    {
+        <MudText Typo="Typo.h5">New @_provider.DisplayName connection</MudText>
+        <MudText Typo="Typo.body2" Class="text-secondary">@_provider.Description</MudText>
+
+        @if (State.LastError is { } err)
+        {
+            <MudAlert Severity="Severity.Error" data-testid="create-error">
+                @err.CopyKey @(err.Detail is null ? string.Empty : $" — {err.Detail}")
+            </MudAlert>
+        }
+
+        @if (State.Draft is not null && !_provider.IsStub)
+        {
+            <DynamicComponent Type="@_provider.CreateFormComponentType"
+                              Parameters="@FormParameters" />
+        }
+        else if (_provider.IsStub)
+        {
+            <DynamicComponent Type="@_provider.CreateFormComponentType"
+                              Parameters="@StubFormParameters" />
+        }
+
+        @if (LatestDiagnostic is not null)
+        {
+            <DiagnosticGrid Diagnostic="LatestDiagnostic" />
+        }
+
+        <MudStack Row="true">
+            <MudButton Variant="Variant.Outlined"
+                       OnClick="Cancel"
+                       data-testid="create-cancel">
+                Cancel
+            </MudButton>
+            <MudSpacer />
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Info"
+                       OnClick="RunPreflight"
+                       Disabled="@(_provider.IsStub || _testing)"
+                       data-testid="create-test">
+                @(_testing ? "Testing…" : "Test connection")
+            </MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="Submit"
+                       Disabled="@(_provider.IsStub || _saving)"
+                       data-testid="create-save">
+                @(_saving ? "Saving…" : "Save connection")
+            </MudButton>
+        </MudStack>
+    }
+</MudStack>
+
+@code {
+    private IProviderRegistration? _provider;
+    private bool _saving;
+    private bool _testing;
+    private List<BreadcrumbItem> _crumbs = new();
+
+    private ConnectionDiagnostic? LatestDiagnostic => State.LatestDiagnostic;
+
+    private Dictionary<string, object> FormParameters => new()
+    {
+        ["Draft"] = State.Draft!,
+        ["DraftChanged"] = EventCallback.Factory.Create<ConnectionDraft>(this, OnDraftChanged),
+        ["IsEdit"] = false
+    };
+
+    private Dictionary<string, object> StubFormParameters => new()
+    {
+        ["DisplayName"] = _provider?.DisplayName ?? "this provider",
+        ["Draft"] = State.Draft!,
+        ["DraftChanged"] = EventCallback.Factory.Create<ConnectionDraft>(this, OnDraftChanged),
+        ["IsEdit"] = false
+    };
+
+    protected override void OnInitialized()
+    {
+        State.OnChanged += HandleChanged;
+        var providerId = ResolveProviderId(Nav.Uri);
+
+        if (State.Draft is null || !string.Equals(State.Draft.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
+        {
+            State.BeginCreateDraft(providerId);
+        }
+
+        if (State.ProviderRegistry.TryGet(providerId, out var registration))
+        {
+            _provider = registration;
+        }
+
+        _crumbs = new()
+        {
+            new BreadcrumbItem("Data connections", "/operator/data-connections"),
+            new BreadcrumbItem("New", null, true)
+        };
+    }
+
+    private void HandleChanged() => InvokeAsync(StateHasChanged);
+
+    private Task OnDraftChanged(ConnectionDraft draft)
+    {
+        State.UpdateDraft(_ => { });
+        return Task.CompletedTask;
+    }
+
+    private async Task RunPreflight()
+    {
+        _testing = true;
+        try
+        {
+            await State.RunDraftPreflightAsync();
+        }
+        finally
+        {
+            _testing = false;
+        }
+    }
+
+    private async Task Submit()
+    {
+        _saving = true;
+        try
+        {
+            var result = await State.SubmitDraftAsync();
+            if (result.IsSuccess && result.Value is { } detail)
+            {
+                Nav.NavigateTo($"/operator/data-connections/{detail.ConnectionId}");
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void Cancel()
+    {
+        State.ClearDraft();
+        Nav.NavigateTo("/operator/data-connections");
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= HandleChanged;
+    }
+
+    private static string ResolveProviderId(string uri)
+    {
+        var queryStart = uri.IndexOf('?', StringComparison.Ordinal);
+        if (queryStart < 0)
+        {
+            return "postgres";
+        }
+        var query = uri[(queryStart + 1)..];
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var sep = pair.IndexOf('=', StringComparison.Ordinal);
+            if (sep <= 0)
+            {
+                continue;
+            }
+            var key = Uri.UnescapeDataString(pair[..sep]);
+            if (string.Equals(key, "provider", StringComparison.OrdinalIgnoreCase))
+            {
+                return Uri.UnescapeDataString(pair[(sep + 1)..]);
+            }
+        }
+        return "postgres";
+    }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Create.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Create.razor
@@ -101,14 +101,23 @@
         State.OnChanged += HandleChanged;
         var providerId = ResolveProviderId(Nav.Uri);
 
-        if (State.Draft is null || !string.Equals(State.Draft.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
-        {
-            State.BeginCreateDraft(providerId);
-        }
-
+        // Resolve the provider before priming the draft. BeginCreateDraft
+        // throws InvalidOperationException for unknown ids, which would
+        // otherwise crash this page before the missing-provider alert can
+        // render for `/new?provider=bogus`.
         if (State.ProviderRegistry.TryGet(providerId, out var registration))
         {
             _provider = registration;
+            if (State.Draft is null || !string.Equals(State.Draft.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
+            {
+                State.BeginCreateDraft(providerId);
+            }
+        }
+        else if (State.Draft is not null)
+        {
+            // Bogus provider — drop any leftover draft so the warning alert
+            // does not silently keep the prior provider's in-flight values.
+            State.ClearDraft();
         }
 
         _crumbs = new()

--- a/src/Honua.Admin/Pages/Operator/DataConnections/DeleteConfirmDialog.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/DeleteConfirmDialog.razor
@@ -1,0 +1,38 @@
+@using MudBlazor
+
+<MudDialog>
+    <DialogContent>
+        <MudText>@ContentText</MudText>
+        <MudTextField T="string"
+                      Value="@_typed"
+                      ValueChanged="@(v => _typed = v ?? string.Empty)"
+                      Label="Type the connection name"
+                      Immediate="true"
+                      data-testid="delete-confirm-input" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" data-testid="delete-cancel">Cancel</MudButton>
+        <MudButton Color="@Color"
+                   Variant="Variant.Filled"
+                   OnClick="Confirm"
+                   Disabled="@(!string.Equals(_typed, ConfirmName, StringComparison.Ordinal))"
+                   data-testid="delete-confirm">
+            @ButtonText
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private string _typed = string.Empty;
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter] public string ContentText { get; set; } = string.Empty;
+    [Parameter] public string ButtonText { get; set; } = "Confirm";
+    [Parameter] public Color Color { get; set; } = Color.Error;
+    [Parameter] public string ConfirmName { get; set; } = string.Empty;
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Confirm() => MudDialog.Close(DialogResult.Ok(true));
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
@@ -126,9 +126,18 @@
     private Dictionary<string, object> EditFormParameters => new()
     {
         ["Draft"] = State.Draft!,
-        ["DraftChanged"] = EventCallback.Factory.Create<ConnectionDraft>(this, _ => Task.CompletedTask),
+        ["DraftChanged"] = EventCallback.Factory.Create<ConnectionDraft>(this, OnDraftChanged),
         ["IsEdit"] = true
     };
+
+    private Task OnDraftChanged(ConnectionDraft draft)
+    {
+        // Mirror Create.razor: the form mutates Draft by reference, but we still
+        // need to push a Notify() through the state so any future page-level
+        // bindings (validation, dirty indicators) re-render.
+        State.UpdateDraft(_ => { });
+        return Task.CompletedTask;
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
@@ -200,8 +200,14 @@
         var result = await dialog.Result;
         if (result is { Canceled: false })
         {
-            await State.DeleteAsync(Id);
-            Nav.NavigateTo("/operator/data-connections");
+            var deleteResult = await State.DeleteAsync(Id);
+            if (deleteResult.IsSuccess)
+            {
+                Nav.NavigateTo("/operator/data-connections");
+            }
+            // On failure, stay on the detail page so the existing detail-error
+            // alert renders State.LastError. Index.RefreshListAsync would clear
+            // it; the operator must be able to act on Conflict / NotFound here.
         }
     }
 

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
@@ -1,0 +1,230 @@
+@page "/operator/data-connections/{id:guid}"
+@using Microsoft.AspNetCore.Authorization
+@using MudBlazor
+@using Honua.Admin.Components.Shared
+@using Honua.Admin.Models.DataConnections
+@using Honua.Admin.Services.DataConnections
+@using Honua.Admin.Services.DataConnections.Providers
+@attribute [Authorize]
+@inject DataConnectionsState State
+@inject NavigationManager Nav
+@inject IDialogService Dialogs
+@implements IDisposable
+
+<PageTitle>Connection detail</PageTitle>
+
+<MudStack Spacing="3">
+    <MudBreadcrumbs Items="_crumbs" />
+
+    @if (State.LastError is { } err)
+    {
+        <MudAlert Severity="Severity.Error" data-testid="detail-error">
+            @err.CopyKey @(err.Detail is null ? string.Empty : $" — {err.Detail}")
+        </MudAlert>
+    }
+
+    @if (State.SelectedDetail is { } detail)
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h5">@detail.Name</MudText>
+            @if (!detail.IsActive)
+            {
+                <MudChip T="string" Color="Color.Warning" Size="Size.Small">disabled</MudChip>
+            }
+            <MudSpacer />
+            <MudButton Variant="Variant.Outlined"
+                       OnClick="OpenDiagnostics"
+                       StartIcon="@Icons.Material.Filled.Science"
+                       data-testid="open-diagnostics">
+                Open diagnostics
+            </MudButton>
+            @if (!_editing)
+            {
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Primary"
+                           OnClick="StartEdit"
+                           StartIcon="@Icons.Material.Filled.Edit"
+                           data-testid="start-edit">
+                    Edit
+                </MudButton>
+            }
+            <MudButton Variant="Variant.Outlined"
+                       Color="@(detail.IsActive ? Color.Warning : Color.Success)"
+                       OnClick="ToggleActive"
+                       data-testid="toggle-active">
+                @(detail.IsActive ? "Disable" : "Enable")
+            </MudButton>
+            <MudMenu Icon="@Icons.Material.Filled.MoreVert" data-testid="overflow-menu">
+                <MudMenuItem OnClick="ConfirmDelete" data-testid="overflow-delete">
+                    <MudText Color="Color.Error">Delete connection…</MudText>
+                </MudMenuItem>
+            </MudMenu>
+        </MudStack>
+
+        @if (_editing && State.Draft is not null && _editProvider is not null)
+        {
+            <MudPaper Class="pa-3" Outlined="true" data-testid="edit-form">
+                <DynamicComponent Type="@_editProvider.CreateFormComponentType"
+                                  Parameters="@EditFormParameters" />
+                <MudStack Row="true" Class="mt-3">
+                    <MudButton Variant="Variant.Outlined"
+                               OnClick="CancelEdit"
+                               data-testid="edit-cancel">
+                        Cancel
+                    </MudButton>
+                    <MudSpacer />
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               OnClick="SubmitEdit"
+                               Disabled="@_savingEdit"
+                               data-testid="edit-save">
+                        @(_savingEdit ? "Saving…" : "Save changes")
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        }
+        else
+        {
+            <MudGrid>
+                <MudItem xs="12" md="6">
+                    <MudPaper Class="pa-3" Outlined="true">
+                        <MudText Typo="Typo.h6">Endpoint</MudText>
+                        <MudText>Host: <strong>@detail.Host:@detail.Port</strong></MudText>
+                        <MudText>Database: <strong>@detail.DatabaseName</strong></MudText>
+                        <MudText>Username: <strong>@detail.Username</strong></MudText>
+                        <MudText>SSL: <strong>@(detail.SslRequired ? "required" : "optional") (@detail.SslMode)</strong></MudText>
+                    </MudPaper>
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MaskedSecretField Label="Stored credential"
+                                       StorageType="@detail.StorageType"
+                                       Hint="@(detail.CredentialReference ?? "encrypted at rest")"
+                                       TestId="detail-credential" />
+                    <MudPaper Class="pa-3 mt-3" Outlined="true">
+                        <MudText Typo="Typo.h6">Health</MudText>
+                        <MudText>Status: <strong>@detail.HealthStatus</strong></MudText>
+                        <MudText>Last checked: <strong>@(detail.LastHealthCheck?.ToString("u") ?? "never")</strong></MudText>
+                    </MudPaper>
+                </MudItem>
+            </MudGrid>
+        }
+    }
+    else
+    {
+        <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+    }
+</MudStack>
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    private List<BreadcrumbItem> _crumbs = new();
+    private bool _editing;
+    private bool _savingEdit;
+    private IProviderRegistration? _editProvider;
+
+    private Dictionary<string, object> EditFormParameters => new()
+    {
+        ["Draft"] = State.Draft!,
+        ["DraftChanged"] = EventCallback.Factory.Create<ConnectionDraft>(this, _ => Task.CompletedTask),
+        ["IsEdit"] = true
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += HandleChanged;
+        _crumbs = new()
+        {
+            new BreadcrumbItem("Data connections", "/operator/data-connections"),
+            new BreadcrumbItem("Detail", null, true)
+        };
+        await State.LoadDetailAsync(Id);
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (State.SelectedDetail?.ConnectionId != Id)
+        {
+            await State.LoadDetailAsync(Id);
+        }
+    }
+
+    private void HandleChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task ToggleActive()
+    {
+        if (State.SelectedDetail is null)
+        {
+            return;
+        }
+        var current = State.SelectedDetail.IsActive;
+        await State.SetActiveAsync(Id, !current);
+    }
+
+    private async Task ConfirmDelete()
+    {
+        var name = State.SelectedDetail?.Name ?? "this connection";
+        var parameters = new DialogParameters
+        {
+            ["ContentText"] = $"Type the connection name '{name}' to confirm. This also removes audit history on the server.",
+            ["ButtonText"] = "Delete",
+            ["Color"] = Color.Error,
+            ["ConfirmName"] = name
+        };
+        var dialog = await Dialogs.ShowAsync<DeleteConfirmDialog>("Delete connection", parameters);
+        var result = await dialog.Result;
+        if (result is { Canceled: false })
+        {
+            await State.DeleteAsync(Id);
+            Nav.NavigateTo("/operator/data-connections");
+        }
+    }
+
+    private void OpenDiagnostics() => Nav.NavigateTo($"/operator/data-connections/{Id}/diagnostics");
+
+    private void StartEdit()
+    {
+        if (State.SelectedDetail is null)
+        {
+            return;
+        }
+        if (!State.ProviderRegistry.TryGet(State.SelectedDetail.ProviderId, out var registration) || registration.IsStub)
+        {
+            // Stub providers are read-only — fall through with no edit form.
+            return;
+        }
+        _editProvider = registration;
+        State.BeginEditDraft(State.SelectedDetail);
+        _editing = true;
+    }
+
+    private void CancelEdit()
+    {
+        _editing = false;
+        _editProvider = null;
+        State.ClearDraft();
+    }
+
+    private async Task SubmitEdit()
+    {
+        _savingEdit = true;
+        try
+        {
+            var result = await State.SubmitEditAsync();
+            if (result.IsSuccess)
+            {
+                _editing = false;
+                _editProvider = null;
+            }
+        }
+        finally
+        {
+            _savingEdit = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= HandleChanged;
+    }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Detail.razor
@@ -154,7 +154,23 @@
     {
         if (State.SelectedDetail?.ConnectionId != Id)
         {
+            // Blazor reuses this component when the route id changes. Drop
+            // any in-flight edit state and any draft tied to the previous
+            // connection before loading the new detail — otherwise SubmitEdit
+            // would PUT the prior connection's draft against the new id.
+            ResetEditState();
             await State.LoadDetailAsync(Id);
+        }
+    }
+
+    private void ResetEditState()
+    {
+        _editing = false;
+        _editProvider = null;
+        _savingEdit = false;
+        if (State.Draft is { } draft && draft.ConnectionId != Id)
+        {
+            State.ClearDraft();
         }
     }
 

--- a/src/Honua.Admin/Pages/Operator/DataConnections/DiagnosticGrid.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/DiagnosticGrid.razor
@@ -1,0 +1,62 @@
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+
+<MudPaper Class="pa-3" Outlined="true" data-testid="diagnostic-grid">
+    <MudText Typo="Typo.h6">Preflight diagnostic</MudText>
+    <MudText Typo="Typo.body2" Class="text-secondary mb-3">
+        Six structured checks. <em>Not assessed</em> means the server did not return
+        a verdict for that step (server gap — see
+        <code>docs/data-connection-api-gaps.md</code>).
+    </MudText>
+    <MudSimpleTable Dense="true" Hover="true">
+        <thead>
+            <tr>
+                <th>Step</th>
+                <th>Status</th>
+                <th>Detail</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var cell in Diagnostic.Cells)
+            {
+                <tr data-testid="@($"diagnostic-row-{cell.Step.ToString().ToLowerInvariant()}")">
+                    <td>@cell.Step</td>
+                    <td>
+                        <MudChip T="string" Color="@StatusColor(cell.Status)" Size="Size.Small">
+                            @StatusLabel(cell.Status)
+                        </MudChip>
+                    </td>
+                    <td>@(cell.Detail ?? Hint(cell))</td>
+                </tr>
+            }
+        </tbody>
+    </MudSimpleTable>
+    <MudText Typo="Typo.caption" Class="mt-2">
+        Tested at @Diagnostic.RawOutcome.TestedAt.ToString("u").
+    </MudText>
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired] public ConnectionDiagnostic Diagnostic { get; set; } = default!;
+
+    private static Color StatusColor(DiagnosticStatus status) => status switch
+    {
+        DiagnosticStatus.Ok => Color.Success,
+        DiagnosticStatus.Failed => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string StatusLabel(DiagnosticStatus status) => status switch
+    {
+        DiagnosticStatus.Ok => "OK",
+        DiagnosticStatus.Failed => "Failed",
+        _ => "Not assessed"
+    };
+
+    private static string Hint(DiagnosticCell cell) => cell.Status switch
+    {
+        DiagnosticStatus.NotAssessed => "Awaiting structured server response (see gap report).",
+        DiagnosticStatus.Ok => string.Empty,
+        _ => string.Empty
+    };
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Diagnostics.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Diagnostics.razor
@@ -1,0 +1,130 @@
+@page "/operator/data-connections/{id:guid}/diagnostics"
+@using Microsoft.AspNetCore.Authorization
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+@using Honua.Admin.Services.DataConnections
+@using Honua.Admin.Services.DataConnections.Providers
+@attribute [Authorize]
+@inject DataConnectionsState State
+@inject NavigationManager Nav
+@implements IDisposable
+
+<PageTitle>Connection diagnostics</PageTitle>
+
+<MudStack Spacing="3">
+    <MudBreadcrumbs Items="_crumbs" />
+
+    @if (State.LastError is { } err)
+    {
+        <MudAlert Severity="Severity.Error" data-testid="diag-error">
+            @err.CopyKey @(err.Detail is null ? string.Empty : $" — {err.Detail}")
+        </MudAlert>
+    }
+
+    @if (State.SelectedDetail is { } detail)
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h5">Diagnostics — @detail.Name</MudText>
+            <MudSpacer />
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="RunPreflight"
+                       Disabled="@_running"
+                       data-testid="run-preflight">
+                @(_running ? "Running…" : "Run preflight")
+            </MudButton>
+        </MudStack>
+
+        <MudText Typo="Typo.body2" Class="text-secondary">
+            Preflight is read-only — only metadata + permission probes; no DDL or
+            schema mutations are issued.
+        </MudText>
+
+        @if (State.LatestDiagnostic is { } diagnostic)
+        {
+            <DiagnosticGrid Diagnostic="diagnostic" />
+        }
+
+        @if (_provider is not null)
+        {
+            <DynamicComponent Type="@_provider.CapabilityRendererComponentType"
+                              Parameters="@MatrixParameters" />
+        }
+    }
+    else
+    {
+        <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+    }
+</MudStack>
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    private IProviderRegistration? _provider;
+    private bool _running;
+    private List<BreadcrumbItem> _crumbs = new();
+    private ProviderCapabilityMatrix? _matrix;
+
+    private Dictionary<string, object> MatrixParameters => new()
+    {
+        ["Matrix"] = _matrix!
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += HandleChanged;
+        _crumbs = new()
+        {
+            new BreadcrumbItem("Data connections", "/operator/data-connections"),
+            new BreadcrumbItem("Diagnostics", null, true)
+        };
+
+        if (State.SelectedDetail?.ConnectionId != Id)
+        {
+            await State.LoadDetailAsync(Id);
+        }
+        ResolveProvider();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (State.SelectedDetail?.ConnectionId != Id)
+        {
+            await State.LoadDetailAsync(Id);
+        }
+        ResolveProvider();
+    }
+
+    private void ResolveProvider()
+    {
+        if (State.SelectedDetail is null)
+        {
+            return;
+        }
+        if (State.ProviderRegistry.TryGet(State.SelectedDetail.ProviderId, out var registration))
+        {
+            _provider = registration;
+            _matrix = State.GetCapabilityMatrix(registration.ProviderId);
+        }
+    }
+
+    private void HandleChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task RunPreflight()
+    {
+        _running = true;
+        try
+        {
+            await State.RunExistingPreflightAsync(Id);
+        }
+        finally
+        {
+            _running = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= HandleChanged;
+    }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Index.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Index.razor
@@ -1,0 +1,121 @@
+@page "/operator/data-connections"
+@using Microsoft.AspNetCore.Authorization
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+@using Honua.Admin.Services.DataConnections
+@using Honua.Admin.Services.DataConnections.Providers
+@attribute [Authorize]
+@inject DataConnectionsState State
+@inject NavigationManager Nav
+@implements IDisposable
+
+<PageTitle>Data connections</PageTitle>
+
+<MudStack Spacing="3">
+    <MudStack Row="true" AlignItems="AlignItems.Center">
+        <MudText Typo="Typo.h4">Data connections</MudText>
+        <MudSpacer />
+        <MudMenu Label="New connection"
+                 Icon="@Icons.Material.Filled.Add"
+                 Color="Color.Primary"
+                 Variant="Variant.Filled"
+                 EndIcon="@Icons.Material.Filled.ArrowDropDown"
+                 data-testid="new-connection-menu">
+            @foreach (var provider in State.ProviderRegistry.All)
+            {
+                <MudMenuItem OnClick="@(() => StartCreate(provider.ProviderId))"
+                             data-testid="@($"new-connection-{provider.ProviderId}")">
+                    @provider.DisplayName
+                    @if (provider.IsStub)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Default" Class="ml-2">stub</MudChip>
+                    }
+                </MudMenuItem>
+            }
+        </MudMenu>
+    </MudStack>
+
+    @if (State.LastError is { } err)
+    {
+        <MudAlert Severity="Severity.Error" data-testid="list-error">
+            @err.CopyKey @(err.Detail is null ? string.Empty : $" — {err.Detail}")
+        </MudAlert>
+    }
+
+    @if (State.Status == WorkspaceListStatus.Loading)
+    {
+        <MudProgressCircular Indeterminate="true" Size="Size.Small" data-testid="list-loading" />
+    }
+    else if (State.Connections.Count == 0)
+    {
+        <MudPaper Class="pa-6" Outlined="true" data-testid="empty-list">
+            <MudText Typo="Typo.h6">No data connections yet</MudText>
+            <MudText Typo="Typo.body2" Class="text-secondary">
+                Pick a provider from <em>New connection</em> to register the first one.
+            </MudText>
+        </MudPaper>
+    }
+    else
+    {
+        <MudTable Items="State.Connections" Hover="true" Dense="true" data-testid="connections-table">
+            <HeaderContent>
+                <MudTh>Name</MudTh>
+                <MudTh>Provider</MudTh>
+                <MudTh>Host</MudTh>
+                <MudTh>Status</MudTh>
+                <MudTh>Last checked</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd data-testid="@($"row-name-{context.ConnectionId}")">
+                    <MudLink OnClick="@(() => OpenDetail(context.ConnectionId))">@context.Name</MudLink>
+                    @if (!context.IsActive)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Class="ml-2">disabled</MudChip>
+                    }
+                </MudTd>
+                <MudTd>@context.ProviderId</MudTd>
+                <MudTd>@context.Host:@context.Port</MudTd>
+                <MudTd>
+                    <MudChip T="string"
+                             Color="@(context.HealthStatus == "healthy" ? Color.Success : context.HealthStatus == "unhealthy" ? Color.Error : Color.Default)"
+                             Size="Size.Small">
+                        @context.HealthStatus
+                    </MudChip>
+                </MudTd>
+                <MudTd>@(context.LastHealthCheck?.ToString("u") ?? "—")</MudTd>
+                <MudTd>
+                    <MudIconButton Icon="@Icons.Material.Filled.Science"
+                                   aria-label="Open diagnostics"
+                                   OnClick="@(() => OpenDiagnostics(context.ConnectionId))"
+                                   data-testid="@($"row-diag-{context.ConnectionId}")" />
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</MudStack>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += HandleChanged;
+        await State.RefreshListAsync();
+    }
+
+    private void HandleChanged() => InvokeAsync(StateHasChanged);
+
+    private void StartCreate(string providerId)
+    {
+        State.BeginCreateDraft(providerId);
+        Nav.NavigateTo($"/operator/data-connections/new?provider={providerId}");
+    }
+
+    private void OpenDetail(Guid id) => Nav.NavigateTo($"/operator/data-connections/{id}");
+
+    private void OpenDiagnostics(Guid id) => Nav.NavigateTo($"/operator/data-connections/{id}/diagnostics");
+
+    public void Dispose()
+    {
+        State.OnChanged -= HandleChanged;
+    }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Index.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Index.razor
@@ -78,7 +78,7 @@
                 <MudTd>@context.Host:@context.Port</MudTd>
                 <MudTd>
                     <MudChip T="string"
-                             Color="@(context.HealthStatus == "healthy" ? Color.Success : context.HealthStatus == "unhealthy" ? Color.Error : Color.Default)"
+                             Color="@HealthChipColor(context.HealthStatus)"
                              Size="Size.Small">
                         @context.HealthStatus
                     </MudChip>
@@ -113,6 +113,16 @@
     private void OpenDetail(Guid id) => Nav.NavigateTo($"/operator/data-connections/{id}");
 
     private void OpenDiagnostics(Guid id) => Nav.NavigateTo($"/operator/data-connections/{id}/diagnostics");
+
+    // honua-server returns HealthStatus as enum.ToString() ("Healthy", "Warning",
+    // "Unhealthy", "Unknown"); the stub uses lowercase. Normalize both sides.
+    private static Color HealthChipColor(string? status) => status?.Trim().ToLowerInvariant() switch
+    {
+        "healthy" => Color.Success,
+        "unhealthy" => Color.Error,
+        "warning" => Color.Warning,
+        _ => Color.Default
+    };
 
     public void Dispose()
     {

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Providers/PostgresCapabilityRenderer.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Providers/PostgresCapabilityRenderer.razor
@@ -1,0 +1,58 @@
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+
+<MudPaper Class="pa-3" Outlined="true" data-testid="capability-matrix-postgres">
+    <MudText Typo="Typo.h6">Managed Postgres certification matrix</MudText>
+    <MudText Typo="Typo.body2" Class="text-secondary mb-3">
+        Aurora &amp; Azure DB checks. Cells marked <em>Not assessed</em> need
+        <code>honua-server#644</code> to land before they can render a verdict.
+    </MudText>
+    <MudSimpleTable Dense="true" Hover="true">
+        <thead>
+            <tr>
+                <th>Check</th>
+                <th>Category</th>
+                <th>Status</th>
+                <th>Detail</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var check in Matrix.Checks)
+            {
+                <tr data-testid="@($"capability-row-{check.CheckId}")">
+                    <td>@check.DisplayName</td>
+                    <td>@check.Category</td>
+                    <td>
+                        <MudChip T="string" Color="@StatusColor(check.Status)" Size="Size.Small">
+                            @StatusLabel(check.Status)
+                        </MudChip>
+                    </td>
+                    <td>@(check.Detail ?? RemediationCopy(check))</td>
+                </tr>
+            }
+        </tbody>
+    </MudSimpleTable>
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired] public ProviderCapabilityMatrix Matrix { get; set; } = default!;
+
+    private static Color StatusColor(DiagnosticStatus status) => status switch
+    {
+        DiagnosticStatus.Ok => Color.Success,
+        DiagnosticStatus.Failed => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string StatusLabel(DiagnosticStatus status) => status switch
+    {
+        DiagnosticStatus.Ok => "Pass",
+        DiagnosticStatus.Failed => "Fail",
+        _ => "Not assessed"
+    };
+
+    private static string RemediationCopy(CapabilityCheck check) =>
+        check.Status == DiagnosticStatus.NotAssessed
+            ? "Awaiting honua-server#644 — server does not yet expose this signal."
+            : check.RemediationKey;
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Providers/PostgresConnectionForm.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Providers/PostgresConnectionForm.razor
@@ -3,6 +3,9 @@
 @using Honua.Admin.Models.DataConnections
 
 <MudGrid>
+    @* Display name is fixed once a connection is created — the server's
+       UpdateSecureConnectionRequest has no Name field, so we render it
+       read-only in edit mode rather than silently dropping operator input. *@
     <MudItem xs="12" md="6">
         <MudTextField T="string"
                       Label="Display name"
@@ -10,6 +13,9 @@
                       ValueChanged="@(v => Update(d => d.Name = v ?? string.Empty))"
                       Required="true"
                       Immediate="true"
+                      ReadOnly="@IsEdit"
+                      Disabled="@IsEdit"
+                      HelperText="@(IsEdit ? "Display name is fixed after creation." : null)"
                       data-testid="conn-name" />
     </MudItem>
     <MudItem xs="12" md="6">
@@ -54,13 +60,28 @@
                       data-testid="conn-username" />
     </MudItem>
 
+    @* Credential mode and external-secret bindings are creation-only:
+       the server's UpdateSecureConnectionRequest accepts a new Password
+       (re-encryption) but has no SecretReference / SecretType fields, so
+       switching modes or rotating an external reference is not honored
+       on PUT. Lock the radio group in edit mode and only expose the
+       managed-credential rotate field. Operators who need to switch
+       modes today must delete and recreate. *@
     <MudItem xs="12">
         <MudRadioGroup T="CredentialMode"
                        Value="@Draft.CredentialMode"
-                       ValueChanged="@(m => Update(d => d.CredentialMode = m))">
+                       ValueChanged="@(m => Update(d => d.CredentialMode = m))"
+                       ReadOnly="@IsEdit"
+                       Disabled="@IsEdit">
             <MudRadio Value="@CredentialMode.Managed" data-testid="conn-mode-managed">Managed (encrypted at rest)</MudRadio>
             <MudRadio Value="@CredentialMode.External" data-testid="conn-mode-external">External secret reference</MudRadio>
         </MudRadioGroup>
+        @if (IsEdit)
+        {
+            <MudText Typo="Typo.caption" Class="text-secondary" data-testid="conn-mode-edit-help">
+                Credential mode is fixed after creation. Delete and recreate to switch.
+            </MudText>
+        }
     </MudItem>
 
     @if (Draft.CredentialMode == CredentialMode.Managed)
@@ -74,7 +95,7 @@
                                TestId="conn-password" />
         </MudItem>
     }
-    else
+    else if (!IsEdit)
     {
         <MudItem xs="12" md="8">
             <MudTextField T="string"
@@ -91,6 +112,22 @@
                           ValueChanged="@(v => Update(d => d.SecretType = v))"
                           HelperText="aws | azure | vault"
                           data-testid="conn-secret-type" />
+        </MudItem>
+    }
+    else
+    {
+        @* External-mode edit: the secret reference is set at creation and
+           cannot be rotated through the current update contract. Display
+           it read-only so operators see what is stored without having a
+           Save button that silently drops the change. *@
+        <MudItem xs="12" md="8">
+            <MudTextField T="string"
+                          Label="Secret reference"
+                          Value="@Draft.SecretReference"
+                          ReadOnly="true"
+                          Disabled="true"
+                          HelperText="Stored secret reference is fixed after creation."
+                          data-testid="conn-secret-ref" />
         </MudItem>
     }
 

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Providers/PostgresConnectionForm.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Providers/PostgresConnectionForm.razor
@@ -1,0 +1,131 @@
+@using MudBlazor
+@using Honua.Admin.Components.Shared
+@using Honua.Admin.Models.DataConnections
+
+<MudGrid>
+    <MudItem xs="12" md="6">
+        <MudTextField T="string"
+                      Label="Display name"
+                      Value="@Draft.Name"
+                      ValueChanged="@(v => Update(d => d.Name = v ?? string.Empty))"
+                      Required="true"
+                      Immediate="true"
+                      data-testid="conn-name" />
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudTextField T="string"
+                      Label="Description"
+                      Value="@Draft.Description"
+                      ValueChanged="@(v => Update(d => d.Description = v))"
+                      data-testid="conn-description" />
+    </MudItem>
+    <MudItem xs="12" md="8">
+        <MudTextField T="string"
+                      Label="Host"
+                      Value="@Draft.Host"
+                      ValueChanged="@(v => Update(d => d.Host = v ?? string.Empty))"
+                      Required="true"
+                      Immediate="true"
+                      data-testid="conn-host" />
+    </MudItem>
+    <MudItem xs="12" md="4">
+        <MudNumericField T="int"
+                         Label="Port"
+                         Value="@Draft.Port"
+                         ValueChanged="@(v => Update(d => d.Port = v))"
+                         Min="1"
+                         Max="65535"
+                         data-testid="conn-port" />
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudTextField T="string"
+                      Label="Database"
+                      Value="@Draft.DatabaseName"
+                      ValueChanged="@(v => Update(d => d.DatabaseName = v ?? string.Empty))"
+                      Required="true"
+                      data-testid="conn-database" />
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudTextField T="string"
+                      Label="Username"
+                      Value="@Draft.Username"
+                      ValueChanged="@(v => Update(d => d.Username = v ?? string.Empty))"
+                      Required="true"
+                      data-testid="conn-username" />
+    </MudItem>
+
+    <MudItem xs="12">
+        <MudRadioGroup T="CredentialMode"
+                       Value="@Draft.CredentialMode"
+                       ValueChanged="@(m => Update(d => d.CredentialMode = m))">
+            <MudRadio Value="@CredentialMode.Managed" data-testid="conn-mode-managed">Managed (encrypted at rest)</MudRadio>
+            <MudRadio Value="@CredentialMode.External" data-testid="conn-mode-external">External secret reference</MudRadio>
+        </MudRadioGroup>
+    </MudItem>
+
+    @if (Draft.CredentialMode == CredentialMode.Managed)
+    {
+        <MudItem xs="12" md="8">
+            <MaskedSecretInput Label="Password"
+                               Value="@Draft.Password"
+                               ValueChanged="@(v => Update(d => d.Password = v))"
+                               Required="@(!IsEdit)"
+                               HelperText="@(IsEdit ? "Leave blank to keep the existing password" : null)"
+                               TestId="conn-password" />
+        </MudItem>
+    }
+    else
+    {
+        <MudItem xs="12" md="8">
+            <MudTextField T="string"
+                          Label="Secret reference"
+                          Value="@Draft.SecretReference"
+                          ValueChanged="@(v => Update(d => d.SecretReference = v))"
+                          HelperText="Format: provider:path (e.g., aws:secretsmanager:prod-db-creds)"
+                          data-testid="conn-secret-ref" />
+        </MudItem>
+        <MudItem xs="12" md="4">
+            <MudTextField T="string"
+                          Label="Secret type"
+                          Value="@Draft.SecretType"
+                          ValueChanged="@(v => Update(d => d.SecretType = v))"
+                          HelperText="aws | azure | vault"
+                          data-testid="conn-secret-type" />
+        </MudItem>
+    }
+
+    <MudItem xs="12" md="6">
+        <MudSwitch T="bool"
+                   Value="@Draft.SslRequired"
+                   ValueChanged="@(v => Update(d => d.SslRequired = v))"
+                   Label="SSL required"
+                   Color="Color.Primary"
+                   data-testid="conn-ssl-required" />
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudSelect T="string"
+                   Label="SSL mode"
+                   Value="@Draft.SslMode"
+                   ValueChanged="@(v => Update(d => d.SslMode = v ?? "Require"))"
+                   data-testid="conn-ssl-mode">
+            <MudSelectItem Value="@("Disable")">Disable</MudSelectItem>
+            <MudSelectItem Value="@("Allow")">Allow</MudSelectItem>
+            <MudSelectItem Value="@("Prefer")">Prefer</MudSelectItem>
+            <MudSelectItem Value="@("Require")">Require</MudSelectItem>
+            <MudSelectItem Value="@("VerifyCa")">VerifyCa</MudSelectItem>
+            <MudSelectItem Value="@("VerifyFull")">VerifyFull</MudSelectItem>
+        </MudSelect>
+    </MudItem>
+</MudGrid>
+
+@code {
+    [Parameter, EditorRequired] public ConnectionDraft Draft { get; set; } = default!;
+    [Parameter] public EventCallback<ConnectionDraft> DraftChanged { get; set; }
+    [Parameter] public bool IsEdit { get; set; }
+
+    private async Task Update(Action<ConnectionDraft> mutate)
+    {
+        mutate(Draft);
+        await DraftChanged.InvokeAsync(Draft);
+    }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Providers/StubCapabilityRenderer.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Providers/StubCapabilityRenderer.razor
@@ -1,0 +1,11 @@
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+
+<MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="stub-capability-renderer">
+    Capability matrix for <strong>@(Matrix?.ProviderId ?? "this provider")</strong>
+    is empty until concrete server support ships.
+</MudAlert>
+
+@code {
+    [Parameter] public ProviderCapabilityMatrix? Matrix { get; set; }
+}

--- a/src/Honua.Admin/Pages/Operator/DataConnections/Providers/StubProviderForm.razor
+++ b/src/Honua.Admin/Pages/Operator/DataConnections/Providers/StubProviderForm.razor
@@ -1,0 +1,18 @@
+@using MudBlazor
+@using Honua.Admin.Models.DataConnections
+
+<MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="stub-provider-form">
+    <MudText Typo="Typo.h6">@DisplayName provider is registered but not yet available</MudText>
+    <MudText Typo="Typo.body2">
+        The pluggable registration is wired so the workspace recognizes
+        @DisplayName today. Concrete create-form support arrives when
+        <code>honua-server#362</code> ships server-side multi-database support.
+    </MudText>
+</MudAlert>
+
+@code {
+    [Parameter] public string DisplayName { get; set; } = "this provider";
+    [Parameter] public ConnectionDraft? Draft { get; set; }
+    [Parameter] public EventCallback<ConnectionDraft> DraftChanged { get; set; }
+    [Parameter] public bool IsEdit { get; set; }
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -1,4 +1,6 @@
 using Honua.Admin;
+using Honua.Admin.Services.DataConnections;
+using Honua.Admin.Services.DataConnections.Providers;
 using Honua.Admin.Services.Identity;
 using Honua.Admin.Services.LicenseWorkspace;
 using Honua.Admin.Services.SpatialSql;
@@ -91,6 +93,39 @@ builder.Services.AddHttpClient<ILicenseWorkspaceClient, HttpLicenseWorkspaceClie
     }
 });
 builder.Services.AddScoped<LicenseWorkspaceState>();
+
+// Data connections workspace services (ticket #24). HttpDataConnectionClient
+// is the default; StubDataConnectionClient stays available for tests. Mirrors
+// the identity / license HonuaServer:BaseUrl + Development-only X-API-Key
+// handling so the workspace targets the real server, not the WASM host.
+builder.Services.AddSingleton<IProviderRegistration, PostgresProviderRegistration>();
+builder.Services.AddSingleton<IProviderRegistration, SqlServerStubProviderRegistration>();
+builder.Services.AddSingleton<IProviderRegistry, ProviderRegistry>();
+builder.Services.AddScoped<IDataConnectionTelemetry, LoggingDataConnectionTelemetry>();
+builder.Services.AddHttpClient<IDataConnectionClient, HttpDataConnectionClient>(client =>
+{
+    var baseUrl = builder.Configuration["HonuaServer:BaseUrl"];
+    client.BaseAddress = !string.IsNullOrWhiteSpace(baseUrl)
+        ? new Uri(baseUrl)
+        : new Uri(builder.HostEnvironment.BaseAddress);
+
+    var apiKey = builder.Configuration["HonuaServer:ApiKey"];
+    if (!string.IsNullOrWhiteSpace(apiKey))
+    {
+        if (builder.HostEnvironment.IsDevelopment())
+        {
+            client.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                "[Honua.Admin] HonuaServer:ApiKey is set in a non-Development build. " +
+                "Refusing to forward it from the browser. Front the admin UI with a same-origin " +
+                "BFF that injects credentials server-side.");
+        }
+    }
+});
+builder.Services.AddScoped<DataConnectionsState>();
 
 // Dev auth scaffold — replaced once the real admin auth provider lands.
 builder.Services.AddAuthorizationCore();

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -109,6 +109,8 @@ builder.Services.AddHttpClient<IDataConnectionClient, HttpDataConnectionClient>(
         ? new Uri(baseUrl)
         : new Uri(builder.HostEnvironment.BaseAddress);
 
+    // X-API-Key handling mirrors the identity client: dev-only forwarding,
+    // production must front the admin UI with a same-origin BFF.
     var apiKey = builder.Configuration["HonuaServer:ApiKey"];
     if (!string.IsNullOrWhiteSpace(apiKey))
     {

--- a/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
+++ b/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
@@ -44,6 +44,7 @@ public sealed class DataConnectionsState
     private int _detailGeneration;
     private int _preflightGeneration;
     private int _listGeneration;
+    private int _draftGeneration;
 
     // The user-intended owner of SelectedDetail. LoadDetailAsync sets it to
     // its incoming route id; user-driven clears (BeginCreateDraft, DeleteAsync
@@ -137,6 +138,7 @@ public sealed class DataConnectionsState
         // prior connection's data over the new draft.
         _detailGeneration++;
         _preflightGeneration++;
+        _draftGeneration++;
         _selectedConnectionId = null;
         Notify();
 
@@ -158,6 +160,13 @@ public sealed class DataConnectionsState
             return;
         }
         mutate(Draft);
+        LatestDiagnostic = null;
+        _preflightGeneration++;
+        _draftGeneration++;
+        if (Status == WorkspaceListStatus.Testing)
+        {
+            Status = WorkspaceListStatus.Idle;
+        }
         Notify();
     }
 
@@ -168,6 +177,11 @@ public sealed class DataConnectionsState
         // Supersede any in-flight draft preflight so its result cannot repaint
         // the diagnostic grid after the user has cancelled the create flow.
         _preflightGeneration++;
+        _draftGeneration++;
+        if (Status == WorkspaceListStatus.Testing)
+        {
+            Status = WorkspaceListStatus.Idle;
+        }
         Notify();
     }
 
@@ -179,7 +193,9 @@ public sealed class DataConnectionsState
                 new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
         }
 
-        var providerId = Draft.ProviderId;
+        var draft = Draft;
+        var draftGeneration = _draftGeneration;
+        var providerId = draft.ProviderId;
 
         Status = WorkspaceListStatus.Mutating;
         LastError = null;
@@ -190,8 +206,13 @@ public sealed class DataConnectionsState
             ["provider"] = providerId
         });
 
-        var request = ToCreateRequest(Draft);
+        var request = ToCreateRequest(draft);
         var result = await _client.CreateAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!IsCurrentDraft(draft, draftGeneration))
+        {
+            return DropStaleDraftSubmit<DataConnectionSummary>();
+        }
 
         if (!result.IsSuccess)
         {
@@ -210,6 +231,10 @@ public sealed class DataConnectionsState
         var summary = result.Value!;
         _connections.Add(summary);
         await TryRefreshSelectedDetailAsync(summary.ConnectionId, cancellationToken).ConfigureAwait(false);
+        if (!IsCurrentDraft(draft, draftGeneration))
+        {
+            return DropStaleDraftSubmit<DataConnectionSummary>();
+        }
         Draft = null;
         LatestDiagnostic = null;
         // Mutating-success clears LatestDiagnostic — supersede any in-flight
@@ -320,6 +345,13 @@ public sealed class DataConnectionsState
             SecretReference = detail.CredentialReference,
             IsActive = detail.IsActive
         };
+        LatestDiagnostic = null;
+        _preflightGeneration++;
+        _draftGeneration++;
+        if (Status == WorkspaceListStatus.Testing)
+        {
+            Status = WorkspaceListStatus.Idle;
+        }
         Notify();
         return Draft;
     }
@@ -332,26 +364,35 @@ public sealed class DataConnectionsState
                 new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
         }
 
+        var draft = Draft;
+        var draftGeneration = _draftGeneration;
+        var connectionId = draft.ConnectionId.Value;
+
         Status = WorkspaceListStatus.Mutating;
         LastError = null;
         Notify();
 
         var request = new UpdateConnectionRequest
         {
-            Description = Draft.Description,
-            Host = Draft.Host,
-            Port = Draft.Port,
-            DatabaseName = Draft.DatabaseName,
-            Username = Draft.Username,
-            Password = Draft.CredentialMode == CredentialMode.Managed && !string.IsNullOrEmpty(Draft.Password)
-                ? Draft.Password
+            Description = draft.Description,
+            Host = draft.Host,
+            Port = draft.Port,
+            DatabaseName = draft.DatabaseName,
+            Username = draft.Username,
+            Password = draft.CredentialMode == CredentialMode.Managed && !string.IsNullOrEmpty(draft.Password)
+                ? draft.Password
                 : null,
-            SslRequired = Draft.SslRequired,
-            SslMode = Draft.SslMode,
-            IsActive = Draft.IsActive
+            SslRequired = draft.SslRequired,
+            SslMode = draft.SslMode,
+            IsActive = draft.IsActive
         };
 
-        var result = await _client.UpdateAsync(Draft.ConnectionId.Value, request, cancellationToken).ConfigureAwait(false);
+        var result = await _client.UpdateAsync(connectionId, request, cancellationToken).ConfigureAwait(false);
+
+        if (!IsCurrentDraft(draft, draftGeneration))
+        {
+            return DropStaleDraftSubmit<DataConnectionSummary>();
+        }
 
         if (!result.IsSuccess)
         {
@@ -359,7 +400,7 @@ public sealed class DataConnectionsState
             LastError = result.Error;
             _telemetry.Record("data_connections.update_failed", new Dictionary<string, object?>
             {
-                ["connection_id"] = Draft.ConnectionId,
+                ["connection_id"] = connectionId,
                 ["failure_code"] = result.Error!.Kind.ToString()
             });
             Notify();
@@ -369,6 +410,10 @@ public sealed class DataConnectionsState
         var summary = result.Value!;
         ReplaceInList(summary);
         await TryRefreshSelectedDetailAsync(summary.ConnectionId, cancellationToken).ConfigureAwait(false);
+        if (!IsCurrentDraft(draft, draftGeneration))
+        {
+            return DropStaleDraftSubmit<DataConnectionSummary>();
+        }
         Draft = null;
         LatestDiagnostic = null;
         // Mutating-success clears LatestDiagnostic — supersede any in-flight
@@ -427,6 +472,8 @@ public sealed class DataConnectionsState
             return null;
         }
 
+        var draft = Draft;
+        var draftGeneration = _draftGeneration;
         var generation = ++_preflightGeneration;
         Status = WorkspaceListStatus.Testing;
         LastError = null;
@@ -435,15 +482,15 @@ public sealed class DataConnectionsState
         _telemetry.Record("data_connections.test_started", new Dictionary<string, object?>
         {
             ["mode"] = "draft",
-            ["provider"] = Draft.ProviderId
+            ["provider"] = draft.ProviderId
         });
 
         var watch = Stopwatch.StartNew();
-        var request = ToCreateRequest(Draft);
+        var request = ToCreateRequest(draft);
         var result = await _client.TestDraftAsync(request, cancellationToken).ConfigureAwait(false);
         watch.Stop();
 
-        return CompletePreflight(result, detail: null, watch.ElapsedMilliseconds, generation);
+        return CompletePreflight(result, detail: null, watch.ElapsedMilliseconds, generation, draft, draftGeneration);
     }
 
     public async Task<ConnectionDiagnostic?> RunExistingPreflightAsync(Guid id, CancellationToken cancellationToken = default)
@@ -466,13 +513,25 @@ public sealed class DataConnectionsState
         return CompletePreflight(result, SelectedDetail, watch.ElapsedMilliseconds, generation);
     }
 
-    private ConnectionDiagnostic? CompletePreflight(ConnectionResult<ConnectionTestOutcome> result, DataConnectionDetail? detail, long elapsedMs, int generation)
+    private ConnectionDiagnostic? CompletePreflight(
+        ConnectionResult<ConnectionTestOutcome> result,
+        DataConnectionDetail? detail,
+        long elapsedMs,
+        int generation,
+        ConnectionDraft? draft = null,
+        int draftGeneration = 0)
     {
         if (generation != _preflightGeneration)
         {
             // A newer preflight (or user-driven supersede) has taken ownership
             // of LatestDiagnostic. Drop this stale outcome so it cannot
             // overwrite the current connection's grid with the prior one's.
+            return null;
+        }
+        if (draft is not null && !IsCurrentDraft(draft, draftGeneration))
+        {
+            Status = WorkspaceListStatus.Idle;
+            Notify();
             return null;
         }
 
@@ -573,6 +632,21 @@ public sealed class DataConnectionsState
         {
             SelectedDetail = result.Value;
         }
+    }
+
+    private bool IsCurrentDraft(ConnectionDraft draft, int generation) =>
+        ReferenceEquals(Draft, draft) && _draftGeneration == generation;
+
+    private ConnectionResult<T> DropStaleDraftSubmit<T>()
+    {
+        if (Status == WorkspaceListStatus.Mutating)
+        {
+            Status = WorkspaceListStatus.Idle;
+            Notify();
+        }
+
+        return ConnectionResult<T>.Fail(
+            new ConnectionOperationError(ConnectionErrorKind.Validation, "error.stale_draft"));
     }
 
     private void ReplaceInList(DataConnectionSummary summary)

--- a/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
+++ b/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
@@ -34,6 +34,27 @@ public sealed class DataConnectionsState
 
     private readonly List<DataConnectionSummary> _connections = new();
 
+    // Per-slot monotonic generations. Any async load that completes after a
+    // newer operation (load/test/refresh) — or after a user action that
+    // explicitly cleared the slot (BeginCreateDraft, ClearDraft, DeleteAsync,
+    // mutating-success clears) — must drop its post-await writes. Without
+    // these, a slow response for connection A can overwrite SelectedDetail /
+    // LatestDiagnostic that the user has since switched to connection B.
+    // Blazor WASM is single-threaded, so plain int increments are atomic.
+    private int _detailGeneration;
+    private int _preflightGeneration;
+    private int _listGeneration;
+
+    // The user-intended owner of SelectedDetail. LoadDetailAsync sets it to
+    // its incoming route id; user-driven clears (BeginCreateDraft, DeleteAsync
+    // matching the current selection) reset it to null. TryRefreshSelectedDetailAsync
+    // — a follower called after mutating endpoints — checks this snapshot post-await
+    // so a route change mid-flight cannot resurrect the just-edited row over
+    // the new selection. The generation counter alone is not enough here:
+    // TryRefresh starts AFTER the new LoadDetail has bumped, so a pure-counter
+    // model would let TryRefresh's stale write through.
+    private Guid? _selectedConnectionId;
+
     public DataConnectionsState(IDataConnectionClient client, IDataConnectionTelemetry telemetry, IProviderRegistry registry)
     {
         _client = client;
@@ -59,6 +80,7 @@ public sealed class DataConnectionsState
 
     public async Task RefreshListAsync(CancellationToken cancellationToken = default)
     {
+        var generation = ++_listGeneration;
         Status = WorkspaceListStatus.Loading;
         LastError = null;
         Notify();
@@ -66,6 +88,13 @@ public sealed class DataConnectionsState
         var watch = Stopwatch.StartNew();
         var result = await _client.ListAsync(cancellationToken).ConfigureAwait(false);
         watch.Stop();
+
+        if (generation != _listGeneration)
+        {
+            // A newer refresh has taken ownership — drop this stale list so it
+            // cannot stomp the fresher snapshot or undo a concurrent mutation.
+            return;
+        }
 
         if (!result.IsSuccess)
         {
@@ -103,6 +132,12 @@ public sealed class DataConnectionsState
         };
         SelectedDetail = null;
         LatestDiagnostic = null;
+        // User explicitly switched to "create new" — supersede any in-flight
+        // detail load or preflight test so a late response cannot resurrect the
+        // prior connection's data over the new draft.
+        _detailGeneration++;
+        _preflightGeneration++;
+        _selectedConnectionId = null;
         Notify();
 
         if (registration.IsStub)
@@ -130,6 +165,9 @@ public sealed class DataConnectionsState
     {
         Draft = null;
         LatestDiagnostic = null;
+        // Supersede any in-flight draft preflight so its result cannot repaint
+        // the diagnostic grid after the user has cancelled the create flow.
+        _preflightGeneration++;
         Notify();
     }
 
@@ -174,6 +212,9 @@ public sealed class DataConnectionsState
         await TryRefreshSelectedDetailAsync(summary.ConnectionId, cancellationToken).ConfigureAwait(false);
         Draft = null;
         LatestDiagnostic = null;
+        // Mutating-success clears LatestDiagnostic — supersede any in-flight
+        // preflight so its post-await write cannot repaint the grid.
+        _preflightGeneration++;
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record("data_connections.create_succeeded", new Dictionary<string, object?>
         {
@@ -186,6 +227,8 @@ public sealed class DataConnectionsState
 
     public async Task LoadDetailAsync(Guid id, CancellationToken cancellationToken = default)
     {
+        var generation = ++_detailGeneration;
+        _selectedConnectionId = id;
         if (SelectedDetail?.ConnectionId != id)
         {
             // Navigating to a different connection — clear the prior selection
@@ -195,12 +238,23 @@ public sealed class DataConnectionsState
             // does not blank the page.
             SelectedDetail = null;
             LatestDiagnostic = null;
+            // Switching connections also invalidates any in-flight preflight
+            // for the prior id.
+            _preflightGeneration++;
         }
         Status = WorkspaceListStatus.Loading;
         LastError = null;
         Notify();
 
         var result = await _client.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (generation != _detailGeneration)
+        {
+            // A newer load (or user-driven supersede) has taken ownership of
+            // SelectedDetail. Drop this stale response so it cannot overwrite
+            // the current connection's data with the prior one's.
+            return;
+        }
+
         if (!result.IsSuccess)
         {
             Status = WorkspaceListStatus.Error;
@@ -235,6 +289,10 @@ public sealed class DataConnectionsState
         ReplaceInList(result.Value!);
         await TryRefreshSelectedDetailAsync(id, cancellationToken).ConfigureAwait(false);
         LatestDiagnostic = null;
+        // Mutating-success clears LatestDiagnostic — supersede any in-flight
+        // preflight so its post-await write cannot repaint the grid against
+        // the freshly-toggled connection state.
+        _preflightGeneration++;
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record(active ? "data_connections.enabled" : "data_connections.disabled", new Dictionary<string, object?>
         {
@@ -313,6 +371,10 @@ public sealed class DataConnectionsState
         await TryRefreshSelectedDetailAsync(summary.ConnectionId, cancellationToken).ConfigureAwait(false);
         Draft = null;
         LatestDiagnostic = null;
+        // Mutating-success clears LatestDiagnostic — supersede any in-flight
+        // preflight so its post-await write cannot repaint the grid against
+        // the freshly-edited connection state.
+        _preflightGeneration++;
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record("data_connections.update_succeeded", new Dictionary<string, object?>
         {
@@ -342,6 +404,12 @@ public sealed class DataConnectionsState
         {
             SelectedDetail = null;
             LatestDiagnostic = null;
+            // Deleting the active selection invalidates any in-flight detail
+            // load or preflight so a late response cannot resurrect the
+            // just-deleted connection's data.
+            _detailGeneration++;
+            _preflightGeneration++;
+            _selectedConnectionId = null;
         }
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record("data_connections.deleted", new Dictionary<string, object?>
@@ -359,6 +427,7 @@ public sealed class DataConnectionsState
             return null;
         }
 
+        var generation = ++_preflightGeneration;
         Status = WorkspaceListStatus.Testing;
         LastError = null;
         Notify();
@@ -374,11 +443,12 @@ public sealed class DataConnectionsState
         var result = await _client.TestDraftAsync(request, cancellationToken).ConfigureAwait(false);
         watch.Stop();
 
-        return CompletePreflight(result, detail: null, watch.ElapsedMilliseconds);
+        return CompletePreflight(result, detail: null, watch.ElapsedMilliseconds, generation);
     }
 
     public async Task<ConnectionDiagnostic?> RunExistingPreflightAsync(Guid id, CancellationToken cancellationToken = default)
     {
+        var generation = ++_preflightGeneration;
         Status = WorkspaceListStatus.Testing;
         LastError = null;
         Notify();
@@ -393,11 +463,19 @@ public sealed class DataConnectionsState
         var result = await _client.TestExistingAsync(id, cancellationToken).ConfigureAwait(false);
         watch.Stop();
 
-        return CompletePreflight(result, SelectedDetail, watch.ElapsedMilliseconds);
+        return CompletePreflight(result, SelectedDetail, watch.ElapsedMilliseconds, generation);
     }
 
-    private ConnectionDiagnostic? CompletePreflight(ConnectionResult<ConnectionTestOutcome> result, DataConnectionDetail? detail, long elapsedMs)
+    private ConnectionDiagnostic? CompletePreflight(ConnectionResult<ConnectionTestOutcome> result, DataConnectionDetail? detail, long elapsedMs, int generation)
     {
+        if (generation != _preflightGeneration)
+        {
+            // A newer preflight (or user-driven supersede) has taken ownership
+            // of LatestDiagnostic. Drop this stale outcome so it cannot
+            // overwrite the current connection's grid with the prior one's.
+            return null;
+        }
+
         if (!result.IsSuccess)
         {
             Status = WorkspaceListStatus.Error;
@@ -477,7 +555,20 @@ public sealed class DataConnectionsState
         // Mutating endpoints (POST/PUT) return a Summary; the page expects a
         // full Detail. Best-effort follow-up: on success, populate SelectedDetail;
         // on failure leave the prior value unchanged so the page does not blank.
+        // TryRefresh is a follower of whatever LoadDetail/BeginCreateDraft has
+        // already claimed: capture the generation without bumping (a bump
+        // would invalidate a concurrent LoadDetail for an unrelated id), then
+        // drop on return if a newer load superseded us OR if the user-intended
+        // owner id no longer matches our target. Both checks are necessary —
+        // generation alone misses the case where TryRefresh starts AFTER the
+        // newer LoadDetail has already bumped, and id alone misses same-id
+        // concurrent loads.
+        var generation = _detailGeneration;
         var result = await _client.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (generation != _detailGeneration || _selectedConnectionId != id)
+        {
+            return;
+        }
         if (result.IsSuccess)
         {
             SelectedDetail = result.Value;

--- a/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
+++ b/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Services.DataConnections.Providers;
+
+namespace Honua.Admin.Services.DataConnections;
+
+public enum WorkspaceListStatus
+{
+    Idle,
+    Loading,
+    Mutating,
+    Testing,
+    Error
+}
+
+/// <summary>
+/// Scoped MVU-style store for the data-connection workspace. Mirrors the
+/// shape of <c>SpecWorkspaceState</c> — every observable mutation funnels
+/// through an explicit method so persistence (none, by design — credentials
+/// must not survive a navigation), telemetry, and notifications stay
+/// single-origin. Failures from the client become a state transition, never
+/// an exception that escapes to Razor.
+/// </summary>
+public sealed class DataConnectionsState
+{
+    private readonly IDataConnectionClient _client;
+    private readonly IDataConnectionTelemetry _telemetry;
+    private readonly IProviderRegistry _registry;
+
+    private readonly List<DataConnectionSummary> _connections = new();
+
+    public DataConnectionsState(IDataConnectionClient client, IDataConnectionTelemetry telemetry, IProviderRegistry registry)
+    {
+        _client = client;
+        _telemetry = telemetry;
+        _registry = registry;
+    }
+
+    public IReadOnlyList<DataConnectionSummary> Connections => _connections;
+
+    public WorkspaceListStatus Status { get; private set; } = WorkspaceListStatus.Idle;
+
+    public ConnectionOperationError? LastError { get; private set; }
+
+    public DataConnectionDetail? SelectedDetail { get; private set; }
+
+    public ConnectionDiagnostic? LatestDiagnostic { get; private set; }
+
+    public ConnectionDraft? Draft { get; private set; }
+
+    public IProviderRegistry ProviderRegistry => _registry;
+
+    public event Action? OnChanged;
+
+    public async Task RefreshListAsync(CancellationToken cancellationToken = default)
+    {
+        Status = WorkspaceListStatus.Loading;
+        LastError = null;
+        Notify();
+
+        var watch = Stopwatch.StartNew();
+        var result = await _client.ListAsync(cancellationToken).ConfigureAwait(false);
+        watch.Stop();
+
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            _telemetry.Record("data_connections.list_failed", new Dictionary<string, object?>
+            {
+                ["error_kind"] = result.Error!.Kind.ToString()
+            });
+            Notify();
+            return;
+        }
+
+        _connections.Clear();
+        _connections.AddRange(result.Value!);
+        Status = WorkspaceListStatus.Idle;
+        _telemetry.RecordLatency("data_connections.list_loaded", watch.ElapsedMilliseconds, new Dictionary<string, object?>
+        {
+            ["count"] = _connections.Count
+        });
+        Notify();
+    }
+
+    public ConnectionDraft BeginCreateDraft(string providerId)
+    {
+        if (!_registry.TryGet(providerId, out var registration))
+        {
+            throw new InvalidOperationException($"Provider '{providerId}' is not registered.");
+        }
+
+        Draft = new ConnectionDraft
+        {
+            ProviderId = registration.ProviderId,
+            Port = registration.DefaultPort
+        };
+        SelectedDetail = null;
+        LatestDiagnostic = null;
+        Notify();
+
+        if (registration.IsStub)
+        {
+            _telemetry.Record("data_connections.provider_stub_viewed", new Dictionary<string, object?>
+            {
+                ["provider_id"] = registration.ProviderId
+            });
+        }
+
+        return Draft;
+    }
+
+    public void UpdateDraft(Action<ConnectionDraft> mutate)
+    {
+        if (Draft is null)
+        {
+            return;
+        }
+        mutate(Draft);
+        Notify();
+    }
+
+    public void ClearDraft()
+    {
+        Draft = null;
+        Notify();
+    }
+
+    public async Task<ConnectionResult<DataConnectionDetail>> SubmitDraftAsync(CancellationToken cancellationToken = default)
+    {
+        if (Draft is null)
+        {
+            return ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
+        }
+
+        Status = WorkspaceListStatus.Mutating;
+        LastError = null;
+        Notify();
+
+        _telemetry.Record("data_connections.create_submitted", new Dictionary<string, object?>
+        {
+            ["provider"] = Draft.ProviderId
+        });
+
+        var request = ToCreateRequest(Draft);
+        var result = await _client.CreateAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            _telemetry.Record("data_connections.create_failed", new Dictionary<string, object?>
+            {
+                ["provider"] = Draft.ProviderId,
+                ["failure_code"] = result.Error!.Kind.ToString()
+            });
+            Notify();
+            return result;
+        }
+
+        // Optimistic insert — replace on next refresh.
+        _connections.Add(ToSummary(result.Value!));
+        SelectedDetail = result.Value;
+        Draft = null;
+        Status = WorkspaceListStatus.Idle;
+        _telemetry.Record("data_connections.create_succeeded", new Dictionary<string, object?>
+        {
+            ["provider"] = result.Value!.ConnectionId.ToString(),
+            ["connection_id"] = result.Value.ConnectionId
+        });
+        Notify();
+        return result;
+    }
+
+    public async Task LoadDetailAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        Status = WorkspaceListStatus.Loading;
+        LastError = null;
+        Notify();
+
+        var result = await _client.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            Notify();
+            return;
+        }
+
+        SelectedDetail = result.Value;
+        Status = WorkspaceListStatus.Idle;
+        Notify();
+    }
+
+    public async Task<ConnectionResult<DataConnectionDetail>> SetActiveAsync(Guid id, bool active, CancellationToken cancellationToken = default)
+    {
+        Status = WorkspaceListStatus.Mutating;
+        LastError = null;
+        Notify();
+
+        var result = active
+            ? await _client.EnableAsync(id, cancellationToken).ConfigureAwait(false)
+            : await _client.DisableAsync(id, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            Notify();
+            return result;
+        }
+
+        SelectedDetail = result.Value;
+        ReplaceInList(result.Value!);
+        Status = WorkspaceListStatus.Idle;
+        _telemetry.Record(active ? "data_connections.enabled" : "data_connections.disabled", new Dictionary<string, object?>
+        {
+            ["connection_id"] = id
+        });
+        Notify();
+        return result;
+    }
+
+    public ConnectionDraft BeginEditDraft(DataConnectionDetail detail)
+    {
+        Draft = new ConnectionDraft
+        {
+            ConnectionId = detail.ConnectionId,
+            ProviderId = detail.ProviderId,
+            Name = detail.Name,
+            Description = detail.Description,
+            Host = detail.Host,
+            Port = detail.Port,
+            DatabaseName = detail.DatabaseName,
+            Username = detail.Username,
+            SslRequired = detail.SslRequired,
+            SslMode = detail.SslMode,
+            CredentialMode = string.Equals(detail.StorageType, "external", StringComparison.OrdinalIgnoreCase) ? CredentialMode.External : CredentialMode.Managed,
+            SecretReference = detail.CredentialReference,
+            IsActive = detail.IsActive
+        };
+        Notify();
+        return Draft;
+    }
+
+    public async Task<ConnectionResult<DataConnectionDetail>> SubmitEditAsync(CancellationToken cancellationToken = default)
+    {
+        if (Draft is null || Draft.ConnectionId is null)
+        {
+            return ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
+        }
+
+        Status = WorkspaceListStatus.Mutating;
+        LastError = null;
+        Notify();
+
+        var request = new UpdateConnectionRequest
+        {
+            Description = Draft.Description,
+            Host = Draft.Host,
+            Port = Draft.Port,
+            DatabaseName = Draft.DatabaseName,
+            Username = Draft.Username,
+            Password = Draft.CredentialMode == CredentialMode.Managed && !string.IsNullOrEmpty(Draft.Password)
+                ? Draft.Password
+                : null,
+            SslRequired = Draft.SslRequired,
+            SslMode = Draft.SslMode,
+            IsActive = Draft.IsActive
+        };
+
+        var result = await _client.UpdateAsync(Draft.ConnectionId.Value, request, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            _telemetry.Record("data_connections.update_failed", new Dictionary<string, object?>
+            {
+                ["connection_id"] = Draft.ConnectionId,
+                ["failure_code"] = result.Error!.Kind.ToString()
+            });
+            Notify();
+            return result;
+        }
+
+        SelectedDetail = result.Value;
+        ReplaceInList(result.Value!);
+        Draft = null;
+        Status = WorkspaceListStatus.Idle;
+        _telemetry.Record("data_connections.update_succeeded", new Dictionary<string, object?>
+        {
+            ["connection_id"] = result.Value!.ConnectionId
+        });
+        Notify();
+        return result;
+    }
+
+    public async Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        Status = WorkspaceListStatus.Mutating;
+        LastError = null;
+        Notify();
+
+        var result = await _client.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            Notify();
+            return result;
+        }
+
+        _connections.RemoveAll(c => c.ConnectionId == id);
+        if (SelectedDetail?.ConnectionId == id)
+        {
+            SelectedDetail = null;
+        }
+        Status = WorkspaceListStatus.Idle;
+        _telemetry.Record("data_connections.deleted", new Dictionary<string, object?>
+        {
+            ["connection_id"] = id
+        });
+        Notify();
+        return result;
+    }
+
+    public async Task<ConnectionDiagnostic?> RunDraftPreflightAsync(CancellationToken cancellationToken = default)
+    {
+        if (Draft is null)
+        {
+            return null;
+        }
+
+        Status = WorkspaceListStatus.Testing;
+        LastError = null;
+        Notify();
+
+        _telemetry.Record("data_connections.test_started", new Dictionary<string, object?>
+        {
+            ["mode"] = "draft",
+            ["provider"] = Draft.ProviderId
+        });
+
+        var watch = Stopwatch.StartNew();
+        var request = ToCreateRequest(Draft);
+        var result = await _client.TestDraftAsync(request, cancellationToken).ConfigureAwait(false);
+        watch.Stop();
+
+        return CompletePreflight(result, detail: null, watch.ElapsedMilliseconds);
+    }
+
+    public async Task<ConnectionDiagnostic?> RunExistingPreflightAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        Status = WorkspaceListStatus.Testing;
+        LastError = null;
+        Notify();
+
+        _telemetry.Record("data_connections.test_started", new Dictionary<string, object?>
+        {
+            ["mode"] = "existing",
+            ["connection_id"] = id
+        });
+
+        var watch = Stopwatch.StartNew();
+        var result = await _client.TestExistingAsync(id, cancellationToken).ConfigureAwait(false);
+        watch.Stop();
+
+        return CompletePreflight(result, SelectedDetail, watch.ElapsedMilliseconds);
+    }
+
+    private ConnectionDiagnostic? CompletePreflight(ConnectionResult<ConnectionTestOutcome> result, DataConnectionDetail? detail, long elapsedMs)
+    {
+        if (!result.IsSuccess)
+        {
+            Status = WorkspaceListStatus.Error;
+            LastError = result.Error;
+            LatestDiagnostic = null;
+            _telemetry.Record("data_connections.test_completed", new Dictionary<string, object?>
+            {
+                ["result_kind"] = "error",
+                ["error_kind"] = result.Error!.Kind.ToString()
+            });
+            Notify();
+            return null;
+        }
+
+        var diagnostic = DiagnosticMapper.Map(result.Value!, detail);
+        LatestDiagnostic = diagnostic;
+        Status = WorkspaceListStatus.Idle;
+
+        var failedStep = diagnostic.AnyFailed
+            ? diagnostic.Cells.First(c => c.Status == DiagnosticStatus.Failed).Step.ToString()
+            : null;
+
+        _telemetry.RecordLatency("data_connections.test_completed", elapsedMs, new Dictionary<string, object?>
+        {
+            ["result_kind"] = result.Value!.IsHealthy ? "healthy" : (failedStep is null ? "not_assessed" : "failed"),
+            ["failed_step"] = failedStep
+        });
+        Notify();
+        return diagnostic;
+    }
+
+    public ProviderCapabilityMatrix GetCapabilityMatrix(string providerId)
+    {
+        var registration = _registry.GetById(providerId);
+        var checks = registration.ManagedHostingChecks
+            .Select(c => c with { Status = DiagnosticStatus.NotAssessed })
+            .ToArray();
+        return new ProviderCapabilityMatrix
+        {
+            ProviderId = providerId,
+            Checks = checks,
+            IsServerSourced = false
+        };
+    }
+
+    private void ReplaceInList(DataConnectionDetail detail)
+    {
+        var index = _connections.FindIndex(c => c.ConnectionId == detail.ConnectionId);
+        var summary = ToSummary(detail);
+        if (index < 0)
+        {
+            _connections.Add(summary);
+        }
+        else
+        {
+            _connections[index] = summary;
+        }
+    }
+
+    private static CreateConnectionRequest ToCreateRequest(ConnectionDraft draft) => new()
+    {
+        Name = draft.Name,
+        Description = draft.Description,
+        Host = draft.Host,
+        Port = draft.Port,
+        DatabaseName = draft.DatabaseName,
+        Username = draft.Username,
+        Password = draft.CredentialMode == CredentialMode.Managed ? draft.Password : null,
+        SecretReference = draft.CredentialMode == CredentialMode.External ? draft.SecretReference : null,
+        SecretType = draft.CredentialMode == CredentialMode.External ? draft.SecretType : null,
+        SslRequired = draft.SslRequired,
+        SslMode = draft.SslMode
+    };
+
+    private static DataConnectionSummary ToSummary(DataConnectionDetail detail) => new()
+    {
+        ConnectionId = detail.ConnectionId,
+        Name = detail.Name,
+        Description = detail.Description,
+        Host = detail.Host,
+        Port = detail.Port,
+        DatabaseName = detail.DatabaseName,
+        Username = detail.Username,
+        SslRequired = detail.SslRequired,
+        SslMode = detail.SslMode,
+        StorageType = detail.StorageType,
+        IsActive = detail.IsActive,
+        HealthStatus = detail.HealthStatus,
+        LastHealthCheck = detail.LastHealthCheck,
+        CreatedAt = detail.CreatedAt,
+        CreatedBy = detail.CreatedBy
+    };
+
+    private void Notify() => OnChanged?.Invoke();
+}

--- a/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
+++ b/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
@@ -188,8 +188,12 @@ public sealed class DataConnectionsState
     {
         if (SelectedDetail?.ConnectionId != id)
         {
-            // Navigating to a different connection — clear the prior preflight
-            // grid so we don't render a stale verdict against the new selection.
+            // Navigating to a different connection — clear the prior selection
+            // and preflight grid so a failed load (or in-flight load) does not
+            // render the previous connection's data under the new route id.
+            // Same-id reloads keep the prior value so a transient network blip
+            // does not blank the page.
+            SelectedDetail = null;
             LatestDiagnostic = null;
         }
         Status = WorkspaceListStatus.Loading;
@@ -411,6 +415,35 @@ public sealed class DataConnectionsState
         var diagnostic = DiagnosticMapper.Map(result.Value!, detail);
         LatestDiagnostic = diagnostic;
         Status = WorkspaceListStatus.Idle;
+
+        // Reconcile local view with the freshly-computed health. The server's
+        // test endpoint does not persist HealthStatus to the row today (see gap
+        // report), so a follow-up GET would return stale data. Derive
+        // PascalCase ("Healthy"/"Unhealthy") locally to match the server's
+        // enum.ToString() format used elsewhere.
+        var outcome = result.Value!;
+        if (outcome.ConnectionId != Guid.Empty)
+        {
+            var refreshedStatus = outcome.IsHealthy ? "Healthy" : "Unhealthy";
+            if (SelectedDetail is { } current && current.ConnectionId == outcome.ConnectionId)
+            {
+                SelectedDetail = current with
+                {
+                    HealthStatus = refreshedStatus,
+                    LastHealthCheck = outcome.TestedAt
+                };
+            }
+
+            var listIndex = _connections.FindIndex(c => c.ConnectionId == outcome.ConnectionId);
+            if (listIndex >= 0)
+            {
+                _connections[listIndex] = _connections[listIndex] with
+                {
+                    HealthStatus = refreshedStatus,
+                    LastHealthCheck = outcome.TestedAt
+                };
+            }
+        }
 
         var failedStep = diagnostic.AnyFailed
             ? diagnostic.Cells.First(c => c.Status == DiagnosticStatus.Failed).Step.ToString()

--- a/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
+++ b/src/Honua.Admin/Services/DataConnections/DataConnectionsState.cs
@@ -129,15 +129,19 @@ public sealed class DataConnectionsState
     public void ClearDraft()
     {
         Draft = null;
+        LatestDiagnostic = null;
         Notify();
     }
 
-    public async Task<ConnectionResult<DataConnectionDetail>> SubmitDraftAsync(CancellationToken cancellationToken = default)
+    public async Task<ConnectionResult<DataConnectionSummary>> SubmitDraftAsync(CancellationToken cancellationToken = default)
     {
         if (Draft is null)
         {
-            return ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
+            return ConnectionResult<DataConnectionSummary>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
         }
+
+        var providerId = Draft.ProviderId;
 
         Status = WorkspaceListStatus.Mutating;
         LastError = null;
@@ -145,7 +149,7 @@ public sealed class DataConnectionsState
 
         _telemetry.Record("data_connections.create_submitted", new Dictionary<string, object?>
         {
-            ["provider"] = Draft.ProviderId
+            ["provider"] = providerId
         });
 
         var request = ToCreateRequest(Draft);
@@ -157,7 +161,7 @@ public sealed class DataConnectionsState
             LastError = result.Error;
             _telemetry.Record("data_connections.create_failed", new Dictionary<string, object?>
             {
-                ["provider"] = Draft.ProviderId,
+                ["provider"] = providerId,
                 ["failure_code"] = result.Error!.Kind.ToString()
             });
             Notify();
@@ -165,14 +169,16 @@ public sealed class DataConnectionsState
         }
 
         // Optimistic insert — replace on next refresh.
-        _connections.Add(ToSummary(result.Value!));
-        SelectedDetail = result.Value;
+        var summary = result.Value!;
+        _connections.Add(summary);
+        await TryRefreshSelectedDetailAsync(summary.ConnectionId, cancellationToken).ConfigureAwait(false);
         Draft = null;
+        LatestDiagnostic = null;
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record("data_connections.create_succeeded", new Dictionary<string, object?>
         {
-            ["provider"] = result.Value!.ConnectionId.ToString(),
-            ["connection_id"] = result.Value.ConnectionId
+            ["provider"] = providerId,
+            ["connection_id"] = summary.ConnectionId
         });
         Notify();
         return result;
@@ -180,6 +186,12 @@ public sealed class DataConnectionsState
 
     public async Task LoadDetailAsync(Guid id, CancellationToken cancellationToken = default)
     {
+        if (SelectedDetail?.ConnectionId != id)
+        {
+            // Navigating to a different connection — clear the prior preflight
+            // grid so we don't render a stale verdict against the new selection.
+            LatestDiagnostic = null;
+        }
         Status = WorkspaceListStatus.Loading;
         LastError = null;
         Notify();
@@ -198,7 +210,7 @@ public sealed class DataConnectionsState
         Notify();
     }
 
-    public async Task<ConnectionResult<DataConnectionDetail>> SetActiveAsync(Guid id, bool active, CancellationToken cancellationToken = default)
+    public async Task<ConnectionResult<DataConnectionSummary>> SetActiveAsync(Guid id, bool active, CancellationToken cancellationToken = default)
     {
         Status = WorkspaceListStatus.Mutating;
         LastError = null;
@@ -216,8 +228,9 @@ public sealed class DataConnectionsState
             return result;
         }
 
-        SelectedDetail = result.Value;
         ReplaceInList(result.Value!);
+        await TryRefreshSelectedDetailAsync(id, cancellationToken).ConfigureAwait(false);
+        LatestDiagnostic = null;
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record(active ? "data_connections.enabled" : "data_connections.disabled", new Dictionary<string, object?>
         {
@@ -249,11 +262,12 @@ public sealed class DataConnectionsState
         return Draft;
     }
 
-    public async Task<ConnectionResult<DataConnectionDetail>> SubmitEditAsync(CancellationToken cancellationToken = default)
+    public async Task<ConnectionResult<DataConnectionSummary>> SubmitEditAsync(CancellationToken cancellationToken = default)
     {
         if (Draft is null || Draft.ConnectionId is null)
         {
-            return ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
+            return ConnectionResult<DataConnectionSummary>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Validation, "error.no_draft"));
         }
 
         Status = WorkspaceListStatus.Mutating;
@@ -290,13 +304,15 @@ public sealed class DataConnectionsState
             return result;
         }
 
-        SelectedDetail = result.Value;
-        ReplaceInList(result.Value!);
+        var summary = result.Value!;
+        ReplaceInList(summary);
+        await TryRefreshSelectedDetailAsync(summary.ConnectionId, cancellationToken).ConfigureAwait(false);
         Draft = null;
+        LatestDiagnostic = null;
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record("data_connections.update_succeeded", new Dictionary<string, object?>
         {
-            ["connection_id"] = result.Value!.ConnectionId
+            ["connection_id"] = summary.ConnectionId
         });
         Notify();
         return result;
@@ -321,6 +337,7 @@ public sealed class DataConnectionsState
         if (SelectedDetail?.ConnectionId == id)
         {
             SelectedDetail = null;
+            LatestDiagnostic = null;
         }
         Status = WorkspaceListStatus.Idle;
         _telemetry.Record("data_connections.deleted", new Dictionary<string, object?>
@@ -422,10 +439,21 @@ public sealed class DataConnectionsState
         };
     }
 
-    private void ReplaceInList(DataConnectionDetail detail)
+    private async Task TryRefreshSelectedDetailAsync(Guid id, CancellationToken cancellationToken)
     {
-        var index = _connections.FindIndex(c => c.ConnectionId == detail.ConnectionId);
-        var summary = ToSummary(detail);
+        // Mutating endpoints (POST/PUT) return a Summary; the page expects a
+        // full Detail. Best-effort follow-up: on success, populate SelectedDetail;
+        // on failure leave the prior value unchanged so the page does not blank.
+        var result = await _client.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            SelectedDetail = result.Value;
+        }
+    }
+
+    private void ReplaceInList(DataConnectionSummary summary)
+    {
+        var index = _connections.FindIndex(c => c.ConnectionId == summary.ConnectionId);
         if (index < 0)
         {
             _connections.Add(summary);
@@ -449,25 +477,6 @@ public sealed class DataConnectionsState
         SecretType = draft.CredentialMode == CredentialMode.External ? draft.SecretType : null,
         SslRequired = draft.SslRequired,
         SslMode = draft.SslMode
-    };
-
-    private static DataConnectionSummary ToSummary(DataConnectionDetail detail) => new()
-    {
-        ConnectionId = detail.ConnectionId,
-        Name = detail.Name,
-        Description = detail.Description,
-        Host = detail.Host,
-        Port = detail.Port,
-        DatabaseName = detail.DatabaseName,
-        Username = detail.Username,
-        SslRequired = detail.SslRequired,
-        SslMode = detail.SslMode,
-        StorageType = detail.StorageType,
-        IsActive = detail.IsActive,
-        HealthStatus = detail.HealthStatus,
-        LastHealthCheck = detail.LastHealthCheck,
-        CreatedAt = detail.CreatedAt,
-        CreatedBy = detail.CreatedBy
     };
 
     private void Notify() => OnChanged?.Invoke();

--- a/src/Honua.Admin/Services/DataConnections/DiagnosticMapper.cs
+++ b/src/Honua.Admin/Services/DataConnections/DiagnosticMapper.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using Honua.Admin.Models.DataConnections;
+
+namespace Honua.Admin.Services.DataConnections;
+
+/// <summary>
+/// The single seam between the server's free-form <c>Message</c> and the
+/// six-cell structured surface. Every page renders the structured cells, never
+/// the raw message — keeping the heuristic isolated means the server-side fix
+/// (structured per-step codes) reaches every consumer in one change.
+/// </summary>
+public static class DiagnosticMapper
+{
+    private static readonly DiagnosticStep[] AllSteps =
+    {
+        DiagnosticStep.Dns,
+        DiagnosticStep.Tcp,
+        DiagnosticStep.Auth,
+        DiagnosticStep.Ssl,
+        DiagnosticStep.Capability,
+        DiagnosticStep.Version
+    };
+
+    public static ConnectionDiagnostic Map(ConnectionTestOutcome outcome, DataConnectionDetail? detail = null)
+    {
+        if (outcome.IsHealthy)
+        {
+            return BuildHealthy(outcome, detail);
+        }
+
+        return BuildFailed(outcome);
+    }
+
+    private static ConnectionDiagnostic BuildHealthy(ConnectionTestOutcome outcome, DataConnectionDetail? detail)
+    {
+        var cells = new List<DiagnosticCell>(AllSteps.Length);
+        foreach (var step in AllSteps)
+        {
+            var detailText = step switch
+            {
+                DiagnosticStep.Capability when detail is not null => $"{detail.SslMode} / managed={detail.StorageType}",
+                DiagnosticStep.Version when detail is not null => detail.HealthStatus,
+                _ => null
+            };
+            cells.Add(new DiagnosticCell(step, DiagnosticStatus.Ok, detailText));
+        }
+
+        return new ConnectionDiagnostic
+        {
+            Cells = cells,
+            RawOutcome = outcome
+        };
+    }
+
+    private static ConnectionDiagnostic BuildFailed(ConnectionTestOutcome outcome)
+    {
+        var message = outcome.Message ?? string.Empty;
+        var failed = ClassifyFailure(message);
+
+        var cells = new List<DiagnosticCell>(AllSteps.Length);
+        foreach (var step in AllSteps)
+        {
+            if (step == failed)
+            {
+                cells.Add(new DiagnosticCell(step, DiagnosticStatus.Failed, message, RemediationKey(step)));
+            }
+            else
+            {
+                cells.Add(new DiagnosticCell(step, DiagnosticStatus.NotAssessed));
+            }
+        }
+
+        return new ConnectionDiagnostic
+        {
+            Cells = cells,
+            RawOutcome = outcome
+        };
+    }
+
+    /// <summary>
+    /// Narrow heuristic — only well-known phrases promote a cell to Failed; an
+    /// unmatched string lights only the Auth fallback. Unrelated cells stay
+    /// NotAssessed so we do not produce false negatives.
+    /// </summary>
+    internal static DiagnosticStep ClassifyFailure(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return DiagnosticStep.Auth;
+        }
+
+        if (Contains(message, "name resolution") || Contains(message, "dns") || Contains(message, "no such host"))
+        {
+            return DiagnosticStep.Dns;
+        }
+
+        if (Contains(message, "ssl") || Contains(message, "tls") || Contains(message, "certificate") || Contains(message, "handshake"))
+        {
+            return DiagnosticStep.Ssl;
+        }
+
+        if (Contains(message, "authentication") || Contains(message, "password") || Contains(message, "role does not exist") || Contains(message, "permission denied"))
+        {
+            return DiagnosticStep.Auth;
+        }
+
+        if (Contains(message, "timeout") || Contains(message, "unreachable") || Contains(message, "refused") || Contains(message, "connection reset"))
+        {
+            return DiagnosticStep.Tcp;
+        }
+
+        if (Contains(message, "version") || Contains(message, "unsupported server"))
+        {
+            return DiagnosticStep.Version;
+        }
+
+        if (Contains(message, "extension") || Contains(message, "capability") || Contains(message, "feature"))
+        {
+            return DiagnosticStep.Capability;
+        }
+
+        return DiagnosticStep.Auth;
+    }
+
+    private static bool Contains(string haystack, string needle) =>
+        haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static string RemediationKey(DiagnosticStep step) => step switch
+    {
+        DiagnosticStep.Dns => "remediation.dns",
+        DiagnosticStep.Tcp => "remediation.tcp",
+        DiagnosticStep.Auth => "remediation.auth",
+        DiagnosticStep.Ssl => "remediation.ssl",
+        DiagnosticStep.Capability => "remediation.capability",
+        DiagnosticStep.Version => "remediation.version",
+        _ => "remediation.unknown"
+    };
+}

--- a/src/Honua.Admin/Services/DataConnections/HttpDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/HttpDataConnectionClient.cs
@@ -153,18 +153,56 @@ public sealed class HttpDataConnectionClient : IDataConnectionClient
             HttpStatusCode.BadRequest or HttpStatusCode.UnprocessableEntity => ConnectionErrorKind.Validation,
             _ => ConnectionErrorKind.Server
         };
+        var copyKey = $"error.{kind.ToString().ToLowerInvariant()}";
 
+        // honua-server returns 4xx data-connection failures as
+        // ApiResponse<object>.Failure(message), e.g. "Invalid SSL mode" or
+        // "Connection is in use by services". A few paths still emit
+        // application/problem+json (e.g., 5xx routed through middleware).
+        // Read the body once and try both shapes so we never drop the
+        // operator-actionable message on the floor.
+        string? body;
         try
         {
-            var problem = await response.Content
-                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.ProblemDetailsPayload, cancellationToken)
-                .ConfigureAwait(false);
-            var detail = problem?.Detail ?? problem?.Title;
-            return new ConnectionOperationError(kind, $"error.{kind.ToString().ToLowerInvariant()}", detail);
+            body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
-            return new ConnectionOperationError(kind, $"error.{kind.ToString().ToLowerInvariant()}");
+            return new ConnectionOperationError(kind, copyKey);
+        }
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return new ConnectionOperationError(kind, copyKey);
+        }
+
+        var detail = TryReadProblemDetail(body) ?? TryReadEnvelopeMessage(body);
+        return new ConnectionOperationError(kind, copyKey, detail);
+    }
+
+    private static string? TryReadProblemDetail(string body)
+    {
+        try
+        {
+            var problem = JsonSerializer.Deserialize(body, DataConnectionsJsonContext.Default.ProblemDetailsPayload);
+            return problem?.Detail ?? problem?.Title;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryReadEnvelopeMessage(string body)
+    {
+        try
+        {
+            var envelope = JsonSerializer.Deserialize(body, DataConnectionsJsonContext.Default.ApiResponseObject);
+            return string.IsNullOrWhiteSpace(envelope?.Message) ? null : envelope!.Message;
+        }
+        catch (JsonException)
+        {
+            return null;
         }
     }
 }

--- a/src/Honua.Admin/Services/DataConnections/HttpDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/HttpDataConnectionClient.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using Honua.Admin.Models.DataConnections;
@@ -12,8 +14,14 @@ namespace Honua.Admin.Services.DataConnections;
 /// <summary>
 /// First non-stub client in the repo. Wraps the existing
 /// <c>/api/v1/admin/connections</c> HTTP surface using
-/// <see cref="HttpClient"/> + source-generated JSON. The gRPC swap
-/// (<c>Honua.Sdk.Grpc</c>) replaces this once the audit ticket lands.
+/// <see cref="HttpClient"/> + source-generated JSON. honua-server admin
+/// endpoints wrap every payload in <see cref="ApiResponse{T}"/>; this client
+/// unwraps via <c>envelope.Data</c> exactly like
+/// <c>HttpIdentityAdminClient</c> does. Every method funnels through
+/// <see cref="ExecuteRequestAsync{T}"/> so network / cancellation / JSON
+/// failures land as typed <see cref="ConnectionOperationError"/> values.
+/// The gRPC swap (<c>Honua.Sdk.Grpc</c>) replaces this once the audit
+/// ticket lands.
 /// </summary>
 public sealed class HttpDataConnectionClient : IDataConnectionClient
 {
@@ -26,109 +34,34 @@ public sealed class HttpDataConnectionClient : IDataConnectionClient
         _http = http;
     }
 
-    public async Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            using var response = await _http.GetAsync(BasePath, cancellationToken).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                return ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Fail(
-                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
-            }
+    public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(CancellationToken cancellationToken = default) =>
+        ExecuteRequestAsync(
+            ct => _http.GetAsync(BasePath, ct),
+            DataConnectionsJsonContext.Default.ApiResponseIReadOnlyListDataConnectionSummary,
+            cancellationToken);
 
-            var payload = await response.Content
-                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionSummaryArray, cancellationToken)
-                .ConfigureAwait(false);
+    public Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
+        ExecuteRequestAsync(
+            ct => _http.GetAsync($"{BasePath}/{id}", ct),
+            DataConnectionsJsonContext.Default.ApiResponseDataConnectionDetail,
+            cancellationToken);
 
-            IReadOnlyList<DataConnectionSummary> result = payload ?? Array.Empty<DataConnectionSummary>();
-            return ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Ok(result);
-        }
-        catch (HttpRequestException ex)
-        {
-            return ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Fail(
-                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
-        }
-    }
+    public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default) =>
+        ExecuteRequestAsync(
+            ct => _http.PostAsJsonAsync(BasePath, request, DataConnectionsJsonContext.Default.CreateConnectionRequest, ct),
+            DataConnectionsJsonContext.Default.ApiResponseDataConnectionSummary,
+            cancellationToken);
 
-    public async Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            using var response = await _http.GetAsync($"{BasePath}/{id}", cancellationToken).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                return ConnectionResult<DataConnectionDetail>.Fail(
-                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
-            }
-            var detail = await response.Content
-                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionDetail, cancellationToken)
-                .ConfigureAwait(false);
-            return detail is null
-                ? ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
-                : ConnectionResult<DataConnectionDetail>.Ok(detail);
-        }
-        catch (HttpRequestException ex)
-        {
-            return ConnectionResult<DataConnectionDetail>.Fail(
-                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
-        }
-    }
+    public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default) =>
+        ExecuteRequestAsync(
+            ct => _http.PutAsJsonAsync($"{BasePath}/{id}", request, DataConnectionsJsonContext.Default.UpdateConnectionRequest, ct),
+            DataConnectionsJsonContext.Default.ApiResponseDataConnectionSummary,
+            cancellationToken);
 
-    public async Task<ConnectionResult<DataConnectionDetail>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            using var response = await _http.PostAsJsonAsync(
-                BasePath, request, DataConnectionsJsonContext.Default.CreateConnectionRequest, cancellationToken).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                return ConnectionResult<DataConnectionDetail>.Fail(
-                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
-            }
-            var detail = await response.Content
-                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionDetail, cancellationToken)
-                .ConfigureAwait(false);
-            return detail is null
-                ? ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
-                : ConnectionResult<DataConnectionDetail>.Ok(detail);
-        }
-        catch (HttpRequestException ex)
-        {
-            return ConnectionResult<DataConnectionDetail>.Fail(
-                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
-        }
-    }
-
-    public async Task<ConnectionResult<DataConnectionDetail>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            using var response = await _http.PutAsJsonAsync(
-                $"{BasePath}/{id}", request, DataConnectionsJsonContext.Default.UpdateConnectionRequest, cancellationToken).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                return ConnectionResult<DataConnectionDetail>.Fail(
-                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
-            }
-            var detail = await response.Content
-                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionDetail, cancellationToken)
-                .ConfigureAwait(false);
-            return detail is null
-                ? ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
-                : ConnectionResult<DataConnectionDetail>.Ok(detail);
-        }
-        catch (HttpRequestException ex)
-        {
-            return ConnectionResult<DataConnectionDetail>.Fail(
-                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
-        }
-    }
-
-    public Task<ConnectionResult<DataConnectionDetail>> DisableAsync(Guid id, CancellationToken cancellationToken = default) =>
+    public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, CancellationToken cancellationToken = default) =>
         UpdateAsync(id, new UpdateConnectionRequest { IsActive = false }, cancellationToken);
 
-    public Task<ConnectionResult<DataConnectionDetail>> EnableAsync(Guid id, CancellationToken cancellationToken = default) =>
+    public Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, CancellationToken cancellationToken = default) =>
         UpdateAsync(id, new UpdateConnectionRequest { IsActive = true }, cancellationToken);
 
     public async Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
@@ -148,52 +81,66 @@ public sealed class HttpDataConnectionClient : IDataConnectionClient
             return ConnectionResult<bool>.Fail(
                 new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
         }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return ConnectionResult<bool>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.timeout"));
+        }
     }
 
-    public async Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
+    public Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default) =>
+        ExecuteRequestAsync(
+            ct => _http.PostAsJsonAsync($"{BasePath}/test", request, DataConnectionsJsonContext.Default.CreateConnectionRequest, ct),
+            DataConnectionsJsonContext.Default.ApiResponseConnectionTestOutcome,
+            cancellationToken);
+
+    public Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, CancellationToken cancellationToken = default) =>
+        ExecuteRequestAsync(
+            ct => _http.PostAsync($"{BasePath}/{id}/test", content: null, ct),
+            DataConnectionsJsonContext.Default.ApiResponseConnectionTestOutcome,
+            cancellationToken);
+
+    private async Task<ConnectionResult<T>> ExecuteRequestAsync<T>(
+        Func<CancellationToken, Task<HttpResponseMessage>> sendRequest,
+        JsonTypeInfo<ApiResponse<T>> envelopeType,
+        CancellationToken cancellationToken)
     {
         try
         {
-            using var response = await _http.PostAsJsonAsync(
-                $"{BasePath}/test", request, DataConnectionsJsonContext.Default.CreateConnectionRequest, cancellationToken).ConfigureAwait(false);
-            return await ReadTestOutcomeAsync(response, cancellationToken).ConfigureAwait(false);
+            using var response = await sendRequest(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ConnectionResult<T>.Fail(
+                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+            }
+
+            var envelope = await response.Content
+                .ReadFromJsonAsync(envelopeType, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (envelope is null || envelope.Data is null)
+            {
+                return ConnectionResult<T>.Fail(
+                    new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"));
+            }
+
+            return ConnectionResult<T>.Ok(envelope.Data);
         }
         catch (HttpRequestException ex)
         {
-            return ConnectionResult<ConnectionTestOutcome>.Fail(
+            return ConnectionResult<T>.Fail(
                 new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
         }
-    }
-
-    public async Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        try
+        catch (JsonException ex)
         {
-            using var response = await _http.PostAsync($"{BasePath}/{id}/test", content: null, cancellationToken).ConfigureAwait(false);
-            return await ReadTestOutcomeAsync(response, cancellationToken).ConfigureAwait(false);
+            return ConnectionResult<T>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Server, "error.malformed_response", ex.Message));
         }
-        catch (HttpRequestException ex)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            return ConnectionResult<ConnectionTestOutcome>.Fail(
-                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+            return ConnectionResult<T>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.timeout"));
         }
-    }
-
-    private static async Task<ConnectionResult<ConnectionTestOutcome>> ReadTestOutcomeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        if (!response.IsSuccessStatusCode)
-        {
-            return ConnectionResult<ConnectionTestOutcome>.Fail(
-                await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
-        }
-
-        var outcome = await response.Content
-            .ReadFromJsonAsync(DataConnectionsJsonContext.Default.ConnectionTestOutcome, cancellationToken)
-            .ConfigureAwait(false);
-
-        return outcome is null
-            ? ConnectionResult<ConnectionTestOutcome>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
-            : ConnectionResult<ConnectionTestOutcome>.Ok(outcome);
     }
 
     private static async Task<ConnectionOperationError> ParseProblemAsync(HttpResponseMessage response, CancellationToken cancellationToken)

--- a/src/Honua.Admin/Services/DataConnections/HttpDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/HttpDataConnectionClient.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.DataConnections;
+
+namespace Honua.Admin.Services.DataConnections;
+
+/// <summary>
+/// First non-stub client in the repo. Wraps the existing
+/// <c>/api/v1/admin/connections</c> HTTP surface using
+/// <see cref="HttpClient"/> + source-generated JSON. The gRPC swap
+/// (<c>Honua.Sdk.Grpc</c>) replaces this once the audit ticket lands.
+/// </summary>
+public sealed class HttpDataConnectionClient : IDataConnectionClient
+{
+    private const string BasePath = "api/v1/admin/connections";
+
+    private readonly HttpClient _http;
+
+    public HttpDataConnectionClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.GetAsync(BasePath, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Fail(
+                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+            }
+
+            var payload = await response.Content
+                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionSummaryArray, cancellationToken)
+                .ConfigureAwait(false);
+
+            IReadOnlyList<DataConnectionSummary> result = payload ?? Array.Empty<DataConnectionSummary>();
+            return ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Ok(result);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    public async Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.GetAsync($"{BasePath}/{id}", cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ConnectionResult<DataConnectionDetail>.Fail(
+                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+            }
+            var detail = await response.Content
+                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionDetail, cancellationToken)
+                .ConfigureAwait(false);
+            return detail is null
+                ? ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
+                : ConnectionResult<DataConnectionDetail>.Ok(detail);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    public async Task<ConnectionResult<DataConnectionDetail>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.PostAsJsonAsync(
+                BasePath, request, DataConnectionsJsonContext.Default.CreateConnectionRequest, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ConnectionResult<DataConnectionDetail>.Fail(
+                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+            }
+            var detail = await response.Content
+                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionDetail, cancellationToken)
+                .ConfigureAwait(false);
+            return detail is null
+                ? ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
+                : ConnectionResult<DataConnectionDetail>.Ok(detail);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    public async Task<ConnectionResult<DataConnectionDetail>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.PutAsJsonAsync(
+                $"{BasePath}/{id}", request, DataConnectionsJsonContext.Default.UpdateConnectionRequest, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ConnectionResult<DataConnectionDetail>.Fail(
+                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+            }
+            var detail = await response.Content
+                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.DataConnectionDetail, cancellationToken)
+                .ConfigureAwait(false);
+            return detail is null
+                ? ConnectionResult<DataConnectionDetail>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
+                : ConnectionResult<DataConnectionDetail>.Ok(detail);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    public Task<ConnectionResult<DataConnectionDetail>> DisableAsync(Guid id, CancellationToken cancellationToken = default) =>
+        UpdateAsync(id, new UpdateConnectionRequest { IsActive = false }, cancellationToken);
+
+    public Task<ConnectionResult<DataConnectionDetail>> EnableAsync(Guid id, CancellationToken cancellationToken = default) =>
+        UpdateAsync(id, new UpdateConnectionRequest { IsActive = true }, cancellationToken);
+
+    public async Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.DeleteAsync($"{BasePath}/{id}", cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ConnectionResult<bool>.Fail(
+                    await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+            }
+            return ConnectionResult<bool>.Ok(true);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<bool>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    public async Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.PostAsJsonAsync(
+                $"{BasePath}/test", request, DataConnectionsJsonContext.Default.CreateConnectionRequest, cancellationToken).ConfigureAwait(false);
+            return await ReadTestOutcomeAsync(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<ConnectionTestOutcome>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    public async Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _http.PostAsync($"{BasePath}/{id}/test", content: null, cancellationToken).ConfigureAwait(false);
+            return await ReadTestOutcomeAsync(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConnectionResult<ConnectionTestOutcome>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Network, "error.network", ex.Message));
+        }
+    }
+
+    private static async Task<ConnectionResult<ConnectionTestOutcome>> ReadTestOutcomeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            return ConnectionResult<ConnectionTestOutcome>.Fail(
+                await ParseProblemAsync(response, cancellationToken).ConfigureAwait(false));
+        }
+
+        var outcome = await response.Content
+            .ReadFromJsonAsync(DataConnectionsJsonContext.Default.ConnectionTestOutcome, cancellationToken)
+            .ConfigureAwait(false);
+
+        return outcome is null
+            ? ConnectionResult<ConnectionTestOutcome>.Fail(new ConnectionOperationError(ConnectionErrorKind.Server, "error.empty_response"))
+            : ConnectionResult<ConnectionTestOutcome>.Ok(outcome);
+    }
+
+    private static async Task<ConnectionOperationError> ParseProblemAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var kind = response.StatusCode switch
+        {
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => ConnectionErrorKind.Auth,
+            HttpStatusCode.NotFound => ConnectionErrorKind.NotFound,
+            HttpStatusCode.Conflict => ConnectionErrorKind.Conflict,
+            HttpStatusCode.BadRequest or HttpStatusCode.UnprocessableEntity => ConnectionErrorKind.Validation,
+            _ => ConnectionErrorKind.Server
+        };
+
+        try
+        {
+            var problem = await response.Content
+                .ReadFromJsonAsync(DataConnectionsJsonContext.Default.ProblemDetailsPayload, cancellationToken)
+                .ConfigureAwait(false);
+            var detail = problem?.Detail ?? problem?.Title;
+            return new ConnectionOperationError(kind, $"error.{kind.ToString().ToLowerInvariant()}", detail);
+        }
+        catch
+        {
+            return new ConnectionOperationError(kind, $"error.{kind.ToString().ToLowerInvariant()}");
+        }
+    }
+}

--- a/src/Honua.Admin/Services/DataConnections/IDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/IDataConnectionClient.cs
@@ -10,7 +10,10 @@ namespace Honua.Admin.Services.DataConnections;
 /// One-to-one wrapper around <c>/api/v1/admin/connections</c>. Every method
 /// returns a typed <see cref="ConnectionResult{T}"/> — failures never throw
 /// across the boundary so the state store can fold them into a state
-/// transition.
+/// transition. Mutating endpoints (POST/PUT) return
+/// <see cref="DataConnectionSummary"/> because that is what honua-server
+/// returns; the state store fetches a fresh <see cref="DataConnectionDetail"/>
+/// via <see cref="GetAsync"/> when the page needs Detail-only fields.
 /// </summary>
 public interface IDataConnectionClient
 {
@@ -18,13 +21,13 @@ public interface IDataConnectionClient
 
     Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, CancellationToken cancellationToken = default);
 
-    Task<ConnectionResult<DataConnectionDetail>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default);
+    Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default);
 
-    Task<ConnectionResult<DataConnectionDetail>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default);
+    Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default);
 
-    Task<ConnectionResult<DataConnectionDetail>> DisableAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, CancellationToken cancellationToken = default);
 
-    Task<ConnectionResult<DataConnectionDetail>> EnableAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, CancellationToken cancellationToken = default);
 
     Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
 

--- a/src/Honua.Admin/Services/DataConnections/IDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/IDataConnectionClient.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.DataConnections;
+
+namespace Honua.Admin.Services.DataConnections;
+
+/// <summary>
+/// One-to-one wrapper around <c>/api/v1/admin/connections</c>. Every method
+/// returns a typed <see cref="ConnectionResult{T}"/> — failures never throw
+/// across the boundary so the state store can fold them into a state
+/// transition.
+/// </summary>
+public interface IDataConnectionClient
+{
+    Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<DataConnectionDetail>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<DataConnectionDetail>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<DataConnectionDetail>> DisableAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<DataConnectionDetail>> EnableAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default);
+
+    Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result envelope: either a value, or a typed error. Modeled on
+/// <c>OneOf</c>-style discriminated unions without the dependency.
+/// </summary>
+public readonly record struct ConnectionResult<T>(T? Value, ConnectionOperationError? Error)
+{
+    public bool IsSuccess => Error is null;
+
+    public static ConnectionResult<T> Ok(T value) => new(value, null);
+
+    public static ConnectionResult<T> Fail(ConnectionOperationError error) => new(default, error);
+}

--- a/src/Honua.Admin/Services/DataConnections/IDataConnectionTelemetry.cs
+++ b/src/Honua.Admin/Services/DataConnections/IDataConnectionTelemetry.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Honua.Admin.Services.DataConnections;
+
+/// <summary>
+/// Telemetry sink for data-connection workspace transitions. Mirrors
+/// <c>ISpecWorkspaceTelemetry</c> exactly so the same admin telemetry sink can
+/// front both surfaces.
+/// </summary>
+public interface IDataConnectionTelemetry
+{
+    void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null);
+
+    void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null);
+}

--- a/src/Honua.Admin/Services/DataConnections/LoggingDataConnectionTelemetry.cs
+++ b/src/Honua.Admin/Services/DataConnections/LoggingDataConnectionTelemetry.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Admin.Services.DataConnections;
+
+public sealed class LoggingDataConnectionTelemetry : IDataConnectionTelemetry
+{
+    private readonly ILogger<LoggingDataConnectionTelemetry> _logger;
+
+    public LoggingDataConnectionTelemetry(ILogger<LoggingDataConnectionTelemetry> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null)
+    {
+        if (properties is null || properties.Count == 0)
+        {
+            _logger.LogInformation("data_connections event={Event}", eventName);
+            return;
+        }
+        _logger.LogInformation("data_connections event={Event} props={@Props}", eventName, properties);
+    }
+
+    public void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null)
+    {
+        if (properties is null || properties.Count == 0)
+        {
+            _logger.LogInformation("data_connections event={Event} elapsed_ms={Elapsed}", eventName, elapsedMillis);
+            return;
+        }
+        _logger.LogInformation("data_connections event={Event} elapsed_ms={Elapsed} props={@Props}", eventName, elapsedMillis, properties);
+    }
+}

--- a/src/Honua.Admin/Services/DataConnections/Providers/IProviderRegistration.cs
+++ b/src/Honua.Admin/Services/DataConnections/Providers/IProviderRegistration.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Honua.Admin.Models.DataConnections;
+
+namespace Honua.Admin.Services.DataConnections.Providers;
+
+/// <summary>
+/// Pluggable provider descriptor. Provider-specific UI lives in the components
+/// referenced here so the workspace shell stays provider-agnostic. New
+/// providers register through <see cref="IProviderRegistry"/>; the workspace
+/// requires no changes when SQL Server / MySQL / cloud spatial DBs ship
+/// concrete implementations.
+/// </summary>
+public interface IProviderRegistration
+{
+    string ProviderId { get; }
+
+    string DisplayName { get; }
+
+    string Description { get; }
+
+    int DefaultPort { get; }
+
+    bool IsStub { get; }
+
+    Type CreateFormComponentType { get; }
+
+    Type CapabilityRendererComponentType { get; }
+
+    IReadOnlyList<CapabilityCheck> ManagedHostingChecks { get; }
+}
+
+public interface IProviderRegistry
+{
+    IReadOnlyList<IProviderRegistration> All { get; }
+
+    IProviderRegistration GetById(string providerId);
+
+    bool TryGet(string providerId, out IProviderRegistration registration);
+}

--- a/src/Honua.Admin/Services/DataConnections/Providers/PostgresProviderRegistration.cs
+++ b/src/Honua.Admin/Services/DataConnections/Providers/PostgresProviderRegistration.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Pages.Operator.DataConnections.Providers;
+
+namespace Honua.Admin.Services.DataConnections.Providers;
+
+/// <summary>
+/// Concrete Postgres registration. Form, capability renderer, and the static
+/// managed-Postgres check list (Aurora / Azure DB) all flow through this
+/// descriptor. Per the gap report, <see cref="ManagedHostingChecks"/> renders
+/// every cell as <see cref="DiagnosticStatus.NotAssessed"/> until
+/// <c>honua-server#644</c> exposes per-check signals.
+/// </summary>
+public sealed class PostgresProviderRegistration : IProviderRegistration
+{
+    public string ProviderId => "postgres";
+
+    public string DisplayName => "PostgreSQL (managed or self-hosted)";
+
+    public string Description => "Aurora, Azure DB for PostgreSQL, or self-hosted Postgres 13+.";
+
+    public int DefaultPort => 5432;
+
+    public bool IsStub => false;
+
+    public Type CreateFormComponentType => typeof(PostgresConnectionForm);
+
+    public Type CapabilityRendererComponentType => typeof(PostgresCapabilityRenderer);
+
+    public IReadOnlyList<CapabilityCheck> ManagedHostingChecks { get; } = new[]
+    {
+        new CapabilityCheck("server-version", "Server version >= 13", "Compatibility", "remediation.upgrade-postgres"),
+        new CapabilityCheck("ssl-enforced", "SSL enforced for client connections", "Security", "remediation.enable-ssl"),
+        new CapabilityCheck("replication-role", "Connection role is primary (not replica)", "Topology", "remediation.target-primary"),
+        new CapabilityCheck("postgis-available", "PostGIS extension available", "Capability", "remediation.install-postgis"),
+        new CapabilityCheck("pgaudit-available", "pgaudit extension available", "Compliance", "remediation.enable-pgaudit"),
+        new CapabilityCheck("aurora-iam-auth", "Aurora: IAM auth permitted (when Aurora-hosted)", "Identity", "remediation.aurora-iam"),
+        new CapabilityCheck("azure-aad-auth", "Azure DB: AAD auth permitted (when Azure-hosted)", "Identity", "remediation.azure-aad")
+    };
+}

--- a/src/Honua.Admin/Services/DataConnections/Providers/ProviderRegistry.cs
+++ b/src/Honua.Admin/Services/DataConnections/Providers/ProviderRegistry.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Honua.Admin.Services.DataConnections.Providers;
+
+public sealed class ProviderRegistry : IProviderRegistry
+{
+    private readonly Dictionary<string, IProviderRegistration> _byId;
+
+    public ProviderRegistry(IEnumerable<IProviderRegistration> registrations)
+    {
+        _byId = registrations.ToDictionary(r => r.ProviderId, StringComparer.OrdinalIgnoreCase);
+        All = _byId.Values.OrderBy(r => r.IsStub ? 1 : 0).ThenBy(r => r.DisplayName, StringComparer.Ordinal).ToArray();
+    }
+
+    public IReadOnlyList<IProviderRegistration> All { get; }
+
+    public IProviderRegistration GetById(string providerId)
+    {
+        if (!_byId.TryGetValue(providerId, out var registration))
+        {
+            throw new KeyNotFoundException($"Provider '{providerId}' is not registered.");
+        }
+        return registration;
+    }
+
+    public bool TryGet(string providerId, out IProviderRegistration registration)
+    {
+        if (_byId.TryGetValue(providerId, out var found))
+        {
+            registration = found;
+            return true;
+        }
+        registration = null!;
+        return false;
+    }
+}

--- a/src/Honua.Admin/Services/DataConnections/Providers/SqlServerStubProviderRegistration.cs
+++ b/src/Honua.Admin/Services/DataConnections/Providers/SqlServerStubProviderRegistration.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Pages.Operator.DataConnections.Providers;
+
+namespace Honua.Admin.Services.DataConnections.Providers;
+
+/// <summary>
+/// Stub registration that proves the registry contract supports a
+/// non-Postgres provider without redesign. The form component renders a
+/// "coming soon" placeholder; the capability list is empty so renderers stay
+/// honest about what is and is not assessed.
+/// </summary>
+public sealed class SqlServerStubProviderRegistration : IProviderRegistration
+{
+    public string ProviderId => "sqlserver";
+
+    public string DisplayName => "SQL Server (stub)";
+
+    public string Description => "Pluggable hook only — concrete support arrives with honua-server#362.";
+
+    public int DefaultPort => 1433;
+
+    public bool IsStub => true;
+
+    public Type CreateFormComponentType => typeof(StubProviderForm);
+
+    public Type CapabilityRendererComponentType => typeof(StubCapabilityRenderer);
+
+    public IReadOnlyList<CapabilityCheck> ManagedHostingChecks { get; } = Array.Empty<CapabilityCheck>();
+}

--- a/src/Honua.Admin/Services/DataConnections/StubDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/StubDataConnectionClient.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.DataConnections;
+
+namespace Honua.Admin.Services.DataConnections;
+
+/// <summary>
+/// Deterministic in-memory backing for tests and dev. The HTTP path is the
+/// production wire; the stub mirrors its observable behavior so the bUnit
+/// E2E and the production path agree on every state transition.
+/// </summary>
+public sealed class StubDataConnectionClient : IDataConnectionClient
+{
+    private readonly Dictionary<Guid, DataConnectionDetail> _store = new();
+
+    /// <summary>
+    /// Optional rule-injection point for tests: when set, the predicate runs
+    /// against the host or the message hint and forces a non-healthy result.
+    /// </summary>
+    public Func<string, string?>? FailureMessageForHost { get; set; }
+
+    public StubDataConnectionClient(IEnumerable<DataConnectionDetail>? seed = null)
+    {
+        if (seed is not null)
+        {
+            foreach (var detail in seed)
+            {
+                _store[detail.ConnectionId] = detail;
+            }
+        }
+    }
+
+    public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = _store.Values
+            .OrderBy(c => c.Name, StringComparer.Ordinal)
+            .Select(ToSummary)
+            .ToArray();
+        IReadOnlyList<DataConnectionSummary> result = snapshot;
+        return Task.FromResult(ConnectionResult<IReadOnlyList<DataConnectionSummary>>.Ok(result));
+    }
+
+    public Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!_store.TryGetValue(id, out var detail))
+        {
+            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.NotFound, "error.not_found")));
+        }
+        return Task.FromResult(ConnectionResult<DataConnectionDetail>.Ok(detail));
+    }
+
+    public Task<ConnectionResult<DataConnectionDetail>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Password) && string.IsNullOrWhiteSpace(request.SecretReference))
+        {
+            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Validation, "error.credential_required",
+                    "Provide a password or a secret reference.")));
+        }
+
+        if (_store.Values.Any(c => string.Equals(c.Name, request.Name, StringComparison.OrdinalIgnoreCase)))
+        {
+            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.Conflict, "error.duplicate_name")));
+        }
+
+        var detail = new DataConnectionDetail
+        {
+            ConnectionId = Guid.NewGuid(),
+            Name = request.Name,
+            Description = request.Description,
+            Host = request.Host,
+            Port = request.Port,
+            DatabaseName = request.DatabaseName,
+            Username = request.Username,
+            SslRequired = request.SslRequired,
+            SslMode = request.SslMode,
+            StorageType = string.IsNullOrWhiteSpace(request.SecretReference) ? "managed" : "external",
+            IsActive = true,
+            HealthStatus = "unknown",
+            LastHealthCheck = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = "operator",
+            CredentialReference = request.SecretReference,
+            EncryptionVersion = 1,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        _store[detail.ConnectionId] = detail;
+        return Task.FromResult(ConnectionResult<DataConnectionDetail>.Ok(detail));
+    }
+
+    public Task<ConnectionResult<DataConnectionDetail>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!_store.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.NotFound, "error.not_found")));
+        }
+
+        var updated = new DataConnectionDetail
+        {
+            ConnectionId = existing.ConnectionId,
+            Name = existing.Name,
+            Description = request.Description ?? existing.Description,
+            Host = request.Host ?? existing.Host,
+            Port = request.Port ?? existing.Port,
+            DatabaseName = request.DatabaseName ?? existing.DatabaseName,
+            Username = request.Username ?? existing.Username,
+            SslRequired = request.SslRequired ?? existing.SslRequired,
+            SslMode = request.SslMode ?? existing.SslMode,
+            StorageType = existing.StorageType,
+            IsActive = request.IsActive ?? existing.IsActive,
+            HealthStatus = existing.HealthStatus,
+            LastHealthCheck = existing.LastHealthCheck,
+            CreatedAt = existing.CreatedAt,
+            CreatedBy = existing.CreatedBy,
+            CredentialReference = existing.CredentialReference,
+            EncryptionVersion = string.IsNullOrEmpty(request.Password) ? existing.EncryptionVersion : existing.EncryptionVersion + 1,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        _store[id] = updated;
+        return Task.FromResult(ConnectionResult<DataConnectionDetail>.Ok(updated));
+    }
+
+    public Task<ConnectionResult<DataConnectionDetail>> DisableAsync(Guid id, CancellationToken cancellationToken = default) =>
+        UpdateAsync(id, new UpdateConnectionRequest { IsActive = false }, cancellationToken);
+
+    public Task<ConnectionResult<DataConnectionDetail>> EnableAsync(Guid id, CancellationToken cancellationToken = default) =>
+        UpdateAsync(id, new UpdateConnectionRequest { IsActive = true }, cancellationToken);
+
+    public Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!_store.Remove(id))
+        {
+            return Task.FromResult(ConnectionResult<bool>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.NotFound, "error.not_found")));
+        }
+        return Task.FromResult(ConnectionResult<bool>.Ok(true));
+    }
+
+    public Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        var hint = FailureMessageForHost?.Invoke(request.Host);
+        return Task.FromResult(BuildOutcome(Guid.Empty, request.Name, hint));
+    }
+
+    public Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!_store.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult(ConnectionResult<ConnectionTestOutcome>.Fail(
+                new ConnectionOperationError(ConnectionErrorKind.NotFound, "error.not_found")));
+        }
+
+        var hint = FailureMessageForHost?.Invoke(existing.Host);
+        var outcome = BuildOutcome(existing.ConnectionId, existing.Name, hint);
+
+        if (outcome.IsSuccess)
+        {
+            _store[id] = existing with
+            {
+                HealthStatus = outcome.Value!.IsHealthy ? "healthy" : "unhealthy",
+                LastHealthCheck = outcome.Value!.TestedAt
+            };
+        }
+
+        return Task.FromResult(outcome);
+    }
+
+    private static ConnectionResult<ConnectionTestOutcome> BuildOutcome(Guid id, string name, string? failureMessage) =>
+        ConnectionResult<ConnectionTestOutcome>.Ok(new ConnectionTestOutcome
+        {
+            ConnectionId = id,
+            ConnectionName = name,
+            IsHealthy = failureMessage is null,
+            TestedAt = DateTimeOffset.UtcNow,
+            Message = failureMessage ?? "Connection healthy."
+        });
+
+    private static DataConnectionSummary ToSummary(DataConnectionDetail detail) => new()
+    {
+        ConnectionId = detail.ConnectionId,
+        Name = detail.Name,
+        Description = detail.Description,
+        Host = detail.Host,
+        Port = detail.Port,
+        DatabaseName = detail.DatabaseName,
+        Username = detail.Username,
+        SslRequired = detail.SslRequired,
+        SslMode = detail.SslMode,
+        StorageType = detail.StorageType,
+        IsActive = detail.IsActive,
+        HealthStatus = detail.HealthStatus,
+        LastHealthCheck = detail.LastHealthCheck,
+        CreatedAt = detail.CreatedAt,
+        CreatedBy = detail.CreatedBy
+    };
+}

--- a/src/Honua.Admin/Services/DataConnections/StubDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/StubDataConnectionClient.cs
@@ -10,7 +10,9 @@ namespace Honua.Admin.Services.DataConnections;
 /// <summary>
 /// Deterministic in-memory backing for tests and dev. The HTTP path is the
 /// production wire; the stub mirrors its observable behavior so the bUnit
-/// E2E and the production path agree on every state transition.
+/// E2E and the production path agree on every state transition. Per the
+/// real server contract, mutating endpoints return a
+/// <see cref="DataConnectionSummary"/> projected from the stored detail.
 /// </summary>
 public sealed class StubDataConnectionClient : IDataConnectionClient
 {
@@ -53,18 +55,18 @@ public sealed class StubDataConnectionClient : IDataConnectionClient
         return Task.FromResult(ConnectionResult<DataConnectionDetail>.Ok(detail));
     }
 
-    public Task<ConnectionResult<DataConnectionDetail>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
+    public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(request.Password) && string.IsNullOrWhiteSpace(request.SecretReference))
         {
-            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+            return Task.FromResult(ConnectionResult<DataConnectionSummary>.Fail(
                 new ConnectionOperationError(ConnectionErrorKind.Validation, "error.credential_required",
                     "Provide a password or a secret reference.")));
         }
 
         if (_store.Values.Any(c => string.Equals(c.Name, request.Name, StringComparison.OrdinalIgnoreCase)))
         {
-            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+            return Task.FromResult(ConnectionResult<DataConnectionSummary>.Fail(
                 new ConnectionOperationError(ConnectionErrorKind.Conflict, "error.duplicate_name")));
         }
 
@@ -91,14 +93,14 @@ public sealed class StubDataConnectionClient : IDataConnectionClient
         };
 
         _store[detail.ConnectionId] = detail;
-        return Task.FromResult(ConnectionResult<DataConnectionDetail>.Ok(detail));
+        return Task.FromResult(ConnectionResult<DataConnectionSummary>.Ok(ToSummary(detail)));
     }
 
-    public Task<ConnectionResult<DataConnectionDetail>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default)
+    public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken cancellationToken = default)
     {
         if (!_store.TryGetValue(id, out var existing))
         {
-            return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+            return Task.FromResult(ConnectionResult<DataConnectionSummary>.Fail(
                 new ConnectionOperationError(ConnectionErrorKind.NotFound, "error.not_found")));
         }
 
@@ -125,13 +127,13 @@ public sealed class StubDataConnectionClient : IDataConnectionClient
         };
 
         _store[id] = updated;
-        return Task.FromResult(ConnectionResult<DataConnectionDetail>.Ok(updated));
+        return Task.FromResult(ConnectionResult<DataConnectionSummary>.Ok(ToSummary(updated)));
     }
 
-    public Task<ConnectionResult<DataConnectionDetail>> DisableAsync(Guid id, CancellationToken cancellationToken = default) =>
+    public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, CancellationToken cancellationToken = default) =>
         UpdateAsync(id, new UpdateConnectionRequest { IsActive = false }, cancellationToken);
 
-    public Task<ConnectionResult<DataConnectionDetail>> EnableAsync(Guid id, CancellationToken cancellationToken = default) =>
+    public Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, CancellationToken cancellationToken = default) =>
         UpdateAsync(id, new UpdateConnectionRequest { IsActive = true }, cancellationToken);
 
     public Task<ConnectionResult<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default)

--- a/src/Honua.Admin/Services/DataConnections/StubDataConnectionClient.cs
+++ b/src/Honua.Admin/Services/DataConnections/StubDataConnectionClient.cs
@@ -37,7 +37,13 @@ public sealed class StubDataConnectionClient : IDataConnectionClient
 
     public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(CancellationToken cancellationToken = default)
     {
+        // Mirror PostgresSecureConnectionRegistry.GetActiveConnectionsAsync's
+        // `WHERE is_active = true` clause: the production list endpoint hides
+        // disabled connections. Disabled rows are still retrievable by id via
+        // GetAsync (server keeps them, just doesn't list them) — see the gap
+        // report for the operator-UX implication of this asymmetry.
         var snapshot = _store.Values
+            .Where(c => c.IsActive)
             .OrderBy(c => c.Name, StringComparer.Ordinal)
             .Select(ToSummary)
             .ToArray();

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -22,6 +22,9 @@
     <MudNavLink Href="/operator/sql" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Storage">
         Spatial SQL
     </MudNavLink>
+    <MudNavLink Href="/operator/data-connections" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Storage">
+        Data connections
+    </MudNavLink>
     <MudNavGroup Title="Identity" Icon="@Icons.Material.Filled.VpnKey" Expanded="true">
         <MudNavLink Href="/admin/identity/providers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AccountCircle">
             Providers

--- a/src/Honua.Admin/_Imports.razor
+++ b/src/Honua.Admin/_Imports.razor
@@ -11,12 +11,17 @@
 @using Honua.Admin.Shared
 @using Honua.Admin.Components.Identity
 @using Honua.Admin.Components.LicenseWorkspace
+@using Honua.Admin.Components.Shared
 @using Honua.Admin.Components.SpecWorkspace
 @using Honua.Admin.Components.SpatialSql
+@using Honua.Admin.Models.DataConnections
 @using Honua.Admin.Models.Identity
 @using Honua.Admin.Models.LicenseWorkspace
 @using Honua.Admin.Models.SpatialSql
 @using Honua.Admin.Models.SpecWorkspace
+@using Honua.Admin.Pages.Operator.DataConnections
+@using Honua.Admin.Services.DataConnections
+@using Honua.Admin.Services.DataConnections.Providers
 @using Honua.Admin.Services.Identity
 @using Honua.Admin.Services.LicenseWorkspace
 @using Honua.Admin.Services.SpatialSql

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsBunitTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsBunitTests.cs
@@ -3,9 +3,13 @@ using System.Threading.Tasks;
 using Bunit;
 using Honua.Admin.Models.DataConnections;
 using Honua.Admin.Pages.Operator.DataConnections;
+using Honua.Admin.Pages.Operator.DataConnections.Providers;
 using Honua.Admin.Services.DataConnections;
 using Honua.Admin.Services.DataConnections.Providers;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
 using MudBlazor.Services;
 using Xunit;
 
@@ -128,6 +132,78 @@ public sealed class DataConnectionsBunitTests : IDisposable
         await state.LoadDetailAsync(newId);
         Assert.NotNull(state.SelectedDetail);
         Assert.False(state.SelectedDetail!.IsActive);
+    }
+
+    [Fact]
+    public void PostgresConnectionForm_in_edit_mode_locks_fields_outside_the_update_contract()
+    {
+        // honua-server's UpdateSecureConnectionRequest has no Name,
+        // SecretReference, or SecretType slots. The form must render those
+        // controls read-only / hidden in edit mode so the operator never
+        // believes a Save will persist them.
+        var draft = new ConnectionDraft
+        {
+            ConnectionId = Guid.NewGuid(),
+            ProviderId = "postgres",
+            Name = "primary",
+            Host = "db.example.com",
+            DatabaseName = "honua",
+            Username = "honua",
+            CredentialMode = CredentialMode.External,
+            SecretReference = "aws:secretsmanager:prod-db-creds",
+            SecretType = "aws"
+        };
+
+        var cut = RenderFormWithPopoverHost(draft, isEdit: true);
+
+        // Display name input is read-only / disabled — MudTextField puts
+        // data-testid on the wrapping element, so look at the markup
+        // around the testid.
+        var nameMarkup = cut.Find("[data-testid='conn-name']").OuterHtml;
+        Assert.Contains("readonly", nameMarkup, StringComparison.OrdinalIgnoreCase);
+
+        // Credential-mode helper appears only in edit mode.
+        cut.Find("[data-testid='conn-mode-edit-help']");
+
+        // External-mode secret reference is rendered read-only; the secret
+        // type input must not be present (rotating the type is impossible
+        // through the current update contract).
+        var secretRefMarkup = cut.Find("[data-testid='conn-secret-ref']").OuterHtml;
+        Assert.Contains("readonly", secretRefMarkup, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(cut.FindAll("[data-testid='conn-secret-type']"));
+    }
+
+    [Fact]
+    public void PostgresConnectionForm_in_create_mode_keeps_credential_mode_editable()
+    {
+        // Sanity check the IsEdit gate cuts only the edit path: a fresh
+        // create-mode draft starting in External mode must keep the
+        // secret-type input live (operator can rotate before save).
+        var draft = new ConnectionDraft
+        {
+            ProviderId = "postgres",
+            CredentialMode = CredentialMode.External
+        };
+
+        var cut = RenderFormWithPopoverHost(draft, isEdit: false);
+
+        Assert.Empty(cut.FindAll("[data-testid='conn-mode-edit-help']"));
+        cut.Find("[data-testid='conn-secret-type']");
+    }
+
+    private IRenderedFragment RenderFormWithPopoverHost(ConnectionDraft draft, bool isEdit)
+    {
+        // MudSelect (used for SSL mode) requires a MudPopoverProvider in
+        // the render tree. Wrap the form in a host that supplies one.
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<PostgresConnectionForm>(1);
+            builder.AddAttribute(2, nameof(PostgresConnectionForm.Draft), draft);
+            builder.AddAttribute(3, nameof(PostgresConnectionForm.IsEdit), isEdit);
+            builder.CloseComponent();
+        });
     }
 
     public void Dispose()

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsBunitTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsBunitTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Pages.Operator.DataConnections;
+using Honua.Admin.Services.DataConnections;
+using Honua.Admin.Services.DataConnections.Providers;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Honua.Admin.Tests.DataConnections;
+
+/// <summary>
+/// Component-level "E2E" exercising the create → test → disable round-trip
+/// against the in-memory <see cref="StubDataConnectionClient"/>. Per the
+/// design brief, this satisfies the "at least one E2E" contract clause
+/// without introducing Playwright + a server harness.
+/// </summary>
+public sealed class DataConnectionsBunitTests : IDisposable
+{
+    private readonly TestContext _ctx = new();
+    private readonly StubDataConnectionClient _client = new();
+
+    public DataConnectionsBunitTests()
+    {
+        _ctx.Services.AddMudServices();
+        _ctx.Services.AddSingleton<IDataConnectionClient>(_client);
+        _ctx.Services.AddSingleton<IProviderRegistration, PostgresProviderRegistration>();
+        _ctx.Services.AddSingleton<IProviderRegistration, SqlServerStubProviderRegistration>();
+        _ctx.Services.AddSingleton<IProviderRegistry, ProviderRegistry>();
+        _ctx.Services.AddSingleton<IDataConnectionTelemetry, RecordingTelemetry>();
+        _ctx.Services.AddScoped<DataConnectionsState>();
+
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public async Task DiagnosticGrid_renders_six_rows_for_a_healthy_outcome()
+    {
+        var state = _ctx.Services.GetRequiredService<DataConnectionsState>();
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "demo";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        var diagnostic = await state.RunDraftPreflightAsync();
+        Assert.NotNull(diagnostic);
+
+        var cut = _ctx.RenderComponent<DiagnosticGrid>(parameters => parameters
+            .Add(p => p.Diagnostic, diagnostic!));
+
+        var rows = cut.FindAll("[data-testid^='diagnostic-row-']");
+        Assert.Equal(6, rows.Count);
+    }
+
+    [Fact]
+    public async Task DiagnosticGrid_renders_failed_step_for_routed_failure_message()
+    {
+        var state = _ctx.Services.GetRequiredService<DataConnectionsState>();
+        _client.FailureMessageForHost = host =>
+            host == "broken.example.com" ? "authentication failed" : null;
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "demo";
+        draft.Host = "broken.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "wrong";
+
+        var diagnostic = await state.RunDraftPreflightAsync();
+        Assert.NotNull(diagnostic);
+
+        var cut = _ctx.RenderComponent<DiagnosticGrid>(parameters => parameters
+            .Add(p => p.Diagnostic, diagnostic!));
+
+        var authRow = cut.Find("[data-testid='diagnostic-row-auth']");
+        Assert.Contains("Failed", authRow.TextContent);
+    }
+
+    [Fact]
+    public async Task End_to_end_create_test_disable_round_trip_against_stub_client()
+    {
+        var state = _ctx.Services.GetRequiredService<DataConnectionsState>();
+
+        // Create
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "ops-primary";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret-1234";
+        draft.CredentialMode = CredentialMode.Managed;
+
+        // Preflight against the draft (read-only — only the test endpoint is called).
+        var diagnostic = await state.RunDraftPreflightAsync();
+        Assert.NotNull(diagnostic);
+        Assert.False(diagnostic!.AnyFailed);
+
+        // Save
+        var createResult = await state.SubmitDraftAsync();
+        Assert.True(createResult.IsSuccess);
+        var newId = createResult.Value!.ConnectionId;
+
+        // List refreshes show the new connection
+        await state.RefreshListAsync();
+        Assert.Single(state.Connections, c => c.ConnectionId == newId);
+
+        // Detail
+        await state.LoadDetailAsync(newId);
+        Assert.NotNull(state.SelectedDetail);
+        Assert.True(state.SelectedDetail!.IsActive);
+
+        // Disable
+        var disableResult = await state.SetActiveAsync(newId, active: false);
+        Assert.True(disableResult.IsSuccess);
+
+        await state.RefreshListAsync();
+        Assert.Single(state.Connections, c => c.ConnectionId == newId && !c.IsActive);
+    }
+
+    public void Dispose()
+    {
+        _ctx.Dispose();
+    }
+}

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsBunitTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsBunitTests.cs
@@ -117,8 +117,17 @@ public sealed class DataConnectionsBunitTests : IDisposable
         var disableResult = await state.SetActiveAsync(newId, active: false);
         Assert.True(disableResult.IsSuccess);
 
+        // Production list endpoint filters out disabled connections (server's
+        // GetActiveConnectionsAsync uses `WHERE is_active = true`). After a
+        // refresh the row should disappear from the workspace list, but…
         await state.RefreshListAsync();
-        Assert.Single(state.Connections, c => c.ConnectionId == newId && !c.IsActive);
+        Assert.DoesNotContain(state.Connections, c => c.ConnectionId == newId);
+
+        // …it remains retrievable by id (GetConnectionAsync does not filter
+        // on IsActive), so direct-URL navigation still resolves the detail.
+        await state.LoadDetailAsync(newId);
+        Assert.NotNull(state.SelectedDetail);
+        Assert.False(state.SelectedDetail!.IsActive);
     }
 
     public void Dispose()

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Honua.Admin.Models.DataConnections;
@@ -174,6 +175,22 @@ public sealed class DataConnectionsStateTests
     }
 
     [Fact]
+    public void BeginCreateDraft_throws_for_unknown_provider_so_callers_must_TryGet_first()
+    {
+        // Pin the contract Create.razor relies on: BeginCreateDraft is the
+        // strict path and throws for unknown ids. The page must consult the
+        // registry's TryGet first or it will crash before the
+        // missing-provider alert can render.
+        var stub = new StubDataConnectionClient();
+        var (state, _) = BuildState(stub);
+
+        var registry = state.ProviderRegistry;
+        Assert.False(registry.TryGet("bogus", out _));
+
+        Assert.Throws<InvalidOperationException>(() => state.BeginCreateDraft("bogus"));
+    }
+
+    [Fact]
     public async Task SubmitEditAsync_updates_existing_connection_and_records_event()
     {
         var seed = Sample("primary", isActive: true);
@@ -308,6 +325,71 @@ public sealed class DataConnectionsStateTests
     }
 
     [Fact]
+    public async Task ClearDraft_when_navigating_to_another_connection_drops_stale_edit_buffer()
+    {
+        // Sibling invariant for Detail.razor's route-change reset: editing
+        // connection A and then navigating to connection B must clear the
+        // draft so SubmitEdit cannot fire B's id with A's wire body. The
+        // page-level reset (ResetEditState) calls ClearDraft only when
+        // Draft.ConnectionId differs from the new route id; pin the
+        // state-store contract that supports it.
+        var first = Sample("first", isActive: true);
+        var second = Sample("second", isActive: true);
+        var stub = new StubDataConnectionClient(new[] { first, second });
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(first.ConnectionId);
+
+        var draft = state.BeginEditDraft(state.SelectedDetail!);
+        Assert.Equal(first.ConnectionId, draft.ConnectionId);
+
+        // Simulate the page-level route-change reset condition.
+        if (state.Draft is { } current && current.ConnectionId != second.ConnectionId)
+        {
+            state.ClearDraft();
+        }
+
+        Assert.Null(state.Draft);
+    }
+
+    [Fact]
+    public async Task SubmitEditAsync_does_not_send_Name_or_SecretReference_to_match_server_contract()
+    {
+        // honua-server's UpdateSecureConnectionRequest has no Name,
+        // SecretReference, or SecretType fields. The edit form is gated on
+        // IsEdit so the operator never sees those fields, but pin the
+        // SubmitEditAsync wire shape too so a future form change cannot
+        // silently start sending values the server will drop.
+        var seed = Sample("primary", isActive: true);
+        var stub = new RecordingUpdateStubClient(seed);
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+
+        var draft = state.BeginEditDraft(state.SelectedDetail!);
+        // Operator-edited values that the form locks down — even if a future
+        // form regression lets them through, SubmitEditAsync must not forward
+        // them to the server.
+        draft.Name = "renamed-but-ignored";
+        draft.SecretReference = "vault:bogus";
+        draft.SecretType = "vault";
+        draft.Description = "primary OLAP";
+
+        await state.SubmitEditAsync();
+
+        Assert.NotNull(stub.LastUpdateRequest);
+        Assert.Equal("primary OLAP", stub.LastUpdateRequest!.Description);
+        // The wire shape has no Name / SecretReference / SecretType slots,
+        // so the values cannot be forwarded — assert the request type itself
+        // does not expose them.
+        Assert.DoesNotContain(typeof(UpdateConnectionRequest).GetProperties(), p => p.Name == "Name");
+        Assert.DoesNotContain(typeof(UpdateConnectionRequest).GetProperties(), p => p.Name == "SecretReference");
+        Assert.DoesNotContain(typeof(UpdateConnectionRequest).GetProperties(), p => p.Name == "SecretType");
+    }
+
+    [Fact]
     public void GetCapabilityMatrix_marks_every_check_not_assessed_until_server_endpoint_lands()
     {
         var stub = new StubDataConnectionClient();
@@ -335,6 +417,48 @@ public sealed class DataConnectionsStateTests
             new PostgresProviderRegistration(),
             new SqlServerStubProviderRegistration()
         });
+    }
+
+    private sealed class RecordingUpdateStubClient : IDataConnectionClient
+    {
+        private readonly StubDataConnectionClient _inner;
+
+        public RecordingUpdateStubClient(DataConnectionDetail seed)
+        {
+            _inner = new StubDataConnectionClient(new[] { seed });
+        }
+
+        public UpdateConnectionRequest? LastUpdateRequest { get; private set; }
+
+        public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.GetAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.CreateAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default)
+        {
+            LastUpdateRequest = request;
+            return _inner.UpdateAsync(id, request, cancellationToken);
+        }
+
+        public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DisableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.EnableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<bool>> DeleteAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DeleteAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.TestDraftAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.TestExistingAsync(id, cancellationToken);
     }
 
     private sealed class ThrowOnGetStubClient : IDataConnectionClient

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
@@ -197,6 +197,117 @@ public sealed class DataConnectionsStateTests
     }
 
     [Fact]
+    public async Task LoadDetailAsync_failure_for_new_id_clears_prior_selection()
+    {
+        // Bug-fix invariant: when the route id changes, a failed Detail load
+        // must not leave SelectedDetail pointing at the previous connection.
+        var first = Sample("primary", isActive: true);
+        var stub = new ThrowOnGetStubClient(seed: first);
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(first.ConnectionId);
+        Assert.NotNull(state.SelectedDetail);
+        Assert.Equal(first.ConnectionId, state.SelectedDetail!.ConnectionId);
+
+        var unknownId = Guid.NewGuid();
+        stub.FailNextGet = true;
+        await state.LoadDetailAsync(unknownId);
+
+        Assert.Null(state.SelectedDetail);
+        Assert.Equal(WorkspaceListStatus.Error, state.Status);
+        Assert.NotNull(state.LastError);
+    }
+
+    [Fact]
+    public async Task LoadDetailAsync_failure_for_same_id_preserves_selection_for_retry()
+    {
+        // Same-id reloads (a transient blip while staying on the same Detail
+        // page) should keep the previously-loaded value so the page does not
+        // blank between retries.
+        var seed = Sample("primary", isActive: true);
+        var stub = new ThrowOnGetStubClient(seed: seed);
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+        Assert.NotNull(state.SelectedDetail);
+
+        stub.FailNextGet = true;
+        await state.LoadDetailAsync(seed.ConnectionId);
+
+        Assert.NotNull(state.SelectedDetail);
+        Assert.Equal(seed.ConnectionId, state.SelectedDetail!.ConnectionId);
+        Assert.Equal(WorkspaceListStatus.Error, state.Status);
+    }
+
+    [Fact]
+    public async Task RunExistingPreflightAsync_success_reconciles_health_in_selected_detail_and_list()
+    {
+        // The server's test endpoint does not persist HealthStatus to the
+        // row, so the state store must derive the refreshed health locally
+        // from the test outcome — otherwise the Detail page and list view
+        // keep showing stale "unknown" until the operator re-creates the
+        // connection.
+        var seed = Sample("primary", isActive: true);
+        var stub = new StubDataConnectionClient(new[] { seed });
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+        Assert.Equal("unknown", state.SelectedDetail!.HealthStatus);
+
+        var diagnostic = await state.RunExistingPreflightAsync(seed.ConnectionId);
+
+        Assert.NotNull(diagnostic);
+        Assert.False(diagnostic!.AnyFailed);
+        Assert.Equal("Healthy", state.SelectedDetail!.HealthStatus);
+        Assert.NotNull(state.SelectedDetail.LastHealthCheck);
+
+        var listEntry = state.Connections.Single(c => c.ConnectionId == seed.ConnectionId);
+        Assert.Equal("Healthy", listEntry.HealthStatus);
+        Assert.NotNull(listEntry.LastHealthCheck);
+    }
+
+    [Fact]
+    public async Task RunExistingPreflightAsync_failed_outcome_marks_unhealthy_locally()
+    {
+        var seed = Sample("primary", isActive: true);
+        var stub = new StubDataConnectionClient(new[] { seed })
+        {
+            FailureMessageForHost = host => host == seed.Host ? "DNS lookup failed" : null
+        };
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+
+        var diagnostic = await state.RunExistingPreflightAsync(seed.ConnectionId);
+
+        Assert.NotNull(diagnostic);
+        Assert.True(diagnostic!.AnyFailed);
+        Assert.Equal("Unhealthy", state.SelectedDetail!.HealthStatus);
+        Assert.NotNull(state.SelectedDetail.LastHealthCheck);
+    }
+
+    [Fact]
+    public async Task ListAsync_filters_disabled_connections_to_match_server_contract()
+    {
+        // PostgresSecureConnectionRegistry.GetActiveConnectionsAsync's SQL is
+        // `WHERE is_active = true`, so disabled rows never appear in the
+        // workspace list. Stub must mirror that for parity.
+        var active = Sample("primary", isActive: true);
+        var disabled = Sample("legacy", isActive: false);
+        var stub = new StubDataConnectionClient(new[] { active, disabled });
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+
+        Assert.Single(state.Connections);
+        Assert.Equal(active.ConnectionId, state.Connections[0].ConnectionId);
+    }
+
+    [Fact]
     public void GetCapabilityMatrix_marks_every_check_not_assessed_until_server_endpoint_lands()
     {
         var stub = new StubDataConnectionClient();
@@ -224,6 +335,53 @@ public sealed class DataConnectionsStateTests
             new PostgresProviderRegistration(),
             new SqlServerStubProviderRegistration()
         });
+    }
+
+    private sealed class ThrowOnGetStubClient : IDataConnectionClient
+    {
+        private readonly StubDataConnectionClient _inner;
+
+        public ThrowOnGetStubClient(DataConnectionDetail seed)
+        {
+            _inner = new StubDataConnectionClient(new[] { seed });
+        }
+
+        public bool FailNextGet { get; set; }
+
+        public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (FailNextGet)
+            {
+                FailNextGet = false;
+                return Task.FromResult(ConnectionResult<DataConnectionDetail>.Fail(
+                    new ConnectionOperationError(ConnectionErrorKind.Network, "error.network")));
+            }
+            return _inner.GetAsync(id, cancellationToken);
+        }
+
+        public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.CreateAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.UpdateAsync(id, request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DisableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.EnableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<bool>> DeleteAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DeleteAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.TestDraftAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.TestExistingAsync(id, cancellationToken);
     }
 
     private static DataConnectionDetail Sample(string name, bool isActive) => new()

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
@@ -753,6 +753,146 @@ public sealed class DataConnectionsStateTests
         Assert.Null(state.LatestDiagnostic);
     }
 
+    [Fact]
+    public async Task Stale_RunDraftPreflight_after_UpdateDraft_does_not_repaint_grid()
+    {
+        // Updating any draft field supersedes the in-flight preflight. The
+        // late result describes the old request body and must not become the
+        // visible diagnostic for the newer draft values.
+        var stub = new GatedDataConnectionClient(Array.Empty<DataConnectionDetail>())
+        {
+            FailureMessageForHost = host => host == "broken.example.com" ? "SSL handshake failed" : null
+        };
+        var (state, _) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "demo";
+        draft.Host = "broken.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        stub.HoldTestDraft();
+        var slow = state.RunDraftPreflightAsync();
+
+        state.UpdateDraft(d => d.Host = "fixed.example.com");
+
+        stub.ReleaseTestDraft();
+        var diagnostic = await slow;
+
+        Assert.Null(diagnostic);
+        Assert.Null(state.LatestDiagnostic);
+        Assert.Equal("fixed.example.com", state.Draft!.Host);
+        Assert.Equal(WorkspaceListStatus.Idle, state.Status);
+    }
+
+    [Fact]
+    public async Task Stale_SubmitDraft_after_UpdateDraft_keeps_newer_draft_for_retry()
+    {
+        // The old save may complete on the server, but the state store must
+        // not clear the form or return success to Create.razor once the
+        // operator has edited the draft again. Returning a failure prevents
+        // late navigation to the stale connection.
+        var stub = new GatedDataConnectionClient(Array.Empty<DataConnectionDetail>());
+        var (state, _) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "old";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        stub.HoldCreate();
+        var staleSubmit = state.SubmitDraftAsync();
+
+        state.UpdateDraft(d => d.Name = "new");
+        stub.ReleaseCreate();
+        var staleResult = await staleSubmit;
+
+        Assert.False(staleResult.IsSuccess);
+        Assert.Equal("error.stale_draft", staleResult.Error!.CopyKey);
+        Assert.Null(state.LastError);
+        Assert.NotNull(state.Draft);
+        Assert.Equal("new", state.Draft!.Name);
+        Assert.Empty(state.Connections);
+        Assert.Equal(WorkspaceListStatus.Idle, state.Status);
+
+        var retry = await state.SubmitDraftAsync();
+
+        Assert.True(retry.IsSuccess);
+        Assert.Null(state.Draft);
+        Assert.Single(state.Connections);
+        Assert.Equal("new", state.Connections[0].Name);
+    }
+
+    [Fact]
+    public async Task Stale_SubmitDraft_after_ClearDraft_does_not_restore_or_error()
+    {
+        // Cancel is the terminal sibling of edit-while-save: a late create
+        // completion must not recreate a draft, surface an error, or leave the
+        // workspace stuck in Mutating.
+        var stub = new GatedDataConnectionClient(Array.Empty<DataConnectionDetail>());
+        var (state, _) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "demo";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        stub.HoldCreate();
+        var staleSubmit = state.SubmitDraftAsync();
+
+        state.ClearDraft();
+        stub.ReleaseCreate();
+        var staleResult = await staleSubmit;
+
+        Assert.False(staleResult.IsSuccess);
+        Assert.Equal("error.stale_draft", staleResult.Error!.CopyKey);
+        Assert.Null(state.Draft);
+        Assert.Null(state.LastError);
+        Assert.Empty(state.Connections);
+        Assert.Equal(WorkspaceListStatus.Idle, state.Status);
+    }
+
+    [Fact]
+    public async Task Stale_SubmitEdit_after_UpdateDraft_keeps_newer_edit_buffer_for_retry()
+    {
+        // Same ownership invariant for edit saves: a late update response
+        // should not clear a draft that now contains newer operator edits.
+        var seed = Sample("primary", isActive: true);
+        var stub = new GatedDataConnectionClient(new[] { seed });
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+        var draft = state.BeginEditDraft(state.SelectedDetail!);
+        draft.Description = "old edit";
+
+        stub.HoldUpdate(seed.ConnectionId);
+        var staleSubmit = state.SubmitEditAsync();
+
+        state.UpdateDraft(d => d.Description = "new edit");
+        stub.ReleaseUpdate(seed.ConnectionId);
+        var staleResult = await staleSubmit;
+
+        Assert.False(staleResult.IsSuccess);
+        Assert.Equal("error.stale_draft", staleResult.Error!.CopyKey);
+        Assert.Null(state.LastError);
+        Assert.NotNull(state.Draft);
+        Assert.Equal("new edit", state.Draft!.Description);
+        Assert.Equal(seed.ConnectionId, state.SelectedDetail!.ConnectionId);
+        Assert.Equal(WorkspaceListStatus.Idle, state.Status);
+
+        var retry = await state.SubmitEditAsync();
+
+        Assert.True(retry.IsSuccess);
+        Assert.Null(state.Draft);
+        Assert.Equal("new edit", retry.Value!.Description);
+    }
+
     /// <summary>
     /// Per-method gates that hold a single in-flight call until released, so
     /// tests can pin the stale-write invariants in <c>DataConnectionsState</c>
@@ -764,6 +904,8 @@ public sealed class DataConnectionsStateTests
         private readonly StubDataConnectionClient _inner;
         private readonly Dictionary<Guid, TaskCompletionSource> _getGates = new();
         private readonly Dictionary<Guid, TaskCompletionSource> _testExistingGates = new();
+        private readonly Dictionary<Guid, TaskCompletionSource> _updateGates = new();
+        private TaskCompletionSource? _createGate;
         private TaskCompletionSource? _testDraftGate;
 
         public GatedDataConnectionClient(IEnumerable<DataConnectionDetail> seed)
@@ -785,6 +927,14 @@ public sealed class DataConnectionsStateTests
 
         public void ReleaseTestExisting(Guid id) => _testExistingGates[id].TrySetResult();
 
+        public void HoldCreate() => _createGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseCreate() => _createGate!.TrySetResult();
+
+        public void HoldUpdate(Guid id) => _updateGates[id] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseUpdate(Guid id) => _updateGates[id].TrySetResult();
+
         public void HoldTestDraft() => _testDraftGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void ReleaseTestDraft() => _testDraftGate!.TrySetResult();
@@ -801,11 +951,23 @@ public sealed class DataConnectionsStateTests
             return await _inner.GetAsync(id, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
-            _inner.CreateAsync(request, cancellationToken);
+        public async Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (_createGate is { } gate)
+            {
+                await gate.Task.ConfigureAwait(false);
+            }
+            return await _inner.CreateAsync(request, cancellationToken).ConfigureAwait(false);
+        }
 
-        public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
-            _inner.UpdateAsync(id, request, cancellationToken);
+        public async Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (_updateGates.TryGetValue(id, out var gate))
+            {
+                await gate.Task.ConfigureAwait(false);
+            }
+            return await _inner.UpdateAsync(id, request, cancellationToken).ConfigureAwait(false);
+        }
 
         public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
             _inner.DisableAsync(id, cancellationToken);

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
@@ -524,4 +524,249 @@ public sealed class DataConnectionsStateTests
         CreatedAt = DateTimeOffset.UtcNow,
         UpdatedAt = DateTimeOffset.UtcNow
     };
+
+    [Fact]
+    public async Task Stale_LoadDetail_response_does_not_overwrite_newer_LoadDetail()
+    {
+        // Codex finding: LoadDetailAsync awaits GetAsync(id) and unconditionally
+        // assigns SelectedDetail = result.Value. If connection A's slow GET
+        // completes after connection B's fast GET, SelectedDetail rewinds to
+        // A while the route is B. Pin the staleness guard.
+        var first = Sample("first", isActive: true);
+        var second = Sample("second", isActive: true);
+        var stub = new GatedDataConnectionClient(new[] { first, second });
+        var (state, _) = BuildState(stub);
+
+        // Hold the slow load for `first` so the second's faster load can
+        // complete first.
+        stub.HoldGet(first.ConnectionId);
+        var slow = state.LoadDetailAsync(first.ConnectionId);
+
+        var fast = state.LoadDetailAsync(second.ConnectionId);
+        await fast;
+        Assert.Equal(second.ConnectionId, state.SelectedDetail!.ConnectionId);
+
+        // Releasing the slow GET must NOT rewind SelectedDetail to first.
+        stub.ReleaseGet(first.ConnectionId);
+        await slow;
+
+        Assert.Equal(second.ConnectionId, state.SelectedDetail!.ConnectionId);
+    }
+
+    [Fact]
+    public async Task Stale_RunExistingPreflight_response_does_not_overwrite_newer_preflight()
+    {
+        // Sibling invariant for RunExistingPreflightAsync: a late TestExisting
+        // for a prior connection cannot replace the current diagnostics grid.
+        var first = Sample("first", isActive: true) with { Host = "broken.example.com" };
+        var second = Sample("second", isActive: true) with { Host = "ok.example.com" };
+        var stub = new GatedDataConnectionClient(new[] { first, second })
+        {
+            FailureMessageForHost = host => host == first.Host ? "DNS lookup failed" : null
+        };
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(first.ConnectionId);
+
+        // Slow preflight for first (would be Unhealthy if it landed).
+        stub.HoldTestExisting(first.ConnectionId);
+        var slow = state.RunExistingPreflightAsync(first.ConnectionId);
+
+        // The user navigates to second and triggers a fresh preflight.
+        await state.LoadDetailAsync(second.ConnectionId);
+        var fastDiagnostic = await state.RunExistingPreflightAsync(second.ConnectionId);
+
+        Assert.NotNull(fastDiagnostic);
+        Assert.False(fastDiagnostic!.AnyFailed);
+        Assert.Same(fastDiagnostic, state.LatestDiagnostic);
+
+        // Releasing the slow preflight must drop its result silently.
+        stub.ReleaseTestExisting(first.ConnectionId);
+        var slowDiagnostic = await slow;
+
+        Assert.Null(slowDiagnostic);
+        Assert.Same(fastDiagnostic, state.LatestDiagnostic);
+        // The list reconciliation for `first` must not have stomped second's
+        // health either — second's row stays Healthy.
+        var secondRow = state.Connections.Single(c => c.ConnectionId == second.ConnectionId);
+        Assert.Equal("Healthy", secondRow.HealthStatus);
+    }
+
+    [Fact]
+    public async Task Stale_LoadDetail_after_BeginCreateDraft_does_not_resurrect_prior_selection()
+    {
+        // BeginCreateDraft is a user-driven supersede: a slow LoadDetail
+        // already in flight must drop its post-await write rather than
+        // restore SelectedDetail over the new "create" context.
+        var seed = Sample("first", isActive: true);
+        var stub = new GatedDataConnectionClient(new[] { seed });
+        var (state, _) = BuildState(stub);
+
+        stub.HoldGet(seed.ConnectionId);
+        var slow = state.LoadDetailAsync(seed.ConnectionId);
+
+        // User pivots to "new connection" before the load lands.
+        state.BeginCreateDraft("postgres");
+        Assert.Null(state.SelectedDetail);
+
+        stub.ReleaseGet(seed.ConnectionId);
+        await slow;
+
+        Assert.Null(state.SelectedDetail);
+        Assert.NotNull(state.Draft);
+    }
+
+    [Fact]
+    public async Task Stale_TryRefresh_after_route_change_does_not_overwrite_new_LoadDetail()
+    {
+        // SubmitEditAsync's internal TryRefreshSelectedDetailAsync (a follower
+        // of the user-intended owner id) must drop if the user has navigated
+        // away mid-flight. Without the id-snapshot guard, the late refresh
+        // for connection A would clobber a successful LoadDetail for B.
+        var first = Sample("first", isActive: true);
+        var second = Sample("second", isActive: true);
+        var stub = new GatedDataConnectionClient(new[] { first, second });
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(first.ConnectionId);
+
+        var draft = state.BeginEditDraft(state.SelectedDetail!);
+        draft.Description = "updated";
+
+        // SubmitEditAsync internally awaits UpdateAsync, then awaits
+        // TryRefreshSelectedDetailAsync. We hold the TryRefresh's GetAsync so
+        // we can interleave a route change before it lands.
+        stub.HoldGet(first.ConnectionId);
+        var submit = state.SubmitEditAsync();
+
+        // Wait for the UpdateAsync to land (synchronous in the gated stub —
+        // only Get/TestExisting are gated). The TryRefresh is now waiting on
+        // the held GetAsync(first).
+        // Now navigate to the second connection — LoadDetail bumps the
+        // detail generation and updates the owner id.
+        await state.LoadDetailAsync(second.ConnectionId);
+        Assert.Equal(second.ConnectionId, state.SelectedDetail!.ConnectionId);
+
+        // Releasing the slow TryRefresh must NOT overwrite SelectedDetail
+        // back to first — its captured generation is stale AND its target
+        // id no longer matches the user-intended owner.
+        stub.ReleaseGet(first.ConnectionId);
+        await submit;
+
+        Assert.Equal(second.ConnectionId, state.SelectedDetail!.ConnectionId);
+    }
+
+    [Fact]
+    public async Task Stale_RunDraftPreflight_after_ClearDraft_does_not_repaint_grid()
+    {
+        // Sibling invariant for RunDraftPreflightAsync: cancelling the draft
+        // (ClearDraft) mid-flight must drop the late preflight result so it
+        // cannot repaint the diagnostic grid after the user has abandoned
+        // the create flow.
+        var stub = new GatedDataConnectionClient(Array.Empty<DataConnectionDetail>());
+        var (state, _) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "demo";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        stub.HoldTestDraft();
+        var slow = state.RunDraftPreflightAsync();
+
+        state.ClearDraft();
+        Assert.Null(state.LatestDiagnostic);
+
+        stub.ReleaseTestDraft();
+        var diagnostic = await slow;
+
+        Assert.Null(diagnostic);
+        Assert.Null(state.LatestDiagnostic);
+    }
+
+    /// <summary>
+    /// Per-method gates that hold a single in-flight call until released, so
+    /// tests can pin the stale-write invariants in <c>DataConnectionsState</c>
+    /// without depending on real timing. All other operations pass through to
+    /// <see cref="StubDataConnectionClient"/>.
+    /// </summary>
+    private sealed class GatedDataConnectionClient : IDataConnectionClient
+    {
+        private readonly StubDataConnectionClient _inner;
+        private readonly Dictionary<Guid, TaskCompletionSource> _getGates = new();
+        private readonly Dictionary<Guid, TaskCompletionSource> _testExistingGates = new();
+        private TaskCompletionSource? _testDraftGate;
+
+        public GatedDataConnectionClient(IEnumerable<DataConnectionDetail> seed)
+        {
+            _inner = new StubDataConnectionClient(seed);
+        }
+
+        public Func<string, string?>? FailureMessageForHost
+        {
+            get => _inner.FailureMessageForHost;
+            set => _inner.FailureMessageForHost = value;
+        }
+
+        public void HoldGet(Guid id) => _getGates[id] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseGet(Guid id) => _getGates[id].TrySetResult();
+
+        public void HoldTestExisting(Guid id) => _testExistingGates[id] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseTestExisting(Guid id) => _testExistingGates[id].TrySetResult();
+
+        public void HoldTestDraft() => _testDraftGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseTestDraft() => _testDraftGate!.TrySetResult();
+
+        public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(cancellationToken);
+
+        public async Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (_getGates.TryGetValue(id, out var gate))
+            {
+                await gate.Task.ConfigureAwait(false);
+            }
+            return await _inner.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.CreateAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.UpdateAsync(id, request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DisableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.EnableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<bool>> DeleteAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DeleteAsync(id, cancellationToken);
+
+        public async Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (_testDraftGate is { } gate)
+            {
+                await gate.Task.ConfigureAwait(false);
+            }
+            return await _inner.TestDraftAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (_testExistingGates.TryGetValue(id, out var gate))
+            {
+                await gate.Task.ConfigureAwait(false);
+            }
+            return await _inner.TestExistingAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+    }
 }

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Services.DataConnections;
+using Honua.Admin.Services.DataConnections.Providers;
+using Xunit;
+
+namespace Honua.Admin.Tests.DataConnections;
+
+public sealed class DataConnectionsStateTests
+{
+    [Fact]
+    public async Task RefreshListAsync_loads_connections_and_emits_loaded_event()
+    {
+        var stub = new StubDataConnectionClient(new[] { Sample("primary", isActive: true) });
+        var (state, telemetry) = BuildState(stub);
+
+        await state.RefreshListAsync();
+
+        Assert.Equal(WorkspaceListStatus.Idle, state.Status);
+        Assert.Single(state.Connections);
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.list_loaded");
+    }
+
+    [Fact]
+    public async Task SubmitDraftAsync_creates_connection_and_emits_create_succeeded()
+    {
+        var stub = new StubDataConnectionClient();
+        var (state, telemetry) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "ops-primary";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret-1234";
+
+        var result = await state.SubmitDraftAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(state.Connections);
+        Assert.Null(state.Draft);
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.create_submitted");
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.create_succeeded");
+    }
+
+    [Fact]
+    public async Task SubmitDraftAsync_with_missing_credentials_fails_validation_and_keeps_draft()
+    {
+        var stub = new StubDataConnectionClient();
+        var (state, telemetry) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "ops-primary";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        // No password, no secret reference.
+
+        var result = await state.SubmitDraftAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Validation, result.Error!.Kind);
+        Assert.Equal(WorkspaceListStatus.Error, state.Status);
+        Assert.NotNull(state.Draft);
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.create_failed");
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_disable_marks_connection_inactive_and_records_event()
+    {
+        var seed = Sample("primary", isActive: true);
+        var stub = new StubDataConnectionClient(new[] { seed });
+        var (state, telemetry) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+        var result = await state.SetActiveAsync(seed.ConnectionId, active: false);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.IsActive);
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.disabled");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_removes_from_list_and_records_event()
+    {
+        var seed = Sample("primary", isActive: true);
+        var stub = new StubDataConnectionClient(new[] { seed });
+        var (state, telemetry) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        var result = await state.DeleteAsync(seed.ConnectionId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(state.Connections);
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.deleted");
+    }
+
+    [Fact]
+    public async Task RunDraftPreflightAsync_healthy_response_lights_all_cells_ok()
+    {
+        var stub = new StubDataConnectionClient();
+        var (state, _) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "draft";
+        draft.Host = "db.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        var diagnostic = await state.RunDraftPreflightAsync();
+
+        Assert.NotNull(diagnostic);
+        Assert.False(diagnostic!.AnyFailed);
+        Assert.All(diagnostic.Cells, c => Assert.Equal(DiagnosticStatus.Ok, c.Status));
+    }
+
+    [Fact]
+    public async Task RunDraftPreflightAsync_failed_message_routes_to_correct_step_and_records_failed_step()
+    {
+        var stub = new StubDataConnectionClient
+        {
+            FailureMessageForHost = host => host == "broken.example.com"
+                ? "SSL handshake failed"
+                : null
+        };
+        var (state, telemetry) = BuildState(stub);
+
+        var draft = state.BeginCreateDraft("postgres");
+        draft.Name = "draft";
+        draft.Host = "broken.example.com";
+        draft.DatabaseName = "honua";
+        draft.Username = "honua";
+        draft.Password = "secret";
+
+        var diagnostic = await state.RunDraftPreflightAsync();
+
+        Assert.NotNull(diagnostic);
+        Assert.Equal(DiagnosticStatus.Failed, diagnostic!.GetCell(DiagnosticStep.Ssl).Status);
+
+        var completed = telemetry.Events.First(e => e.Name == "data_connections.test_completed");
+        Assert.Equal("failed", completed.Properties!["result_kind"]);
+        Assert.Equal("Ssl", completed.Properties!["failed_step"]);
+    }
+
+    [Fact]
+    public void Provider_registry_resolves_postgres_concrete_and_sqlserver_stub()
+    {
+        var registry = BuildRegistry();
+
+        var postgres = registry.GetById("postgres");
+        var sqlServer = registry.GetById("sqlserver");
+
+        Assert.False(postgres.IsStub);
+        Assert.True(sqlServer.IsStub);
+        Assert.Empty(sqlServer.ManagedHostingChecks);
+        Assert.NotEmpty(postgres.ManagedHostingChecks);
+        Assert.Equal(2, registry.All.Count);
+    }
+
+    [Fact]
+    public void BeginCreateDraft_for_stub_provider_emits_provider_stub_viewed_event()
+    {
+        var stub = new StubDataConnectionClient();
+        var (state, telemetry) = BuildState(stub);
+
+        state.BeginCreateDraft("sqlserver");
+
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.provider_stub_viewed");
+    }
+
+    [Fact]
+    public async Task SubmitEditAsync_updates_existing_connection_and_records_event()
+    {
+        var seed = Sample("primary", isActive: true);
+        var stub = new StubDataConnectionClient(new[] { seed });
+        var (state, telemetry) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+
+        var draft = state.BeginEditDraft(state.SelectedDetail!);
+        draft.Description = "primary OLAP cluster";
+        draft.Port = 6432;
+
+        var result = await state.SubmitEditAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(6432, result.Value!.Port);
+        Assert.Equal("primary OLAP cluster", result.Value!.Description);
+        Assert.Null(state.Draft);
+        Assert.Contains(telemetry.Events, e => e.Name == "data_connections.update_succeeded");
+    }
+
+    [Fact]
+    public void GetCapabilityMatrix_marks_every_check_not_assessed_until_server_endpoint_lands()
+    {
+        var stub = new StubDataConnectionClient();
+        var (state, _) = BuildState(stub);
+
+        var matrix = state.GetCapabilityMatrix("postgres");
+
+        Assert.False(matrix.IsServerSourced);
+        Assert.NotEmpty(matrix.Checks);
+        Assert.All(matrix.Checks, c => Assert.Equal(DiagnosticStatus.NotAssessed, c.Status));
+    }
+
+    private static (DataConnectionsState State, RecordingTelemetry Telemetry) BuildState(IDataConnectionClient client)
+    {
+        var registry = BuildRegistry();
+        var telemetry = new RecordingTelemetry();
+        var state = new DataConnectionsState(client, telemetry, registry);
+        return (state, telemetry);
+    }
+
+    private static IProviderRegistry BuildRegistry()
+    {
+        return new ProviderRegistry(new IProviderRegistration[]
+        {
+            new PostgresProviderRegistration(),
+            new SqlServerStubProviderRegistration()
+        });
+    }
+
+    private static DataConnectionDetail Sample(string name, bool isActive) => new()
+    {
+        ConnectionId = Guid.NewGuid(),
+        Name = name,
+        Host = "db.example.com",
+        Port = 5432,
+        DatabaseName = "honua",
+        Username = "honua",
+        SslMode = "Require",
+        StorageType = "managed",
+        IsActive = isActive,
+        HealthStatus = "unknown",
+        CreatedBy = "operator",
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow
+    };
+}

--- a/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DataConnectionsStateTests.cs
@@ -101,6 +101,32 @@ public sealed class DataConnectionsStateTests
     }
 
     [Fact]
+    public async Task DeleteAsync_failure_keeps_row_and_selection_and_surfaces_error()
+    {
+        // Detail.razor.ConfirmDelete relies on this contract: when DeleteAsync
+        // fails (e.g., 409 Conflict for "in use"), the page must stay mounted
+        // so State.LastError can render the actionable error. A regression
+        // here lets the page navigate to Index, whose RefreshListAsync clears
+        // LastError before the operator sees it.
+        var seed = Sample("primary", isActive: true);
+        var stub = new FailingDeleteStubClient(seed,
+            new ConnectionOperationError(ConnectionErrorKind.Conflict, "error.conflict", "Connection is in use by services"));
+        var (state, _) = BuildState(stub);
+
+        await state.RefreshListAsync();
+        await state.LoadDetailAsync(seed.ConnectionId);
+
+        var result = await state.DeleteAsync(seed.ConnectionId);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Conflict, result.Error!.Kind);
+        Assert.NotNull(state.LastError);
+        Assert.Equal(ConnectionErrorKind.Conflict, state.LastError!.Kind);
+        Assert.Single(state.Connections, c => c.ConnectionId == seed.ConnectionId);
+        Assert.Equal(seed.ConnectionId, state.SelectedDetail?.ConnectionId);
+    }
+
+    [Fact]
     public async Task RunDraftPreflightAsync_healthy_response_lights_all_cells_ok()
     {
         var stub = new StubDataConnectionClient();
@@ -500,6 +526,45 @@ public sealed class DataConnectionsStateTests
 
         public Task<ConnectionResult<bool>> DeleteAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
             _inner.DeleteAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.TestDraftAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<ConnectionTestOutcome>> TestExistingAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.TestExistingAsync(id, cancellationToken);
+    }
+
+    private sealed class FailingDeleteStubClient : IDataConnectionClient
+    {
+        private readonly StubDataConnectionClient _inner;
+        private readonly ConnectionOperationError _error;
+
+        public FailingDeleteStubClient(DataConnectionDetail seed, ConnectionOperationError error)
+        {
+            _inner = new StubDataConnectionClient(new[] { seed });
+            _error = error;
+        }
+
+        public Task<ConnectionResult<IReadOnlyList<DataConnectionSummary>>> ListAsync(System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionDetail>> GetAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.GetAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> CreateAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.CreateAsync(request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> UpdateAsync(Guid id, UpdateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.UpdateAsync(id, request, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> DisableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.DisableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<DataConnectionSummary>> EnableAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            _inner.EnableAsync(id, cancellationToken);
+
+        public Task<ConnectionResult<bool>> DeleteAsync(Guid id, System.Threading.CancellationToken cancellationToken = default) =>
+            Task.FromResult(ConnectionResult<bool>.Fail(_error));
 
         public Task<ConnectionResult<ConnectionTestOutcome>> TestDraftAsync(CreateConnectionRequest request, System.Threading.CancellationToken cancellationToken = default) =>
             _inner.TestDraftAsync(request, cancellationToken);

--- a/tests/Honua.Admin.Tests/DataConnections/DiagnosticMapperTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/DiagnosticMapperTests.cs
@@ -1,0 +1,125 @@
+using System;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Services.DataConnections;
+using Xunit;
+
+namespace Honua.Admin.Tests.DataConnections;
+
+public sealed class DiagnosticMapperTests
+{
+    [Fact]
+    public void Healthy_outcome_lights_every_cell_ok()
+    {
+        var outcome = new ConnectionTestOutcome
+        {
+            ConnectionId = Guid.NewGuid(),
+            ConnectionName = "primary",
+            IsHealthy = true,
+            TestedAt = DateTimeOffset.UtcNow
+        };
+
+        var diagnostic = DiagnosticMapper.Map(outcome);
+
+        Assert.Equal(6, diagnostic.Cells.Count);
+        Assert.All(diagnostic.Cells, c => Assert.Equal(DiagnosticStatus.Ok, c.Status));
+        Assert.False(diagnostic.AnyFailed);
+    }
+
+    [Theory]
+    [InlineData("authentication failed for user", DiagnosticStep.Auth)]
+    [InlineData("password authentication failed", DiagnosticStep.Auth)]
+    [InlineData("permission denied for relation", DiagnosticStep.Auth)]
+    [InlineData("SSL handshake failed", DiagnosticStep.Ssl)]
+    [InlineData("certificate expired", DiagnosticStep.Ssl)]
+    [InlineData("TLS negotiation aborted", DiagnosticStep.Ssl)]
+    [InlineData("connection refused", DiagnosticStep.Tcp)]
+    [InlineData("connection timeout after 30s", DiagnosticStep.Tcp)]
+    [InlineData("host unreachable", DiagnosticStep.Tcp)]
+    [InlineData("name resolution failed for db.example.com", DiagnosticStep.Dns)]
+    [InlineData("dns lookup error", DiagnosticStep.Dns)]
+    [InlineData("server version 9.6 too old; require 13", DiagnosticStep.Version)]
+    [InlineData("required extension postgis is missing", DiagnosticStep.Capability)]
+    public void Failed_outcome_routes_to_the_right_cell(string message, DiagnosticStep expected)
+    {
+        var outcome = BuildFailed(message);
+
+        var diagnostic = DiagnosticMapper.Map(outcome);
+
+        Assert.True(diagnostic.AnyFailed);
+        Assert.Equal(DiagnosticStatus.Failed, diagnostic.GetCell(expected).Status);
+        // Every other cell must remain NotAssessed — never Failed for unrelated steps.
+        foreach (var cell in diagnostic.Cells)
+        {
+            if (cell.Step == expected)
+            {
+                continue;
+            }
+            Assert.Equal(DiagnosticStatus.NotAssessed, cell.Status);
+        }
+    }
+
+    [Fact]
+    public void Failed_outcome_with_unrelated_message_falls_back_to_auth_only()
+    {
+        var outcome = BuildFailed("something went wrong somewhere");
+
+        var diagnostic = DiagnosticMapper.Map(outcome);
+
+        Assert.Equal(DiagnosticStatus.Failed, diagnostic.GetCell(DiagnosticStep.Auth).Status);
+        Assert.Equal(DiagnosticStatus.NotAssessed, diagnostic.GetCell(DiagnosticStep.Tcp).Status);
+        Assert.Equal(DiagnosticStatus.NotAssessed, diagnostic.GetCell(DiagnosticStep.Ssl).Status);
+        Assert.Equal(DiagnosticStatus.NotAssessed, diagnostic.GetCell(DiagnosticStep.Dns).Status);
+        Assert.Equal(DiagnosticStatus.NotAssessed, diagnostic.GetCell(DiagnosticStep.Version).Status);
+        Assert.Equal(DiagnosticStatus.NotAssessed, diagnostic.GetCell(DiagnosticStep.Capability).Status);
+    }
+
+    [Fact]
+    public void Failed_outcome_with_empty_message_does_not_throw_and_falls_back_to_auth()
+    {
+        var outcome = BuildFailed(string.Empty);
+
+        var diagnostic = DiagnosticMapper.Map(outcome);
+
+        Assert.Equal(DiagnosticStatus.Failed, diagnostic.GetCell(DiagnosticStep.Auth).Status);
+    }
+
+    [Fact]
+    public void Healthy_outcome_with_detail_attaches_capability_and_version_payload()
+    {
+        var outcome = new ConnectionTestOutcome
+        {
+            ConnectionId = Guid.NewGuid(),
+            ConnectionName = "primary",
+            IsHealthy = true,
+            TestedAt = DateTimeOffset.UtcNow,
+            Message = "ok"
+        };
+        var detail = new DataConnectionDetail
+        {
+            ConnectionId = outcome.ConnectionId,
+            Name = "primary",
+            Host = "db.example.com",
+            Port = 5432,
+            DatabaseName = "honua",
+            Username = "honua",
+            SslMode = "Require",
+            StorageType = "managed",
+            HealthStatus = "Postgres 15.4",
+            CreatedBy = "operator"
+        };
+
+        var diagnostic = DiagnosticMapper.Map(outcome, detail);
+
+        Assert.Equal("Require / managed=managed", diagnostic.GetCell(DiagnosticStep.Capability).Detail);
+        Assert.Equal("Postgres 15.4", diagnostic.GetCell(DiagnosticStep.Version).Detail);
+    }
+
+    private static ConnectionTestOutcome BuildFailed(string message) => new()
+    {
+        ConnectionId = Guid.NewGuid(),
+        ConnectionName = "primary",
+        IsHealthy = false,
+        TestedAt = DateTimeOffset.UtcNow,
+        Message = message
+    };
+}

--- a/tests/Honua.Admin.Tests/DataConnections/HttpDataConnectionClientTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/HttpDataConnectionClientTests.cs
@@ -1,0 +1,401 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.DataConnections;
+using Honua.Admin.Services.DataConnections;
+using Xunit;
+
+namespace Honua.Admin.Tests.DataConnections;
+
+/// <summary>
+/// Pin the wire contract between the admin UI and honua-server's
+/// <c>/api/v1/admin/connections</c> endpoints. honua-server wraps every payload
+/// in <see cref="ApiResponse{T}"/>; the client must unwrap via
+/// <c>envelope.Data</c>. Network / cancellation / malformed-JSON failures must
+/// land as typed <see cref="ConnectionOperationError"/> values, not exceptions.
+/// </summary>
+public sealed class HttpDataConnectionClientTests
+{
+    private const string ServerBase = "https://server.test/";
+
+    [Fact]
+    public async Task ListAsync_unwraps_envelope_and_returns_summaries()
+    {
+        var connectionId = Guid.NewGuid();
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(req =>
+        {
+            Assert.Equal(HttpMethod.Get, req.Method);
+            Assert.Equal($"{ServerBase}api/v1/admin/connections", req.RequestUri!.ToString());
+            return JsonOk(new
+            {
+                success = true,
+                data = new[]
+                {
+                    SampleSummaryPayload(connectionId)
+                }
+            });
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value!);
+        Assert.Equal(connectionId, result.Value![0].ConnectionId);
+    }
+
+    [Fact]
+    public async Task GetAsync_unwraps_envelope_and_returns_detail()
+    {
+        var connectionId = Guid.NewGuid();
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(req =>
+        {
+            Assert.Equal(HttpMethod.Get, req.Method);
+            Assert.Equal($"{ServerBase}api/v1/admin/connections/{connectionId}", req.RequestUri!.ToString());
+            return JsonOk(new
+            {
+                success = true,
+                data = SampleDetailPayload(connectionId)
+            });
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.GetAsync(connectionId, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(connectionId, result.Value!.ConnectionId);
+        Assert.Equal("aws:secretsmanager:prod-db-creds", result.Value.CredentialReference);
+        Assert.Equal(7, result.Value.EncryptionVersion);
+    }
+
+    [Fact]
+    public async Task CreateAsync_returns_summary_per_server_contract()
+    {
+        var connectionId = Guid.NewGuid();
+        var handler = new FakeHttpMessageHandler();
+        string? capturedBody = null;
+        handler.Enqueue(req =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{ServerBase}api/v1/admin/connections", req.RequestUri!.ToString());
+            capturedBody = req.Content!.ReadAsStringAsync().Result;
+            return JsonCreated(new
+            {
+                success = true,
+                data = SampleSummaryPayload(connectionId)
+            });
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.CreateAsync(new CreateConnectionRequest
+        {
+            Name = "primary",
+            Host = "db.example.com",
+            DatabaseName = "honua",
+            Username = "honua",
+            Password = "secret-1234"
+        }, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(connectionId, result.Value!.ConnectionId);
+        Assert.NotNull(capturedBody);
+        Assert.Contains("\"password\":\"secret-1234\"", capturedBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_returns_summary_per_server_contract()
+    {
+        var connectionId = Guid.NewGuid();
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(req =>
+        {
+            Assert.Equal(HttpMethod.Put, req.Method);
+            Assert.Equal($"{ServerBase}api/v1/admin/connections/{connectionId}", req.RequestUri!.ToString());
+            return JsonOk(new
+            {
+                success = true,
+                data = SampleSummaryPayload(connectionId, port: 6432)
+            });
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.UpdateAsync(connectionId, new UpdateConnectionRequest
+        {
+            Port = 6432
+        }, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(6432, result.Value!.Port);
+    }
+
+    [Fact]
+    public async Task TestExistingAsync_unwraps_envelope_and_returns_outcome()
+    {
+        var connectionId = Guid.NewGuid();
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(req =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{ServerBase}api/v1/admin/connections/{connectionId}/test", req.RequestUri!.ToString());
+            return JsonOk(new
+            {
+                success = true,
+                data = new
+                {
+                    connectionId = connectionId,
+                    connectionName = "primary",
+                    isHealthy = true,
+                    testedAt = DateTimeOffset.UtcNow,
+                    message = "Connection is healthy"
+                }
+            });
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.TestExistingAsync(connectionId, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.IsHealthy);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_returns_ok_on_2xx()
+    {
+        var connectionId = Guid.NewGuid();
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(req =>
+        {
+            Assert.Equal(HttpMethod.Delete, req.Method);
+            Assert.Equal($"{ServerBase}api/v1/admin/connections/{connectionId}", req.RequestUri!.ToString());
+            return JsonOk(new { success = true, message = "Connection deleted" });
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.DeleteAsync(connectionId, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ListAsync_surfaces_problem_details_on_500()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent(
+                "{\"type\":\"about:blank\",\"title\":\"boom\",\"status\":500,\"detail\":\"engine failure\"}",
+                Encoding.UTF8, "application/problem+json")
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Server, result.Error!.Kind);
+        Assert.Equal("engine failure", result.Error.Detail);
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_NotFound_on_404()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("{\"success\":false,\"message\":\"missing\"}", Encoding.UTF8, "application/json")
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.GetAsync(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.NotFound, result.Error!.Kind);
+    }
+
+    [Fact]
+    public async Task CreateAsync_returns_validation_error_on_400()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("{\"success\":false,\"message\":\"Invalid SSL mode\"}", Encoding.UTF8, "application/json")
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.CreateAsync(new CreateConnectionRequest
+        {
+            Name = "x",
+            Host = "h",
+            DatabaseName = "d",
+            Username = "u",
+            Password = "p",
+            SslMode = "garbage"
+        }, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Validation, result.Error!.Kind);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_typed_error_on_HttpRequestException()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.EnqueueThrow(new HttpRequestException("DNS resolution failed"));
+
+        var client = MakeClient(handler);
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Network, result.Error!.Kind);
+        Assert.Contains("DNS resolution failed", result.Error.Detail!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_malformed_response_on_invalid_json()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("not json at all", Encoding.UTF8, "application/json")
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Server, result.Error!.Kind);
+        Assert.Equal("error.malformed_response", result.Error.CopyKey);
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_empty_response_when_envelope_data_is_null()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => JsonOk(new { success = true, data = (object?)null }));
+
+        var client = MakeClient(handler);
+        var result = await client.GetAsync(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Server, result.Error!.Kind);
+        Assert.Equal("error.empty_response", result.Error.CopyKey);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_timeout_when_handler_throws_OperationCanceledException()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.EnqueueThrow(new TaskCanceledException("simulated request timeout"));
+
+        var client = MakeClient(handler);
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Network, result.Error!.Kind);
+        Assert.Equal("error.timeout", result.Error.CopyKey);
+    }
+
+    private static object SampleSummaryPayload(Guid connectionId, int port = 5432) => new
+    {
+        connectionId,
+        name = "primary",
+        description = (string?)null,
+        host = "db.example.com",
+        port,
+        databaseName = "honua",
+        username = "honua",
+        sslRequired = true,
+        sslMode = "Require",
+        storageType = "managed",
+        isActive = true,
+        healthStatus = "Unknown",
+        lastHealthCheck = (DateTimeOffset?)null,
+        createdAt = DateTimeOffset.UtcNow,
+        createdBy = "admin"
+    };
+
+    private static object SampleDetailPayload(Guid connectionId) => new
+    {
+        connectionId,
+        name = "primary",
+        description = "primary OLAP",
+        host = "db.example.com",
+        port = 5432,
+        databaseName = "honua",
+        username = "honua",
+        sslRequired = true,
+        sslMode = "Require",
+        storageType = "external",
+        isActive = true,
+        healthStatus = "Healthy",
+        lastHealthCheck = DateTimeOffset.UtcNow,
+        createdAt = DateTimeOffset.UtcNow,
+        createdBy = "admin",
+        credentialReference = "aws:secretsmanager:prod-db-creds",
+        encryptionVersion = 7,
+        updatedAt = DateTimeOffset.UtcNow
+    };
+
+    private static HttpResponseMessage JsonOk(object payload) => JsonResponse(HttpStatusCode.OK, payload);
+
+    private static HttpResponseMessage JsonCreated(object payload) => JsonResponse(HttpStatusCode.Created, payload);
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode status, object payload)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+        var json = JsonSerializer.Serialize(payload, options);
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static HttpDataConnectionClient MakeClient(FakeHttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri(ServerBase) };
+        return new HttpDataConnectionClient(http);
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _queue = new();
+
+        public void Enqueue(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _queue.Enqueue(responder);
+        }
+
+        public void EnqueueThrow(Exception exception)
+        {
+            _queue.Enqueue(_ => throw exception);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_queue.Count == 0)
+            {
+                return Task.FromException<HttpResponseMessage>(new InvalidOperationException(
+                    $"Unexpected HTTP request: {request.Method} {request.RequestUri}"));
+            }
+            var responder = _queue.Dequeue();
+            try
+            {
+                return Task.FromResult(responder(request));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<HttpResponseMessage>(ex);
+            }
+        }
+    }
+}

--- a/tests/Honua.Admin.Tests/DataConnections/HttpDataConnectionClientTests.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/HttpDataConnectionClientTests.cs
@@ -240,6 +240,49 @@ public sealed class HttpDataConnectionClientTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(ConnectionErrorKind.Validation, result.Error!.Kind);
+        // honua-server returns 4xx as ApiResponse<object>.Failure(message);
+        // the operator-actionable message must survive into the typed error
+        // detail rather than getting dropped by the ProblemDetails parser.
+        Assert.Equal("Invalid SSL mode", result.Error.Detail);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_returns_conflict_with_envelope_message_on_409()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = new StringContent(
+                "{\"success\":false,\"message\":\"Connection is in use by services\"}",
+                Encoding.UTF8, "application/json")
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.DeleteAsync(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ConnectionErrorKind.Conflict, result.Error!.Kind);
+        Assert.Equal("Connection is in use by services", result.Error.Detail);
+    }
+
+    [Fact]
+    public async Task ParseProblemAsync_prefers_problem_details_when_both_shapes_could_match()
+    {
+        // ProblemDetails-shaped 5xx body should still take precedence over
+        // a coincidentally parseable envelope shape.
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent(
+                "{\"type\":\"about:blank\",\"title\":\"boom\",\"status\":500,\"detail\":\"engine failure\"}",
+                Encoding.UTF8, "application/problem+json")
+        });
+
+        var client = MakeClient(handler);
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("engine failure", result.Error!.Detail);
     }
 
     [Fact]

--- a/tests/Honua.Admin.Tests/DataConnections/RecordingTelemetry.cs
+++ b/tests/Honua.Admin.Tests/DataConnections/RecordingTelemetry.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Honua.Admin.Services.DataConnections;
+
+namespace Honua.Admin.Tests.DataConnections;
+
+public sealed class RecordingTelemetry : IDataConnectionTelemetry
+{
+    public ConcurrentBag<TelemetryEvent> Events { get; } = new();
+
+    public void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null)
+    {
+        Events.Add(new TelemetryEvent(eventName, properties, null));
+    }
+
+    public void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null)
+    {
+        Events.Add(new TelemetryEvent(eventName, properties, elapsedMillis));
+    }
+}
+
+public sealed record TelemetryEvent(string Name, IReadOnlyDictionary<string, object?>? Properties, long? ElapsedMillis);

--- a/tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
+++ b/tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="bunit" Version="1.40.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #24
## Summary

Data connection management workspace: provider capabilities, preflight, and managed Postgres checks
## Changes Made

- Data connection management workspace: provider capabilities, preflight, and managed Postgres checks
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
Bounded sibling sweep stayed inside the Data Connections state subsystem. Checked cancel, retry, reconciliation, ownership, and terminal-state paths: `UpdateDraft`, `ClearDraft`, `RunDraftPreflightAsync`, `SubmitDraftAsync`, `SubmitEditAsync`, and submit-time `TryRefreshSelectedDetailAsync`.

Did not reopen the human-deferred preflight transition follow-up `#31`; this pass fixed the active draft ownership invariant.

Follow-ons:
No new follow-ons. Existing server-side gap report items remain outside this repo pass.

Code kaizen:
Auto-deferred by kaizen policy.
