### PR TITLE
test: add admin quality gate baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
+  ADMIN_PUBLISH_MAX_BYTES: 62914560
+  ADMIN_FRAMEWORK_MAX_BYTES: 47185920
+  ADMIN_WASM_MAX_BYTES: 25165824
 
 jobs:
   build:
@@ -139,12 +142,26 @@ jobs:
 
       - name: Check Bundle Size
         run: |
-          DIST_SIZE=$(du -sh ./dist | cut -f1)
-          echo "📦 Published bundle size: $DIST_SIZE"
+          DIST_BYTES=$(du -sb ./dist | cut -f1)
+          FRAMEWORK_BYTES=$(du -sb ./dist/wwwroot/_framework | cut -f1)
+          WASM_BYTES=$(find ./dist/wwwroot/_framework -name "*.wasm" -printf "%s\n" | awk '{ total += $1 } END { print total + 0 }')
 
-          # Check for common size issues
-          WASM_SIZE=$(find ./dist -name "*.wasm" -exec du -ch {} + | grep total | cut -f1)
-          echo "📊 WebAssembly size: $WASM_SIZE"
+          echo "Published bundle bytes: ${DIST_BYTES} / ${ADMIN_PUBLISH_MAX_BYTES}"
+          echo "Framework payload bytes: ${FRAMEWORK_BYTES} / ${ADMIN_FRAMEWORK_MAX_BYTES}"
+          echo "WebAssembly bytes: ${WASM_BYTES} / ${ADMIN_WASM_MAX_BYTES}"
+
+          if [ "${DIST_BYTES}" -gt "${ADMIN_PUBLISH_MAX_BYTES}" ]; then
+            echo "Published output exceeds budget"
+            exit 1
+          fi
+          if [ "${FRAMEWORK_BYTES}" -gt "${ADMIN_FRAMEWORK_MAX_BYTES}" ]; then
+            echo "Framework payload exceeds budget"
+            exit 1
+          fi
+          if [ "${WASM_BYTES}" -gt "${ADMIN_WASM_MAX_BYTES}" ]; then
+            echo "WebAssembly payload exceeds budget"
+            exit 1
+          fi
 
   security:
     name: Security Scan

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Coverage of the wider honua-server admin API is tracked in
 inventory, hand-edited coverage matrix, and a drift-guard test.
 Backlog review, scope gates, and done/close hygiene are tracked in
 [`docs/operating-cadence.md`](docs/operating-cadence.md).
+Admin UI performance, accessibility, smoke-test, and release gate baselines
+are tracked in
+[`docs/admin-ui-quality-gates.md`](docs/admin-ui-quality-gates.md).
 
 ## Architecture
 

