### PR TITLE
test: add container e2e readiness lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,49 @@ jobs:
           path: TestResults/
           retention-days: 7
 
+  container-e2e:
+    name: Container E2E Readiness
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    env:
+      HONUA_ADMIN_CONTAINER_E2E: ${{ vars.HONUA_ADMIN_CONTAINER_E2E || 'false' }}
+      HONUA_SERVER_IMAGE: ${{ vars.HONUA_SERVER_IMAGE || 'ghcr.io/honua-io/honua-server:latest' }}
+      HONUA_POSTGIS_IMAGE: ${{ vars.HONUA_POSTGIS_IMAGE || 'postgis/postgis:18-3.6' }}
+      HONUA_ADMIN_CONTAINER_API_KEY: ${{ secrets.HONUA_ADMIN_CONTAINER_API_KEY || 'test-admin-key' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore Honua.Admin.sln
+
+      - name: Verify Docker is available
+        run: docker info
+
+      - name: Run container E2E lane
+        run: |
+          dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj \
+            --configuration Release \
+            --no-restore \
+            --filter "Category=ContainerE2E" \
+            --logger "console;verbosity=minimal" \
+            -- RunConfiguration.MaxCpuCount=1
+
   publish-check:
     name: Publish Verification
     runs-on: ubuntu-latest
@@ -195,7 +238,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [build, test, publish-check, security]
+    needs: [build, test, container-e2e, publish-check, security]
     if: always()
     steps:
       - name: Check all jobs succeeded
@@ -206,6 +249,10 @@ jobs:
           fi
           if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "❌ Test job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.container-e2e.result }}" != "success" ]]; then
+            echo "❌ Container E2E readiness failed"
             exit 1
           fi
           if [[ "${{ needs.publish-check.result }}" != "success" ]]; then

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Backlog review, scope gates, and done/close hygiene are tracked in
 Admin UI performance, accessibility, smoke-test, and release gate baselines
 are tracked in
 [`docs/admin-ui-quality-gates.md`](docs/admin-ui-quality-gates.md).
+Containerized admin E2E readiness and Testcontainers configuration are tracked
+in [`docs/container-e2e.md`](docs/container-e2e.md).
 
 ## Architecture
 

