### PR TITLE
feat: add admin SignalR connection shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Configure server connection in `src/Honua.Admin/wwwroot/appsettings.json`:
 {
   "HonuaServer": {
     "BaseUrl": "https://your-server.com",
+    "HubUrl": "https://your-server.com/hubs/admin",
     "ApiKey": "your-api-key",
     "RequestTimeoutSeconds": 30
   }
@@ -93,6 +94,9 @@ Configure server connection in `src/Honua.Admin/wwwroot/appsettings.json`:
 `HonuaServer:BaseUrl` is the absolute URL of the Honua server. When omitted,
 the admin shell falls back to `StubHonuaAdminClient` — deterministic
 in-memory data so the UI is demoable before the real server is wired up.
+`HonuaServer:HubUrl` is optional; when omitted, realtime admin updates use
+`{BaseUrl}/hubs/admin`. If neither value is present the UI keeps its normal
+request/refresh behavior and marks realtime updates as disabled.
 
 `HonuaServer:ApiKey` is **development-only**. Blazor WebAssembly ships
 configuration to the browser, so any value placed here is visible to every

--- a/src/Honua.Admin/Configuration/HonuaAdminOptions.cs
+++ b/src/Honua.Admin/Configuration/HonuaAdminOptions.cs
@@ -20,6 +20,9 @@ public sealed class HonuaAdminOptions
     /// <summary>The base address of the honua-server admin API.</summary>
     public string BaseUrl { get; set; } = string.Empty;
 
+    /// <summary>Optional absolute SignalR admin hub URL. Defaults to BaseUrl + /hubs/admin.</summary>
+    public string HubUrl { get; set; } = string.Empty;
+
     /// <summary>Optional API key; only used when no operator login is in effect.</summary>
     public string ApiKey { get; set; } = string.Empty;
 

--- a/src/Honua.Admin/Honua.Admin.csproj
+++ b/src/Honua.Admin/Honua.Admin.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="QRCoder" Version="1.6.0" />

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddSingleton<AdminAuthStateProvider>();
 builder.Services.AddTransient<AdminAuthHandler>();
 builder.Services.AddTransient<GlobalErrorHandler>();
 builder.Services.AddScoped<IAdminTelemetry, LoggingAdminTelemetry>();
+builder.Services.AddScoped<IAdminRealtimeConnection, AdminRealtimeConnection>();
 
 // While the real honua-server is reachable the typed HttpClient routes through the
 // auth + global-error handlers. Until then (default `appsettings.json` ships no

--- a/src/Honua.Admin/Services/Admin/AdminRealtimeConnection.cs
+++ b/src/Honua.Admin/Services/Admin/AdminRealtimeConnection.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Auth;
+using Honua.Admin.Configuration;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Admin.Services.Admin;
+
+public enum AdminRealtimeConnectionStatus
+{
+    Disabled,
+    Disconnected,
+    Connecting,
+    Connected,
+    Reconnecting,
+    Unavailable,
+}
+
+public interface IAdminRealtimeConnection : IAsyncDisposable
+{
+    AdminRealtimeConnectionStatus Status { get; }
+    Uri? HubUri { get; }
+    string? LastError { get; }
+    event Action? StateChanged;
+    Task StartAsync(CancellationToken cancellationToken = default);
+    Task StopAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class AdminRealtimeConnection : IAdminRealtimeConnection
+{
+    private readonly IOptions<HonuaAdminOptions> _options;
+    private readonly AdminAuthStateProvider _auth;
+    private readonly ILogger<AdminRealtimeConnection> _logger;
+    private HubConnection? _connection;
+
+    public AdminRealtimeConnection(
+        IOptions<HonuaAdminOptions> options,
+        AdminAuthStateProvider auth,
+        ILogger<AdminRealtimeConnection> logger)
+    {
+        _options = options;
+        _auth = auth;
+        _logger = logger;
+    }
+
+    public AdminRealtimeConnectionStatus Status { get; private set; } = AdminRealtimeConnectionStatus.Disabled;
+    public Uri? HubUri { get; private set; }
+    public string? LastError { get; private set; }
+    public event Action? StateChanged;
+
+    public static Uri? ResolveHubUri(HonuaAdminOptions options, string? runtimeServerUrl)
+    {
+        if (Uri.TryCreate(options.HubUrl, UriKind.Absolute, out var explicitHubUri))
+        {
+            return explicitHubUri;
+        }
+
+        var baseUrl = !string.IsNullOrWhiteSpace(runtimeServerUrl)
+            ? runtimeServerUrl
+            : options.BaseUrl;
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+        {
+            return null;
+        }
+
+        return new Uri(baseUri, "hubs/admin");
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (Status is AdminRealtimeConnectionStatus.Connected or AdminRealtimeConnectionStatus.Connecting)
+        {
+            return;
+        }
+
+        HubUri = ResolveHubUri(_options.Value, _auth.ServerUrl);
+        if (HubUri is null)
+        {
+            SetStatus(AdminRealtimeConnectionStatus.Disabled);
+            return;
+        }
+
+        _connection ??= BuildConnection(HubUri);
+
+        try
+        {
+            SetStatus(AdminRealtimeConnectionStatus.Connecting);
+            await _connection.StartAsync(cancellationToken).ConfigureAwait(false);
+            LastError = null;
+            SetStatus(AdminRealtimeConnectionStatus.Connected);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LastError = ex.Message;
+            _logger.LogWarning(ex, "Admin SignalR hub unavailable at {HubUri}", HubUri);
+            SetStatus(AdminRealtimeConnectionStatus.Unavailable);
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_connection is null)
+        {
+            SetStatus(AdminRealtimeConnectionStatus.Disabled);
+            return;
+        }
+
+        await _connection.StopAsync(cancellationToken).ConfigureAwait(false);
+        SetStatus(AdminRealtimeConnectionStatus.Disconnected);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private HubConnection BuildConnection(Uri hubUri)
+    {
+        var connection = new HubConnectionBuilder()
+            .WithUrl(hubUri, options =>
+            {
+                options.AccessTokenProvider = ResolveAccessTokenAsync;
+            })
+            .WithAutomaticReconnect()
+            .Build();
+
+        connection.Reconnecting += ex =>
+        {
+            LastError = ex?.Message;
+            SetStatus(AdminRealtimeConnectionStatus.Reconnecting);
+            return Task.CompletedTask;
+        };
+        connection.Reconnected += _ =>
+        {
+            LastError = null;
+            SetStatus(AdminRealtimeConnectionStatus.Connected);
+            return Task.CompletedTask;
+        };
+        connection.Closed += ex =>
+        {
+            LastError = ex?.Message;
+            SetStatus(AdminRealtimeConnectionStatus.Disconnected);
+            return Task.CompletedTask;
+        };
+
+        return connection;
+    }
+
+    private Task<string?> ResolveAccessTokenAsync()
+    {
+        var token = !string.IsNullOrWhiteSpace(_auth.ApiKey)
+            ? _auth.ApiKey
+            : _options.Value.ApiKey;
+
+        return Task.FromResult(string.IsNullOrWhiteSpace(token) ? null : token);
+    }
+
+    private void SetStatus(AdminRealtimeConnectionStatus status)
+    {
+        if (Status == status)
+        {
+            return;
+        }
+
+        Status = status;
+        StateChanged?.Invoke();
+    }
+}

--- a/src/Honua.Admin/Shared/MainLayout.razor
+++ b/src/Honua.Admin/Shared/MainLayout.razor
@@ -1,4 +1,6 @@
 @inherits LayoutComponentBase
+@implements IDisposable
+@inject IAdminRealtimeConnection Realtime
 @using MudBlazor
 
 <MudThemeProvider />
@@ -10,6 +12,13 @@
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         <MudText Typo="Typo.h6">Honua Server Admin</MudText>
         <MudSpacer />
+        <MudChip T="string"
+                 Size="Size.Small"
+                 Color="@RealtimeColor"
+                 Variant="Variant.Outlined"
+                 aria-label="@RealtimeAriaLabel">
+            @RealtimeLabel
+        </MudChip>
     </MudAppBar>
 
     <MudDrawer Open="true" Elevation="1">
@@ -23,3 +32,47 @@
         @Body
     </MudMainContent>
 </MudLayout>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        Realtime.StateChanged += OnRealtimeStateChanged;
+        await Realtime.StartAsync();
+    }
+
+    private string RealtimeLabel => Realtime.Status switch
+    {
+        AdminRealtimeConnectionStatus.Connected => "Live",
+        AdminRealtimeConnectionStatus.Connecting => "Connecting",
+        AdminRealtimeConnectionStatus.Reconnecting => "Reconnecting",
+        AdminRealtimeConnectionStatus.Unavailable => "Offline",
+        AdminRealtimeConnectionStatus.Disconnected => "Offline",
+        _ => "Static",
+    };
+
+    private string RealtimeAriaLabel => Realtime.Status switch
+    {
+        AdminRealtimeConnectionStatus.Connected => "Realtime updates connected",
+        AdminRealtimeConnectionStatus.Connecting => "Realtime updates connecting",
+        AdminRealtimeConnectionStatus.Reconnecting => "Realtime updates reconnecting",
+        AdminRealtimeConnectionStatus.Unavailable => "Realtime updates unavailable",
+        AdminRealtimeConnectionStatus.Disconnected => "Realtime updates disconnected",
+        _ => "Realtime updates disabled",
+    };
+
+    private Color RealtimeColor => Realtime.Status switch
+    {
+        AdminRealtimeConnectionStatus.Connected => Color.Success,
+        AdminRealtimeConnectionStatus.Connecting => Color.Info,
+        AdminRealtimeConnectionStatus.Reconnecting => Color.Warning,
+        AdminRealtimeConnectionStatus.Unavailable => Color.Warning,
+        AdminRealtimeConnectionStatus.Disconnected => Color.Default,
+        _ => Color.Default,
+    };
+
+    private void OnRealtimeStateChanged()
+        => _ = InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+        => Realtime.StateChanged -= OnRealtimeStateChanged;
+}

--- a/src/Honua.Admin/wwwroot/appsettings.json
+++ b/src/Honua.Admin/wwwroot/appsettings.json
@@ -1,6 +1,7 @@
 {
   "HonuaServer": {
     "BaseUrl": "",
+    "HubUrl": "",
     "ApiKey": "",
     "RequestTimeoutSeconds": 30
   }

--- a/tests/Honua.Admin.Tests/AdminRealtimeConnectionTests.cs
+++ b/tests/Honua.Admin.Tests/AdminRealtimeConnectionTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Threading.Tasks;
+using Honua.Admin.Auth;
+using Honua.Admin.Configuration;
+using Honua.Admin.Services.Admin;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class AdminRealtimeConnectionTests
+{
+    [Fact]
+    public void ResolveHubUri_UsesExplicitHubUrl()
+    {
+        var options = new HonuaAdminOptions
+        {
+            BaseUrl = "https://server.example",
+            HubUrl = "https://push.example/custom/admin",
+        };
+
+        var uri = AdminRealtimeConnection.ResolveHubUri(options, runtimeServerUrl: null);
+
+        Assert.Equal("https://push.example/custom/admin", uri?.ToString().TrimEnd('/'));
+    }
+
+    [Fact]
+    public void ResolveHubUri_DefaultsToAdminHubUnderBaseUrl()
+    {
+        var options = new HonuaAdminOptions
+        {
+            BaseUrl = "https://server.example/root/",
+        };
+
+        var uri = AdminRealtimeConnection.ResolveHubUri(options, runtimeServerUrl: null);
+
+        Assert.Equal("https://server.example/root/hubs/admin", uri?.ToString().TrimEnd('/'));
+    }
+
+    [Fact]
+    public void ResolveHubUri_PrefersRuntimeServerUrl()
+    {
+        var options = new HonuaAdminOptions
+        {
+            BaseUrl = "https://configured.example",
+        };
+
+        var uri = AdminRealtimeConnection.ResolveHubUri(options, "https://operator.example/");
+
+        Assert.Equal("https://operator.example/hubs/admin", uri?.ToString().TrimEnd('/'));
+    }
+
+    [Fact]
+    public async Task StartAsync_WithoutHubUrlLeavesConnectionDisabled()
+    {
+        var auth = new AdminAuthStateProvider(ThrowingJsRuntime.Instance);
+        var realtime = new AdminRealtimeConnection(
+            Options.Create(new HonuaAdminOptions()),
+            auth,
+            NullLogger<AdminRealtimeConnection>.Instance);
+
+        await realtime.StartAsync();
+
+        Assert.Equal(AdminRealtimeConnectionStatus.Disabled, realtime.Status);
+        Assert.Null(realtime.HubUri);
+    }
+
+    private sealed class ThrowingJsRuntime : IJSRuntime
+    {
+        public static readonly ThrowingJsRuntime Instance = new();
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+            => throw new InvalidOperationException("JS interop is not available in this test.");
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier,
+            System.Threading.CancellationToken cancellationToken,
+            object?[]? args)
+            => throw new InvalidOperationException("JS interop is not available in this test.");
+    }
+}


### PR DESCRIPTION
## Summary

- adds the SignalR client package and a scoped `IAdminRealtimeConnection` service with automatic reconnect, disabled fallback, and unavailable-state handling
- resolves the admin hub URL from `HonuaServer:HubUrl`, runtime auth server URL, or `{BaseUrl}/hubs/admin`
- surfaces realtime connection state in the main app bar without breaking the existing request/refresh behavior
- documents `HonuaServer:HubUrl` and adds unit coverage for URL resolution and disabled fallback

## Scope

This is the infrastructure slice for #18. It does not close the full issue yet; push-event handlers for dashboard cards, observability rows, deploy operation progress, and connection health remain follow-up work once the server hub contract is available.

## Validation

- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --filter FullyQualifiedName~AdminRealtimeConnectionTests --logger "console;verbosity=minimal"`
- `dotnet test Honua.Admin.sln --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1`
- `dotnet build Honua.Admin.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic`
- `dotnet publish src/Honua.Admin/Honua.Admin.csproj --configuration Release --output ./dist --no-restore`
- local publish budget check: 33,181,033 / 62,914,560 total bytes; 28,305,775 / 47,185,920 framework bytes; 13,859,500 / 25,165,824 wasm bytes

Related to #18
