### PR TITLE
ci: repair GitHub Actions gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
-    branches: [main, trunk]
+    branches: [master, main, trunk]
   pull_request:
-    branches: [main, trunk]
+    branches: [master, main, trunk]
 
 permissions: {}
 
@@ -130,7 +131,7 @@ jobs:
             echo "❌ Missing index.html in published output"
             exit 1
           fi
-          if [ ! -f "./dist/wwwroot/_framework/blazor.webassembly.js" ]; then
+          if ! find "./dist/wwwroot/_framework" -maxdepth 1 -name "blazor.webassembly*.js" -print -quit | grep -q .; then
             echo "❌ Missing Blazor WebAssembly runtime"
             exit 1
           fi

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,8 +10,8 @@ jobs:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
-      issues: read
     steps:
       - name: Check PR Requirements
         uses: actions/github-script@v8
@@ -139,19 +139,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-pr
     if: github.event_name == 'pull_request'
+    timeout-minutes: 90
+    permissions:
+      checks: read
     steps:
-      - name: Wait for CI
+      - name: Wait for CI gate
         uses: actions/github-script@v8
         with:
           script: |
             const checkName = 'CI Gate';
-            const { data: checks } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request.head.sha
-            });
+            const headSha = context.payload.pull_request.head.sha;
+            const attempts = 360;
+            const intervalMs = 15000;
 
-            const ciCheck = checks.check_runs.find(check => check.name === checkName);
-            if (ciCheck && ciCheck.conclusion !== 'success') {
-              core.setFailed('CI must pass before merge');
+            for (let attempt = 1; attempt <= attempts; attempt++) {
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: headSha,
+                per_page: 100
+              });
+
+              const ciCheck = checks.check_runs.find(check => check.name === checkName);
+              if (!ciCheck) {
+                core.info(`Waiting for ${checkName} to be created for ${headSha} (${attempt}/${attempts})`);
+              } else if (ciCheck.status !== 'completed') {
+                core.info(`${checkName} is ${ciCheck.status}; waiting (${attempt}/${attempts})`);
+              } else if (ciCheck.conclusion === 'success') {
+                core.info(`${checkName} passed`);
+                return;
+              } else {
+                core.setFailed(`${checkName} concluded ${ciCheck.conclusion}: ${ciCheck.html_url}`);
+                return;
+              }
+
+              await new Promise(resolve => setTimeout(resolve, intervalMs));
             }
+
+            core.setFailed(`Timed out waiting for ${checkName} on ${headSha}`);

--- a/tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj
+++ b/tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Honua.Admin.Tests/Audit/CoverageDriftTests.cs
+++ b/tests/Honua.Admin.Tests/Audit/CoverageDriftTests.cs
@@ -158,10 +158,14 @@ public sealed class CoverageDriftTests
         var cursor = assemblyDir;
         while (cursor is not null)
         {
-            var sibling = Path.Combine(Path.GetDirectoryName(cursor)!, "honua-server");
-            if (Directory.Exists(Path.Combine(sibling, "src", "Honua.Server", "Features")))
+            var parent = Path.GetDirectoryName(cursor);
+            if (parent is not null)
             {
-                return sibling;
+                var sibling = Path.Combine(parent, "honua-server");
+                if (Directory.Exists(Path.Combine(sibling, "src", "Honua.Server", "Features")))
+                {
+                    return sibling;
+                }
             }
             cursor = Path.GetDirectoryName(cursor);
         }

--- a/tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
+++ b/tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Related to #9

## Summary
- run CI on the actual default branch (`master`) while keeping `main` and `trunk` compatibility
- make the required PR validation check wait for the real `CI Gate` instead of passing when CI is missing
- add the missing `coverlet.collector` package so `--collect:"XPlat Code Coverage"` produces coverage attachments
- update publish verification for fingerprinted .NET 10 Blazor WebAssembly runtime files

## Validation
- `dotnet test Honua.Admin.sln --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1`
- `dotnet build Honua.Admin.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic`
- `dotnet publish src/Honua.Admin/Honua.Admin.csproj --configuration Release --output ./dist --no-restore`
- publish output guard for `dist/wwwroot/index.html` and `blazor.webassembly*.js`