--- a/docs/container-e2e.md
+++ b/docs/container-e2e.md
@@ -1,0 +1,43 @@
+# Container E2E tests
+
+Issue
+[#19](https://github.com/honua-io/honua-server-admin/issues/19) tracks the
+full Docker-backed admin UI E2E suite. The current baseline keeps the fast
+in-process TestServer integration tests and adds an opt-in Testcontainers lane
+for real PostGIS plus Honua Server coverage.
+
+## CI behavior
+
+`Container E2E Readiness` runs on every pull request. It verifies Docker is
+available and runs the `Category=ContainerE2E` test lane.
+
+By default, `HONUA_ADMIN_CONTAINER_E2E=false`, so the test lane exits without
+starting containers. Set the repository variable `HONUA_ADMIN_CONTAINER_E2E` to
+`true` when a pullable Honua Server image is available for CI.
+
+## Configuration
+
+| Variable or secret | Default | Purpose |
+| --- | --- | --- |
+| `HONUA_ADMIN_CONTAINER_E2E` | `false` | Enables live container startup when truthy (`true`, `1`, `yes`). |
+| `HONUA_SERVER_IMAGE` | `ghcr.io/honua-io/honua-server:latest` | Honua Server image used by the E2E fixture. |
+| `HONUA_POSTGIS_IMAGE` | `postgis/postgis:18-3.6` | PostGIS image used by the E2E fixture. |
+| `HONUA_ADMIN_CONTAINER_API_KEY` | `test-admin-key` | API key passed to the server and admin client. Configure as a secret in CI. |
+| `HONUA_POSTGIS_DATABASE` | `honua_integration` | PostGIS database name. |
+| `HONUA_POSTGIS_USERNAME` | `honua_test` | PostGIS username. |
+| `HONUA_POSTGIS_PASSWORD` | `honua_test` | PostGIS password. |
+| `HONUA_SERVER_CONTAINER_PORT` | `8080` | HTTP port exposed inside the Honua Server container. |
+| `HONUA_SERVER_WAIT_PATH` | `/api/v1/admin/features/` | HTTP path used by Testcontainers readiness checks. |
+
+## Local run
+
+```bash
+HONUA_ADMIN_CONTAINER_E2E=true \
+HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest \
+dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj \
+  --filter "Category=ContainerE2E"
+```
+
+Keep the container lane focused on release-critical admin flows. The
+non-container integration tests remain the fast contract suite for normal local
+development.

--- a/tests/Honua.Admin.IntegrationTests/Fixtures/ContainerizedHonuaServerFixture.cs
+++ b/tests/Honua.Admin.IntegrationTests/Fixtures/ContainerizedHonuaServerFixture.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Honua.Admin.Services.Admin;
+using Testcontainers.PostgreSql;
+
+namespace Honua.Admin.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Opt-in Docker fixture for the issue #19 containerized E2E lane. The fixture
+/// starts PostGIS and Honua Server on a private Docker network, then points the
+/// real admin HTTP client at the mapped Honua Server port.
+/// </summary>
+public sealed class ContainerizedHonuaServerFixture : IAsyncDisposable
+{
+    private readonly ContainerizedHonuaServerOptions _options;
+    private readonly INetwork _network;
+    private readonly PostgreSqlContainer _postgis;
+    private readonly IContainer _honuaServer;
+    private readonly HttpClient _httpClient;
+
+    private ContainerizedHonuaServerFixture(ContainerizedHonuaServerOptions options)
+    {
+        _options = options;
+        _network = new NetworkBuilder()
+            .WithName($"honua-admin-e2e-{Guid.NewGuid():N}")
+            .Build();
+
+        _postgis = new PostgreSqlBuilder()
+            .WithImage(options.PostgisImage)
+            .WithDatabase(options.PostgisDatabase)
+            .WithUsername(options.PostgisUsername)
+            .WithPassword(options.PostgisPassword)
+            .WithNetwork(_network)
+            .WithNetworkAliases("postgis")
+            .Build();
+
+        _honuaServer = new ContainerBuilder()
+            .WithImage(options.HonuaServerImage)
+            .WithNetwork(_network)
+            .WithPortBinding(options.HonuaServerPort, assignRandomHostPort: true)
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ASPNETCORE_URLS", $"http://+:{options.HonuaServerPort}")
+            .WithEnvironment("ConnectionStrings__DefaultConnection", options.PostgisNetworkConnectionString)
+            .WithEnvironment("HONUA_DEV_AUTH", "true")
+            .WithEnvironment("HONUA_ADMIN_PASSWORD", options.AdminApiKey)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request
+                .ForPort((ushort)options.HonuaServerPort)
+                .ForPath(options.WaitPath)))
+            .Build();
+
+        _httpClient = new HttpClient();
+        if (!string.IsNullOrWhiteSpace(options.AdminApiKey))
+        {
+            _httpClient.DefaultRequestHeaders.Add("X-API-Key", options.AdminApiKey);
+        }
+    }
+
+    public string BaseUrl { get; private set; } = string.Empty;
+
+    public IHonuaAdminClient AdminClient { get; private set; } = null!;
+
+    public static bool IsEnabled => ContainerizedHonuaServerOptions.Load().Enabled;
+
+    public static async Task<ContainerizedHonuaServerFixture> StartAsync(CancellationToken cancellationToken = default)
+    {
+        var fixture = new ContainerizedHonuaServerFixture(ContainerizedHonuaServerOptions.Load());
+        await fixture.StartCoreAsync(cancellationToken).ConfigureAwait(false);
+        return fixture;
+    }
+
+    private async Task StartCoreAsync(CancellationToken cancellationToken)
+    {
+        await _network.CreateAsync(cancellationToken).ConfigureAwait(false);
+        await _postgis.StartAsync(cancellationToken).ConfigureAwait(false);
+        await _honuaServer.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        var mappedPort = _honuaServer.GetMappedPublicPort(_options.HonuaServerPort);
+        BaseUrl = new UriBuilder("http", _honuaServer.Hostname, mappedPort).Uri.ToString();
+        _httpClient.BaseAddress = new Uri(BaseUrl, UriKind.Absolute);
+        _httpClient.Timeout = TimeSpan.FromSeconds(_options.RequestTimeoutSeconds);
+        AdminClient = new HonuaAdminClient(_httpClient, new NullTelemetry());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _httpClient.Dispose();
+
+        await DisposeContainerAsync(_honuaServer).ConfigureAwait(false);
+        await DisposeContainerAsync(_postgis).ConfigureAwait(false);
+
+        await _network.DeleteAsync().ConfigureAwait(false);
+        await _network.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private static async Task DisposeContainerAsync(IAsyncDisposable disposable)
+    {
+        try
+        {
+            await disposable.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Cleanup failures should not hide the original test failure.
+        }
+    }
+
+    private sealed class NullTelemetry : IAdminTelemetry
+    {
+        public void PageNavigated(string pageRoute, string? principalId) { }
+        public void DestructiveAction(string action, string? targetId, string? principalId) { }
+        public void ClientRequestFailed(string operation, string error) { }
+    }
+}
+
+public sealed record ContainerizedHonuaServerOptions
+{
+    public bool Enabled { get; init; }
+    public string HonuaServerImage { get; init; } = "ghcr.io/honua-io/honua-server:latest";
+    public string PostgisImage { get; init; } = "postgis/postgis:18-3.6";
+    public string PostgisDatabase { get; init; } = "honua_integration";
+    public string PostgisUsername { get; init; } = "honua_test";
+    public string PostgisPassword { get; init; } = "honua_test";
+    public string AdminApiKey { get; init; } = "test-admin-key";
+    public int HonuaServerPort { get; init; } = 8080;
+    public int RequestTimeoutSeconds { get; init; } = 30;
+    public string WaitPath { get; init; } = "/api/v1/admin/features/";
+
+    public string PostgisNetworkConnectionString
+        => $"Host=postgis;Port=5432;Database={PostgisDatabase};Username={PostgisUsername};Password={PostgisPassword};";
+
+    public static ContainerizedHonuaServerOptions Load() => new()
+    {
+        Enabled = IsTruthy(Environment.GetEnvironmentVariable("HONUA_ADMIN_CONTAINER_E2E")),
+        HonuaServerImage = GetValue("HONUA_SERVER_IMAGE", "ghcr.io/honua-io/honua-server:latest"),
+        PostgisImage = GetValue("HONUA_POSTGIS_IMAGE", "postgis/postgis:18-3.6"),
+        PostgisDatabase = GetValue("HONUA_POSTGIS_DATABASE", "honua_integration"),
+        PostgisUsername = GetValue("HONUA_POSTGIS_USERNAME", "honua_test"),
+        PostgisPassword = GetValue("HONUA_POSTGIS_PASSWORD", "honua_test"),
+        AdminApiKey = GetValue("HONUA_ADMIN_CONTAINER_API_KEY", "test-admin-key"),
+        HonuaServerPort = GetInt("HONUA_SERVER_CONTAINER_PORT", 8080),
+        RequestTimeoutSeconds = GetInt("HONUA_ADMIN_CONTAINER_TIMEOUT_SECONDS", 30),
+        WaitPath = GetValue("HONUA_SERVER_WAIT_PATH", "/api/v1/admin/features/"),
+    };
+
+    private static string GetValue(string key, string fallback)
+        => string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(key))
+            ? fallback
+            : Environment.GetEnvironmentVariable(key)!;
+
+    private static int GetInt(string key, int fallback)
+        => int.TryParse(Environment.GetEnvironmentVariable(key), out var value) && value > 0
+            ? value
+            : fallback;
+
+    private static bool IsTruthy(string? value)
+        => string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj
+++ b/tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj
@@ -20,6 +20,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Honua.Admin.IntegrationTests/Tests/ContainerizedAdminApiEndToEndTests.cs
+++ b/tests/Honua.Admin.IntegrationTests/Tests/ContainerizedAdminApiEndToEndTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.IntegrationTests.Fixtures;
+using Xunit;
+
+namespace Honua.Admin.IntegrationTests.Tests;
+
+/// <summary>
+/// Docker-backed E2E smoke coverage for issue #19. The test is opt-in until
+/// the repo has a stable Honua Server image configured in CI.
+/// </summary>
+public sealed class ContainerizedAdminApiEndToEndTests
+{
+    [Fact]
+    [Trait("Category", "ContainerE2E")]
+    public async Task HonuaServerContainer_ReturnsAdminFeatureOverview()
+    {
+        if (!ContainerizedHonuaServerFixture.IsEnabled)
+        {
+            return;
+        }
+
+        await using var fixture = await ContainerizedHonuaServerFixture.StartAsync(CancellationToken.None);
+
+        var overview = await fixture.AdminClient.GetFeatureOverviewAsync(CancellationToken.None);
+
+        Assert.False(string.IsNullOrWhiteSpace(fixture.BaseUrl));
+        Assert.NotNull(overview);
+        Assert.NotEmpty(overview.CurrentEdition);
+        Assert.NotEmpty(overview.Features);
+    }
+}


### PR DESCRIPTION
## Summary

- adds an opt-in Testcontainers fixture that starts PostGIS plus a configurable Honua Server container on a private Docker network
- adds a `Category=ContainerE2E` admin API smoke test that uses the real `HonuaAdminClient` when `HONUA_ADMIN_CONTAINER_E2E=true`
- adds a GitHub Actions `Container E2E Readiness` job that verifies Docker availability and runs the container lane, included in `CI Gate`
- documents the repository variables/secrets needed to enable live container E2E runs

## Scope

This is the container-readiness baseline for #19. It does not close the full issue yet; the remaining CRUD, layer publishing/style, service settings, metadata/ETag, observability, and deploy preflight scenarios still need to be layered into the `Category=ContainerE2E` lane once the Honua Server image is configured for CI.

## Validation

- `docker --version`
- `dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --filter "Category=ContainerE2E" --logger "console;verbosity=minimal"`
- `dotnet test Honua.Admin.sln --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1`
- `dotnet build Honua.Admin.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic`

Related to #19