--- a/docs/admin-ui-quality-gates.md
+++ b/docs/admin-ui-quality-gates.md
@@ -1,0 +1,71 @@
+# Admin UI quality gates
+
+Issue
+[#9](https://github.com/honua-io/honua-server-admin/issues/9) owns the
+baseline quality gates for admin UI changes. These checks are intentionally
+small enough to run on every pull request, with deeper browser and server-backed
+tests added as follow-up work.
+
+## Performance budgets
+
+The CI publish check fails when the Blazor WebAssembly output exceeds these
+budgets:
+
+| Budget | Limit | CI source |
+| --- | ---: | --- |
+| Total published output | 60 MiB | `ADMIN_PUBLISH_MAX_BYTES` |
+| `_framework` payload | 45 MiB | `ADMIN_FRAMEWORK_MAX_BYTES` |
+| WebAssembly binaries | 24 MiB | `ADMIN_WASM_MAX_BYTES` |
+
+The bUnit smoke suite also pins the stub-backed first render budget for each
+top workflow at 10 seconds. This is not a replacement for real browser timing;
+it catches obvious render stalls and runaway lifecycle loops before a PR is
+merged.
+
+## Accessibility baseline
+
+Every PR that touches admin UI pages must keep the baseline bUnit accessibility
+checks green:
+
+- interactive elements expose an accessible name through visible text,
+  `aria-label`, `aria-labelledby`, `title`, placeholder text, or an associated
+  `<label>`;
+- tables expose an accessible name through `aria-label`, `aria-labelledby`, or
+  `<caption>`;
+- icon-only controls use an explicit accessible label;
+- destructive actions remain reachable by keyboard and preserve their telemetry
+  guard tests.
+
+Manual release validation should still run a browser accessibility pass on the
+changed workflow with keyboard-only navigation and an axe-compatible checker.
+
+## Regression smoke suite
+
+The PR gate renders these top workflows with the deterministic
+`StubHonuaAdminClient`:
+
+| Workflow | Route | Baseline assertion |
+| --- | --- | --- |
+| Dashboard | `/` | Feature overview and quick links render |
+| Connections | `/connections` | Connection rows and create action render |
+| Layers | `/layers` | Layer rows and publish action render |
+| Services | `/services` | Service rows and settings action render |
+| Deploy | `/deploy` | Preflight entry point renders |
+| Observability | `/observability` | Recent error panel renders |
+| Server info | `/server-info` | Configuration metadata renders |
+
+Add a row here when a workflow becomes release-critical, then extend
+`AdminQualityGateTests.TopWorkflows` in the same PR.
+
+## Release checklist
+
+Before tagging or merging a release branch:
+
+- confirm `CI Gate` and `Require CI Success` passed on the release candidate;
+- review the publish-size output in `Publish Verification` and compare it with
+  the budgets above;
+- run the top workflow smoke suite locally if the release contains major UI or
+  dependency changes;
+- complete the manual accessibility pass for changed workflows;
+- leave an issue comment when any quality gate is deferred, including the
+  follow-up issue and release owner.

--- a/docs/operating-cadence.md
+++ b/docs/operating-cadence.md
@@ -77,6 +77,8 @@ Post this as a dated comment on issue
 - `dotnet run --project tools/audit-api-surface -- generate`
 - `dotnet run --project tools/audit-api-surface -- seed-coverage`
 - `dotnet run --project tools/audit-api-surface -- render`
+- Release candidates must satisfy the quality-gate release checklist in
+  [`docs/admin-ui-quality-gates.md`](admin-ui-quality-gates.md).
 
 Run the audit commands when server API coverage changed or when a sibling
 `honua-server` checkout is available for drift comparison.

--- a/src/Honua.Admin/Pages/Admin/DeployControlPage.razor
+++ b/src/Honua.Admin/Pages/Admin/DeployControlPage.razor
@@ -22,7 +22,7 @@
                 <MudAlert Severity="@(_preflight.ReadyForCoordinatedDeploy ? Severity.Success : Severity.Warning)" Class="mt-4">
                     @_preflight.Message
                 </MudAlert>
-                <MudSimpleTable Dense="true" Hover="true" Class="mt-3">
+                <MudSimpleTable Dense="true" Hover="true" Class="mt-3" aria-label="Deploy preflight details">
                     <tbody>
                         <tr><td>Status</td><td>@_preflight.Status</td></tr>
                         <tr><td>Environment</td><td>@_preflight.Environment</td></tr>
@@ -90,7 +90,7 @@
             </MudStack>
             @if (_operation is not null)
             {
-                <MudSimpleTable Dense="true" Hover="true" Class="mt-4">
+                <MudSimpleTable Dense="true" Hover="true" Class="mt-4" aria-label="Deploy operation details">
                     <tbody>
                         <tr><td>Operation</td><td>@_operation.OperationId</td></tr>
                         <tr><td>Status</td><td>@_operation.Status</td></tr>

--- a/src/Honua.Admin/Pages/Admin/LayerListPage.razor
+++ b/src/Honua.Admin/Pages/Admin/LayerListPage.razor
@@ -25,10 +25,10 @@
         <MudCardContent>
             <MudGrid>
                 <MudItem xs="12" md="6">
-                    <MudTextField @bind-Value="_activeConnectionId" Label="Connection id or name" Variant="Variant.Outlined" />
+                    <MudTextField @bind-Value="_activeConnectionId" Label="Connection id or name" Variant="Variant.Outlined" aria-label="Connection id or name" />
                 </MudItem>
                 <MudItem xs="12" md="3">
-                    <MudTextField @bind-Value="_serviceName" Label="Service" Placeholder="default" Variant="Variant.Outlined" />
+                    <MudTextField @bind-Value="_serviceName" Label="Service" Placeholder="default" Variant="Variant.Outlined" aria-label="Service" />
                 </MudItem>
                 <MudItem xs="12" md="3">
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Refresh" OnClick="LoadLayersAsync" Disabled="IsLoading">

--- a/src/Honua.Admin/Pages/Admin/ObservabilityPage.razor
+++ b/src/Honua.Admin/Pages/Admin/ObservabilityPage.razor
@@ -81,7 +81,7 @@
             </MudTabPanel>
 
             <MudTabPanel Text="Telemetry" Icon="@Icons.Material.Filled.Insights">
-                <MudSimpleTable Dense="true" Hover="true">
+                <MudSimpleTable Dense="true" Hover="true" aria-label="Telemetry status">
                     <tbody>
                         <tr><td>Tracing enabled</td><td>@(_telemetry?.TracingEnabled == true ? "yes" : "no")</td></tr>
                         <tr><td>OTLP configured</td><td>@(_telemetry?.OtlpConfigured == true ? "yes" : "no")</td></tr>
@@ -93,7 +93,7 @@
             <MudTabPanel Text="Migrations" Icon="@Icons.Material.Filled.Storage">
                 @if (_migrations is not null)
                 {
-                    <MudSimpleTable Dense="true" Hover="true">
+                    <MudSimpleTable Dense="true" Hover="true" aria-label="Migration status">
                         <tbody>
                             <tr><td>Status</td><td>@_migrations.Status</td></tr>
                             <tr><td>Ready</td><td>@(_migrations.IsReady ? "yes" : "no")</td></tr>

--- a/src/Honua.Admin/Pages/Admin/ServerInfoPage.razor
+++ b/src/Honua.Admin/Pages/Admin/ServerInfoPage.razor
@@ -75,7 +75,7 @@
             </MudTabPanel>
 
             <MudTabPanel Text="Discovery" Icon="@Icons.Material.Filled.Search">
-                <MudTable Items="@(_discovery?.DiscoveredTypes ?? Array.Empty<ConfigurationTypeInfo>())" Dense="true" Hover="true">
+                <MudTable Items="@(_discovery?.DiscoveredTypes ?? Array.Empty<ConfigurationTypeInfo>())" Dense="true" Hover="true" aria-label="Configuration discovery">
                     <HeaderContent>
                         <MudTh>Section</MudTh>
                         <MudTh>Type</MudTh>
@@ -101,7 +101,7 @@
                 }
                 else
                 {
-                    <MudTable Items="_secrets.Issues" Dense="true">
+                    <MudTable Items="_secrets.Issues" Dense="true" aria-label="Configuration secret issues">
                         <HeaderContent>
                             <MudTh>Reference</MudTh>
                             <MudTh>Severity</MudTh>
@@ -117,7 +117,7 @@
             </MudTabPanel>
 
             <MudTabPanel Text="Audit" Icon="@Icons.Material.Filled.Assignment">
-                <MudSimpleTable Dense="true" Hover="true">
+                <MudSimpleTable Dense="true" Hover="true" aria-label="Configuration audit">
                     <tbody>
                         <tr><td>Machine</td><td>@_audit.MachineName</td></tr>
                         <tr><td>Application</td><td>@_audit.ApplicationName</td></tr>
@@ -128,7 +128,7 @@
             </MudTabPanel>
 
             <MudTabPanel Text="Documentation" Icon="@Icons.Material.Filled.Article">
-                <MudTable Items="_documentation" Dense="true" Hover="true">
+                <MudTable Items="_documentation" Dense="true" Hover="true" aria-label="Configuration documentation">
                     <HeaderContent>
                         <MudTh>Section</MudTh>
                         <MudTh>Type</MudTh>

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using AngleSharp.Dom;
+using Bunit;
+using Honua.Admin.Models.Admin;
+using Honua.Admin.Pages.Admin;
+using Honua.Admin.Services.Admin;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Honua.Admin.Tests.Pages;
+
+/// <summary>
+/// Baseline quality gates for the top admin workflows tracked by issue #9.
+/// These are intentionally lightweight bunit checks so they can run on every PR.
+/// </summary>
+public sealed class AdminQualityGateTests : TestContext
+{
+    private static readonly TimeSpan StubRenderBudget = TimeSpan.FromSeconds(10);
+
+    public AdminQualityGateTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddScoped<IAdminTelemetry, NullAdminTelemetry>();
+        Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
+    }
+
+    public static IEnumerable<object[]> TopWorkflows()
+    {
+        yield return
+        [
+            "Dashboard",
+            typeof(Honua.Admin.Pages.Index),
+            "Honua Server Administration",
+            new[] { "[aria-label='Feature overview']", "a[href='/connections']" },
+        ];
+        yield return
+        [
+            "Connections",
+            typeof(ConnectionListPage),
+            "primary-postgis",
+            new[] { "[aria-label='Connections list']", "a[href='/connections/new']" },
+        ];
+        yield return
+        [
+            "Layers",
+            typeof(LayerListPage),
+            "Parcels",
+            new[] { "[aria-label='Published layers']", "a[href$='/publish']" },
+        ];
+        yield return
+        [
+            "Services",
+            typeof(ServiceListPage),
+            "Default feature service",
+            new[] { "[aria-label='Services']", "a[href='/services/default/settings']" },
+        ];
+        yield return
+        [
+            "Deploy",
+            typeof(DeployControlPage),
+            "Run preflight",
+            new[] { "button" },
+        ];
+        yield return
+        [
+            "Observability",
+            typeof(ObservabilityPage),
+            "Sample recent error",
+            new[] { "[aria-label='Recent errors']" },
+        ];
+        yield return
+        [
+            "Server info",
+            typeof(ServerInfoPage),
+            "Honua:Database",
+            new[] { "[aria-label='Configuration metadata']" },
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(TopWorkflows))]
+    public void TopWorkflowPages_RenderWithinBudgetAndMeetAccessibilityBaseline(
+        string workflowName,
+        Type pageType,
+        string expectedText,
+        string[] requiredSelectors)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var cut = RenderAdminPage(pageType);
+
+        cut.WaitForAssertion(() => cut.Markup.MarkupMatchesContaining(expectedText), StubRenderBudget);
+        stopwatch.Stop();
+
+        Assert.True(
+            stopwatch.Elapsed <= StubRenderBudget,
+            $"{workflowName} exceeded the {StubRenderBudget.TotalSeconds:0}s stub render budget. Actual: {stopwatch.Elapsed.TotalMilliseconds:0} ms.");
+
+        foreach (var selector in requiredSelectors)
+        {
+            cut.Find(selector);
+        }
+
+        AssertInteractiveElementsHaveAccessibleNames(cut);
+        AssertTablesHaveAccessibleNames(cut);
+    }
+
+    private IRenderedFragment RenderAdminPage(Type pageType)
+    {
+        return Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent(1, pageType);
+            builder.CloseComponent();
+        });
+    }
+
+    private static void AssertInteractiveElementsHaveAccessibleNames(IRenderedFragment cut)
+    {
+        var unlabeled = cut.FindAll("a[href], button, input:not([type='hidden']), select, textarea")
+            .Where(element => !HasAccessibleName(element))
+            .Select(Describe)
+            .ToArray();
+
+        Assert.True(
+            unlabeled.Length == 0,
+            "Interactive elements must expose accessible names: " + string.Join(", ", unlabeled));
+    }
+
+    private static void AssertTablesHaveAccessibleNames(IRenderedFragment cut)
+    {
+        var unnamed = cut.FindAll("table")
+            .Where(table => !HasTableName(table))
+            .Select(Describe)
+            .ToArray();
+
+        Assert.True(
+            unnamed.Length == 0,
+            "Tables must have aria-label, aria-labelledby, or caption: " + string.Join(", ", unnamed));
+    }
+
+    private static bool HasAccessibleName(IElement element)
+    {
+        if (HasTextAttribute(element, "aria-label") ||
+            HasTextAttribute(element, "title") ||
+            HasTextAttribute(element, "placeholder") ||
+            !string.IsNullOrWhiteSpace(element.TextContent))
+        {
+            return true;
+        }
+
+        if (HasLabelledByText(element))
+        {
+            return true;
+        }
+
+        var id = element.GetAttribute("id");
+        if (!string.IsNullOrWhiteSpace(id) &&
+            element.Owner?.QuerySelector($"label[for='{id}']") is { TextContent: var labelText } &&
+            !string.IsNullOrWhiteSpace(labelText))
+        {
+            return true;
+        }
+
+        return element.ParentElement?.LocalName.Equals("label", StringComparison.OrdinalIgnoreCase) == true &&
+            !string.IsNullOrWhiteSpace(element.ParentElement.TextContent);
+    }
+
+    private static bool HasTableName(IElement table)
+    {
+        return HasTextAttribute(table, "aria-label") ||
+            HasLabelledByText(table) ||
+            table.QuerySelector("caption") is { TextContent: var caption } &&
+            !string.IsNullOrWhiteSpace(caption) ||
+            HasNamedMudTableHost(table);
+    }
+
+    private static bool HasNamedMudTableHost(IElement table)
+    {
+        for (var element = table.ParentElement; element is not null; element = element.ParentElement)
+        {
+            if ((element.ClassList.Contains("mud-table") || element.ClassList.Contains("mud-simple-table")) &&
+                (HasTextAttribute(element, "aria-label") || HasLabelledByText(element)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasLabelledByText(IElement element)
+    {
+        var labelledBy = element.GetAttribute("aria-labelledby");
+        if (string.IsNullOrWhiteSpace(labelledBy) || element.Owner is null)
+        {
+            return false;
+        }
+
+        return labelledBy.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(id => element.Owner.GetElementById(id))
+            .Any(label => !string.IsNullOrWhiteSpace(label?.TextContent));
+    }
+
+    private static bool HasTextAttribute(IElement element, string attributeName)
+        => !string.IsNullOrWhiteSpace(element.GetAttribute(attributeName));
+
+    private static string Describe(IElement element)
+    {
+        var id = element.GetAttribute("id");
+        var classes = element.GetAttribute("class");
+        return $"<{element.LocalName}{DescribeAttribute("id", id)}{DescribeAttribute("class", classes)}>";
+    }
+
+    private static string DescribeAttribute(string name, string? value)
+        => string.IsNullOrWhiteSpace(value) ? string.Empty : $" {name}='{value}'";
+
+    private sealed class NullAdminTelemetry : IAdminTelemetry
+    {
+        public void PageNavigated(string pageRoute, string? principalId) { }
+        public void DestructiveAction(string action, string? targetId, string? principalId) { }
+        public void ClientRequestFailed(string operation, string error) { }
+    }
+}


### PR DESCRIPTION
## Summary

- adds the admin UI quality-gates doc with publish-size budgets, accessibility baseline, smoke suite coverage, and release checklist criteria
- enforces publish output, framework payload, and wasm byte budgets in the CI publish check
- adds bUnit quality-gate coverage for the top admin workflows, including accessible-name checks and a stub render budget
- labels existing admin table/filter surfaces needed by the new baseline

## Validation

- dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic
- dotnet test Honua.Admin.sln --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
- dotnet build Honua.Admin.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true
- dotnet publish src/Honua.Admin/Honua.Admin.csproj --configuration Release --output ./dist --no-restore
- local publish budget check: 32,168,884 / 62,914,560 total bytes; 27,401,578 / 47,185,920 framework bytes; 13,356,422 / 25,165,824 wasm bytes

Related to #9
