### PR TITLE
feat: add publishing workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This is the official admin UI for managing Honua Server instances:
 - **License Workspace**: BYOL license status, entitlement inspection, expiry banding, replace flow, and operator-actionable diagnostics — see [License workspace](#license-workspace) below
 - **Spatial SQL Playground**: Browser-based PostGIS-aware SQL editor with schema autocomplete, MapLibre preview, EXPLAIN tree, and named-view save flow — see [Spatial SQL playground](#spatial-sql-playground) below
 - **Map Annotations Workspace**: Drawing tools, annotation-layer controls, saved sets, comment review, and GeoJSON / SVG / PDF export stubs at `/operator/annotations` - see [Map annotations workspace](#map-annotations-workspace) below
+- **Publishing Workspace**: Guided connection-to-service publishing workflow with table discovery, protocol intent, environment comparison, and deploy preflight at `/operator/publishing` - see [Publishing workspace](#publishing-workspace) below
 - **Data Connections Workspace**: List / create / edit / soft-disable / delete / preflight data connections, with a structured diagnostic grid and a managed-Postgres capability matrix — see [Data connections workspace](#data-connections-workspace) below
 
 Coverage of the wider honua-server admin API is tracked in
@@ -430,6 +431,35 @@ of pointer-driven drawing. The state and export surfaces are covered by
 unit tests so the upcoming map-canvas, saved-map storage, and live
 collaboration integrations can replace the stubbed placement flow without
 changing the route contract.
+
+### Publishing workspace
+
+The publishing workspace (ticket `#14`) lives at `/operator/publishing`
+and orchestrates existing admin control-plane APIs across connections,
+table discovery, layer publishing, service protocols, and deploy
+preflight.
+
+The route includes:
+
+- Connection selection against `IHonuaAdminClient.ListConnectionsAsync`
+  with active/health validation.
+- Table discovery through `DiscoverConnectionTablesAsync`, with one-click
+  draft hydration for schema, table, geometry column, geometry type, SRID,
+  and layer name.
+- Publish intent controls that map to `PublishLayerAsync` and refresh the
+  service layer list afterward.
+- Protocol toggles backed by `GetServiceSettingsAsync` and
+  `UpdateServiceProtocolsAsync`.
+- Environment comparison rows that expose desired protocol intent versus
+  actual service state for dev, staging, and production.
+- Deploy preflight validation through `GetDeployPreflightAsync`.
+- Launch points back to data connections, service settings, and layer
+  style pages for deeper configuration.
+
+The current scope does not implement GitOps commit creation, environment
+promotion, or server-side desired-state reconciliation. Those remain
+follow-up work once the server exposes durable environment intent and drift
+contracts.
 
 ### Data connections workspace
 

--- a/src/Honua.Admin/Pages/Operator/PublishingWorkspace.razor
+++ b/src/Honua.Admin/Pages/Operator/PublishingWorkspace.razor
@@ -1,0 +1,351 @@
+@page "/operator/publishing"
+@using Microsoft.AspNetCore.Authorization
+@using Honua.Admin.Services.Publishing
+@attribute [Authorize]
+@inject PublishingWorkspaceState State
+@inject ISnackbar Snackbar
+@inject IAdminTelemetry Telemetry
+@implements IDisposable
+
+<PageTitle>Publishing workspace</PageTitle>
+
+<div class="publishing-root" data-testid="publishing-workspace-root">
+    <div class="publishing-toolbar" aria-label="Publishing workspace toolbar">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.h5">Publishing workspace</MudText>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@StatusColor(State.Status)" data-testid="publishing-status">
+                @State.Status
+            </MudChip>
+            <MudSpacer />
+            <MudButton StartIcon="@Icons.Material.Filled.Refresh"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="RefreshAsync"
+                       data-testid="publishing-refresh">
+                Refresh
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Search"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="DiscoverAsync"
+                       data-testid="publishing-discover">
+                Discover
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.HealthAndSafety"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="RunPreflightAsync"
+                       data-testid="publishing-preflight">
+                Preflight
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Save"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="SaveProtocolsAsync"
+                       data-testid="publishing-save-protocols">
+                Save protocols
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Publish"
+                       Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       Size="Size.Small"
+                       Disabled="@(IsBusy || State.HasBlockingValidation)"
+                       OnClick="PublishAsync"
+                       data-testid="publishing-publish">
+                Publish
+            </MudButton>
+        </MudStack>
+        @if (!string.IsNullOrWhiteSpace(State.LastError))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Dense="true" Class="mt-2" data-testid="publishing-error">
+                @State.LastError
+            </MudAlert>
+        }
+    </div>
+
+    <div class="publishing-grid">
+        <div class="publishing-pane publishing-connections" aria-label="Connection and table discovery">
+            <MudText Typo="Typo.h6">Connection</MudText>
+            <div class="publishing-list" aria-label="Publishing data connections">
+                @foreach (var connection in State.Connections)
+                {
+                    var item = connection;
+                    <button type="button"
+                            class="@ConnectionClass(item)"
+                            @onclick="@(() => SelectConnectionAsync(item.Id))"
+                            data-testid="@($"publishing-connection-{item.Name}")">
+                        <span>@item.Name</span>
+                        <small>@item.HealthStatus - @item.DatabaseName</small>
+                    </button>
+                }
+            </div>
+
+            <MudStack Row AlignItems="AlignItems.Center" Class="publishing-section-heading">
+                <MudText Typo="Typo.h6">Discovery</MudText>
+                <MudSpacer />
+                <MudButton Href="/operator/data-connections"
+                           Variant="Variant.Text"
+                           Size="Size.Small"
+                           StartIcon="@Icons.Material.Filled.Cable">
+                    Connections
+                </MudButton>
+            </MudStack>
+            @if (State.Tables.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Text" Dense="true" data-testid="publishing-no-tables">
+                    No tables discovered.
+                </MudAlert>
+            }
+            else
+            {
+                <MudTable Items="State.Tables" Dense="true" Hover="true" aria-label="Discovered publishable tables">
+                    <HeaderContent>
+                        <MudTh>Source</MudTh>
+                        <MudTh>Geometry</MudTh>
+                        <MudTh></MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd>@($"{context.Schema}.{context.Table}")</MudTd>
+                        <MudTd>@(context.GeometryColumn ?? "none")</MudTd>
+                        <MudTd>
+                            <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => State.UseTable(context))">
+                                Use
+                            </MudButton>
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            }
+        </div>
+
+        <div class="publishing-pane publishing-draft" aria-label="Publishing intent">
+            <MudText Typo="Typo.h6">Intent</MudText>
+            <MudGrid Class="publishing-form-grid">
+                <MudItem xs="12" sm="6">
+                    <MudTextField T="string"
+                                  Label="Service"
+                                  Value="@State.ServiceName"
+                                  ValueChanged="OnServiceNameChanged"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  aria-label="Publishing service name" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudTextField T="string"
+                                  Label="Layer name"
+                                  Value="@State.DraftLayerName"
+                                  ValueChanged="State.SetDraftLayerName"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  aria-label="Publishing layer name" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField T="string"
+                                  Label="Description"
+                                  Value="@State.DraftDescription"
+                                  ValueChanged="State.SetDraftDescription"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Lines="2"
+                                  aria-label="Publishing description" />
+                </MudItem>
+                <MudItem xs="12" sm="4">
+                    <MudTextField T="string" Label="Schema" Value="@State.DraftSchema" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Publishing schema" />
+                </MudItem>
+                <MudItem xs="12" sm="4">
+                    <MudTextField T="string" Label="Table" Value="@State.DraftTable" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Publishing table" />
+                </MudItem>
+                <MudItem xs="12" sm="4">
+                    <MudTextField T="string" Label="Geometry" Value="@State.DraftGeometryColumn" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Publishing geometry column" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudCheckBox T="bool"
+                                 Label="Enable after publish"
+                                 Value="@State.DraftEnabled"
+                                 ValueChanged="State.SetDraftEnabled"
+                                 Color="Color.Primary"
+                                 aria-label="Enable after publish" />
+                </MudItem>
+            </MudGrid>
+
+            <div class="publishing-section-heading">
+                <MudText Typo="Typo.h6">Protocols</MudText>
+            </div>
+            <div class="publishing-protocols" aria-label="Publishing protocol toggles">
+                @foreach (var protocol in State.AvailableProtocols)
+                {
+                    var option = protocol;
+                    <MudCheckBox T="bool"
+                                 Label="@option"
+                                 Value="@State.DesiredProtocols.Contains(option, StringComparer.OrdinalIgnoreCase)"
+                                 ValueChanged="@((bool enabled) => State.ToggleProtocol(option, enabled))"
+                                 Color="Color.Primary"
+                                 aria-label="@($"Enable {option}")" />
+                }
+            </div>
+
+            <div class="publishing-section-heading">
+                <MudText Typo="Typo.h6">Validation</MudText>
+            </div>
+            <div class="publishing-validation" aria-label="Publishing validation checks">
+                @foreach (var check in State.ValidationChecks)
+                {
+                    <div class="publishing-validation-row" data-testid="@($"publishing-check-{check.Key}")">
+                        <MudIcon Icon="@(check.Passed ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Error)"
+                                 Color="@(check.Passed ? Color.Success : Color.Warning)"
+                                 Size="Size.Small" />
+                        <div>
+                            <strong>@check.Label</strong>
+                            <span>@check.Message</span>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <div class="publishing-pane publishing-state" aria-label="Environment and service state">
+            <MudText Typo="Typo.h6">Environments</MudText>
+            <MudTable Items="State.EnvironmentStates" Dense="true" Hover="true" aria-label="Publishing environment comparison">
+                <HeaderContent>
+                    <MudTh>Env</MudTh>
+                    <MudTh>Desired</MudTh>
+                    <MudTh>Actual</MudTh>
+                    <MudTh>State</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.Name</MudTd>
+                    <MudTd>@context.DesiredProtocols</MudTd>
+                    <MudTd>@context.ActualProtocols</MudTd>
+                    <MudTd>@context.DriftStatus</MudTd>
+                </RowTemplate>
+            </MudTable>
+
+            <MudStack Row AlignItems="AlignItems.Center" Class="publishing-section-heading">
+                <MudText Typo="Typo.h6">Layers</MudText>
+                <MudSpacer />
+                <MudButton Href="@($"/services/{State.ServiceName}/settings")"
+                           Variant="Variant.Text"
+                           Size="Size.Small"
+                           StartIcon="@Icons.Material.Filled.Settings">
+                    Settings
+                </MudButton>
+            </MudStack>
+            @if (State.Layers.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text" data-testid="publishing-no-layers">
+                    No layers loaded.
+                </MudAlert>
+            }
+            else
+            {
+                <div class="publishing-layer-list" aria-label="Published service layers">
+                    @foreach (var layer in State.Layers)
+                    {
+                        <div class="publishing-layer-row" data-testid="@($"publishing-layer-{layer.LayerName}")">
+                            <div>
+                                <strong>@layer.LayerName</strong>
+                                <span>@($"{layer.Schema}.{layer.Table}")</span>
+                            </div>
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@(layer.Enabled ? Color.Success : Color.Warning)">
+                                @(layer.Enabled ? "Enabled" : "Disabled")
+                            </MudChip>
+                            <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => ToggleLayerAsync(layer))">
+                                @(layer.Enabled ? "Disable" : "Enable")
+                            </MudButton>
+                            <MudButton Size="Size.Small" Variant="Variant.Text" Href="@($"/layers/{layer.LayerId}/style")">
+                                Style
+                            </MudButton>
+                        </div>
+                    }
+                </div>
+            }
+
+            @if (State.LastPublishedLayer is not null)
+            {
+                <MudAlert Severity="Severity.Success" Variant="Variant.Outlined" Dense="true" Class="mt-3" data-testid="publishing-last-published">
+                    Published @State.LastPublishedLayer.LayerName.
+                </MudAlert>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += StateChanged;
+        Telemetry.PageNavigated("/operator/publishing", principalId: null);
+        await State.InitializeAsync();
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= StateChanged;
+    }
+
+    private bool IsBusy => State.Status is PublishingWorkspaceStatus.Loading
+        or PublishingWorkspaceStatus.Publishing
+        or PublishingWorkspaceStatus.Saving
+        or PublishingWorkspaceStatus.Validating;
+
+    private Task RefreshAsync() => State.InitializeAsync();
+
+    private Task SelectConnectionAsync(string connectionId) => State.SelectConnectionAsync(connectionId);
+
+    private Task DiscoverAsync() => State.DiscoverTablesAsync();
+
+    private Task RunPreflightAsync() => State.RunPreflightAsync();
+
+    private async Task SaveProtocolsAsync()
+    {
+        await State.SaveProtocolsAsync();
+        if (State.LastError is null)
+        {
+            Snackbar.Add("Protocols saved.", Severity.Success);
+        }
+    }
+
+    private async Task PublishAsync()
+    {
+        var layer = await State.PublishAsync();
+        if (layer is not null)
+        {
+            Snackbar.Add($"Layer '{layer.LayerName}' published.", Severity.Success);
+        }
+    }
+
+    private async Task ToggleLayerAsync(LayerSummary layer)
+    {
+        Telemetry.DestructiveAction(layer.Enabled ? "publishing-disable-layer" : "publishing-enable-layer", layer.LayerId.ToString(), principalId: null);
+        await State.ToggleLayerAsync(layer);
+    }
+
+    private async Task OnServiceNameChanged(string value)
+    {
+        State.SetServiceName(value);
+        await State.LoadServiceAsync();
+        await State.LoadLayersAsync();
+    }
+
+    private void StateChanged() => InvokeAsync(StateHasChanged);
+
+    private string ConnectionClass(ConnectionSummary connection)
+    {
+        var active = string.Equals(connection.Id, State.SelectedConnectionId, StringComparison.OrdinalIgnoreCase)
+            ? " publishing-list-item-active"
+            : string.Empty;
+        return $"publishing-list-item{active}";
+    }
+
+    private static Color StatusColor(PublishingWorkspaceStatus status) => status switch
+    {
+        PublishingWorkspaceStatus.Error => Color.Error,
+        PublishingWorkspaceStatus.Loading => Color.Info,
+        PublishingWorkspaceStatus.Publishing => Color.Info,
+        PublishingWorkspaceStatus.Saving => Color.Info,
+        _ => Color.Default
+    };
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -7,6 +7,7 @@ using Honua.Admin.Services.DataConnections;
 using Honua.Admin.Services.DataConnections.Providers;
 using Honua.Admin.Services.Identity;
 using Honua.Admin.Services.LicenseWorkspace;
+using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.SpatialSql;
 using Honua.Admin.Services.SpecWorkspace;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -40,6 +41,11 @@ builder.Services.AddScoped<SpatialSqlPlaygroundState>();
 // Map annotation workspace (issue #8) ships as an in-memory admin UI slice until
 // saved-map and collaboration APIs are available from the server.
 builder.Services.AddScoped<AnnotationWorkspaceState>();
+
+// Service publishing workspace (issue #14) orchestrates existing admin control
+// plane APIs across connection discovery, publish intent, protocol state, and
+// deployment preflight.
+builder.Services.AddScoped<PublishingWorkspaceState>();
 
 // Admin client + auth wiring (ticket #28 — restored from PR #17 onto the post-#27 shell).
 builder.Services.AddSingleton<AdminAuthStateProvider>();

--- a/src/Honua.Admin/Services/Publishing/PublishingWorkspaceState.cs
+++ b/src/Honua.Admin/Services/Publishing/PublishingWorkspaceState.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.Admin;
+using Honua.Admin.Services.Admin;
+
+namespace Honua.Admin.Services.Publishing;
+
+public enum PublishingWorkspaceStatus
+{
+    Idle,
+    Loading,
+    Validating,
+    Publishing,
+    Saving,
+    Error
+}
+
+public sealed record PublishingValidationCheck(
+    string Key,
+    string Label,
+    bool Passed,
+    string Message);
+
+public sealed record PublishingEnvironmentState(
+    string Name,
+    string DesiredRevision,
+    string ActualRevision,
+    string DesiredProtocols,
+    string ActualProtocols,
+    string DriftStatus);
+
+public sealed class PublishingWorkspaceState
+{
+    private readonly IHonuaAdminClient _client;
+    private readonly HashSet<string> _desiredProtocols = new(StringComparer.OrdinalIgnoreCase);
+
+    public PublishingWorkspaceState(IHonuaAdminClient client)
+    {
+        _client = client;
+    }
+
+    public PublishingWorkspaceStatus Status { get; private set; } = PublishingWorkspaceStatus.Idle;
+
+    public string? LastError { get; private set; }
+
+    public IReadOnlyList<ConnectionSummary> Connections { get; private set; } = Array.Empty<ConnectionSummary>();
+
+    public IReadOnlyList<DiscoveredTable> Tables { get; private set; } = Array.Empty<DiscoveredTable>();
+
+    public IReadOnlyList<LayerSummary> Layers { get; private set; } = Array.Empty<LayerSummary>();
+
+    public IReadOnlyList<ServiceSummary> Services { get; private set; } = Array.Empty<ServiceSummary>();
+
+    public ServiceSettings? ServiceSettings { get; private set; }
+
+    public DeployPreflightResult? DeployPreflight { get; private set; }
+
+    public LayerSummary? LastPublishedLayer { get; private set; }
+
+    public string? SelectedConnectionId { get; private set; }
+
+    public string ServiceName { get; private set; } = "default";
+
+    public string DraftSchema { get; private set; } = "public";
+
+    public string DraftTable { get; private set; } = string.Empty;
+
+    public string DraftLayerName { get; private set; } = string.Empty;
+
+    public string? DraftDescription { get; private set; }
+
+    public string? DraftGeometryColumn { get; private set; } = "geom";
+
+    public string? DraftGeometryType { get; private set; }
+
+    public int? DraftSrid { get; private set; } = 4326;
+
+    public string? DraftPrimaryKey { get; private set; }
+
+    public bool DraftEnabled { get; private set; } = true;
+
+    public event Action? OnChanged;
+
+    public ConnectionSummary? SelectedConnection =>
+        Connections.FirstOrDefault(connection => string.Equals(connection.Id, SelectedConnectionId, StringComparison.OrdinalIgnoreCase));
+
+    public IReadOnlyList<string> DesiredProtocols => _desiredProtocols.Order(StringComparer.OrdinalIgnoreCase).ToArray();
+
+    public IReadOnlyList<string> AvailableProtocols =>
+        ServiceSettings?.AvailableProtocols.Count > 0
+            ? ServiceSettings.AvailableProtocols
+            : ["FeatureServer", "MapServer", "OgcFeatures", "OData", "Grpc"];
+
+    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed);
+
+    public IReadOnlyList<PublishingValidationCheck> ValidationChecks
+    {
+        get
+        {
+            var selectedConnection = SelectedConnection;
+            var tableSelected = !string.IsNullOrWhiteSpace(DraftTable);
+            return
+            [
+                new PublishingValidationCheck(
+                    "connection",
+                    "Connection",
+                    selectedConnection?.IsActive == true,
+                    selectedConnection is null
+                        ? "Select a data connection."
+                        : selectedConnection.IsActive
+                            ? $"{selectedConnection.Name} is active."
+                            : $"{selectedConnection.Name} is inactive."),
+                new PublishingValidationCheck(
+                    "health",
+                    "Health",
+                    string.Equals(selectedConnection?.HealthStatus, "Healthy", StringComparison.OrdinalIgnoreCase),
+                    selectedConnection is null
+                        ? "No connection selected."
+                        : $"{selectedConnection.HealthStatus} connection health."),
+                new PublishingValidationCheck(
+                    "table",
+                    "Table",
+                    tableSelected,
+                    tableSelected ? $"{DraftSchema}.{DraftTable} selected." : "Select a discovered table."),
+                new PublishingValidationCheck(
+                    "geometry",
+                    "Geometry",
+                    !tableSelected || !string.IsNullOrWhiteSpace(DraftGeometryColumn),
+                    string.IsNullOrWhiteSpace(DraftGeometryColumn) ? "Geometry column is missing." : $"{DraftGeometryColumn} geometry column."),
+                new PublishingValidationCheck(
+                    "service",
+                    "Service",
+                    !string.IsNullOrWhiteSpace(ServiceName),
+                    string.IsNullOrWhiteSpace(ServiceName) ? "Service name is required." : $"{ServiceName} service target."),
+                new PublishingValidationCheck(
+                    "protocols",
+                    "Protocols",
+                    _desiredProtocols.Count > 0,
+                    _desiredProtocols.Count > 0 ? string.Join(", ", DesiredProtocols) : "Enable at least one protocol."),
+                new PublishingValidationCheck(
+                    "deploy",
+                    "Preflight",
+                    DeployPreflight?.ReadyForCoordinatedDeploy == true,
+                    DeployPreflight?.Message ?? "Run deploy preflight.")
+            ];
+        }
+    }
+
+    public IReadOnlyList<PublishingEnvironmentState> EnvironmentStates
+    {
+        get
+        {
+            var desiredProtocols = string.Join(", ", DesiredProtocols);
+            var actualProtocols = string.Join(", ", ServiceSettings?.EnabledProtocols ?? Array.Empty<string>());
+            return
+            [
+                new PublishingEnvironmentState("dev", "service-intent", "service-intent", desiredProtocols, actualProtocols, ProtocolDriftLabel),
+                new PublishingEnvironmentState("staging", "service-intent", "awaiting promotion", desiredProtocols, "FeatureServer", "Promotion pending"),
+                new PublishingEnvironmentState("production", "service-intent", "stable", desiredProtocols, "FeatureServer, OgcFeatures", "Review required")
+            ];
+        }
+    }
+
+    public string ProtocolDriftLabel
+    {
+        get
+        {
+            var actual = new HashSet<string>(ServiceSettings?.EnabledProtocols ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            return actual.SetEquals(_desiredProtocols) ? "In sync" : "Drift";
+        }
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        Status = PublishingWorkspaceStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            Connections = await _client.ListConnectionsAsync(cancellationToken).ConfigureAwait(false);
+            Services = await _client.ListServicesAsync(cancellationToken).ConfigureAwait(false);
+            SelectedConnectionId = Connections.FirstOrDefault()?.Id;
+            ServiceName = Services.FirstOrDefault()?.ServiceName ?? "default";
+            await LoadServiceAsync(cancellationToken).ConfigureAwait(false);
+            await DiscoverTablesAsync(cancellationToken).ConfigureAwait(false);
+            await LoadLayersAsync(cancellationToken).ConfigureAwait(false);
+            await RunPreflightAsync(cancellationToken).ConfigureAwait(false);
+            Status = PublishingWorkspaceStatus.Idle;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Status = PublishingWorkspaceStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    public async Task SelectConnectionAsync(string connectionId, CancellationToken cancellationToken = default)
+    {
+        SelectedConnectionId = connectionId;
+        LastError = null;
+        Tables = Array.Empty<DiscoveredTable>();
+        Layers = Array.Empty<LayerSummary>();
+        await DiscoverTablesAsync(cancellationToken).ConfigureAwait(false);
+        await LoadLayersAsync(cancellationToken).ConfigureAwait(false);
+        Notify();
+    }
+
+    public void SetServiceName(string? serviceName)
+    {
+        ServiceName = string.IsNullOrWhiteSpace(serviceName) ? "default" : serviceName.Trim();
+        LastError = null;
+        Notify();
+    }
+
+    public void SetDraftLayerName(string? value)
+    {
+        DraftLayerName = value ?? string.Empty;
+        Notify();
+    }
+
+    public void SetDraftDescription(string? value)
+    {
+        DraftDescription = value;
+        Notify();
+    }
+
+    public void SetDraftEnabled(bool value)
+    {
+        DraftEnabled = value;
+        Notify();
+    }
+
+    public void ToggleProtocol(string protocol, bool enabled)
+    {
+        if (string.IsNullOrWhiteSpace(protocol))
+        {
+            return;
+        }
+
+        if (enabled)
+        {
+            _desiredProtocols.Add(protocol);
+        }
+        else
+        {
+            _desiredProtocols.Remove(protocol);
+        }
+        LastError = null;
+        Notify();
+    }
+
+    public void UseTable(DiscoveredTable table)
+    {
+        DraftSchema = table.Schema;
+        DraftTable = table.Table;
+        DraftLayerName = table.Table;
+        DraftGeometryColumn = table.GeometryColumn;
+        DraftGeometryType = table.GeometryType;
+        DraftSrid = table.Srid;
+        DraftPrimaryKey = table.Columns.FirstOrDefault(column => column.IsPrimaryKey)?.Name;
+        LastError = null;
+        Notify();
+    }
+
+    public async Task DiscoverTablesAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(SelectedConnectionId))
+        {
+            Tables = Array.Empty<DiscoveredTable>();
+            return;
+        }
+
+        Tables = await _client.DiscoverConnectionTablesAsync(SelectedConnectionId, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(DraftTable) && Tables.Count > 0)
+        {
+            UseTable(Tables[0]);
+        }
+    }
+
+    public async Task LoadServiceAsync(CancellationToken cancellationToken = default)
+    {
+        ServiceSettings = await _client.GetServiceSettingsAsync(ServiceName, cancellationToken).ConfigureAwait(false);
+        _desiredProtocols.Clear();
+        foreach (var protocol in ServiceSettings.EnabledProtocols)
+        {
+            _desiredProtocols.Add(protocol);
+        }
+    }
+
+    public async Task LoadLayersAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(SelectedConnectionId))
+        {
+            Layers = Array.Empty<LayerSummary>();
+            return;
+        }
+
+        Layers = await _client.ListLayersAsync(SelectedConnectionId, ServiceName, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RunPreflightAsync(CancellationToken cancellationToken = default)
+    {
+        DeployPreflight = await _client.GetDeployPreflightAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SaveProtocolsAsync(CancellationToken cancellationToken = default)
+    {
+        Status = PublishingWorkspaceStatus.Saving;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            ServiceSettings = await _client.UpdateServiceProtocolsAsync(
+                ServiceName,
+                new UpdateProtocolsRequest { EnabledProtocols = DesiredProtocols },
+                cancellationToken).ConfigureAwait(false);
+            Status = PublishingWorkspaceStatus.Idle;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Status = PublishingWorkspaceStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    public async Task<LayerSummary?> PublishAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(SelectedConnectionId))
+        {
+            LastError = "Select a connection before publishing.";
+            Notify();
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(DraftTable))
+        {
+            LastError = "Select a table before publishing.";
+            Notify();
+            return null;
+        }
+
+        Status = PublishingWorkspaceStatus.Publishing;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            LastPublishedLayer = await _client.PublishLayerAsync(
+                SelectedConnectionId,
+                new PublishLayerRequest
+                {
+                    Schema = DraftSchema,
+                    Table = DraftTable,
+                    LayerName = string.IsNullOrWhiteSpace(DraftLayerName) ? DraftTable : DraftLayerName,
+                    Description = DraftDescription,
+                    GeometryColumn = DraftGeometryColumn,
+                    GeometryType = DraftGeometryType,
+                    Srid = DraftSrid,
+                    PrimaryKey = DraftPrimaryKey,
+                    ServiceName = ServiceName,
+                    Enabled = DraftEnabled
+                },
+                cancellationToken).ConfigureAwait(false);
+            await LoadLayersAsync(cancellationToken).ConfigureAwait(false);
+            Status = PublishingWorkspaceStatus.Idle;
+            Notify();
+            return LastPublishedLayer;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Status = PublishingWorkspaceStatus.Error;
+            LastError = ex.Message;
+            Notify();
+            return null;
+        }
+    }
+
+    public async Task ToggleLayerAsync(LayerSummary layer, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(SelectedConnectionId))
+        {
+            return;
+        }
+
+        await _client.SetLayerEnabledAsync(
+            SelectedConnectionId,
+            layer.LayerId,
+            !layer.Enabled,
+            ServiceName,
+            cancellationToken).ConfigureAwait(false);
+        await LoadLayersAsync(cancellationToken).ConfigureAwait(false);
+        Notify();
+    }
+
+    private void Notify() => OnChanged?.Invoke();
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -20,6 +20,9 @@
     <MudNavLink Href="/operator/data-connections" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Storage">
         Data connections
     </MudNavLink>
+    <MudNavLink Href="/operator/publishing" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Publish">
+        Publishing
+    </MudNavLink>
 
     <MudNavGroup Title="Operations" Icon="@Icons.Material.Filled.Settings" Expanded="true">
         <MudNavLink Href="/connections" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Cable">

--- a/src/Honua.Admin/_Imports.razor
+++ b/src/Honua.Admin/_Imports.razor
@@ -26,6 +26,7 @@
 @using Honua.Admin.Services.Annotations
 @using Honua.Admin.Services.Identity
 @using Honua.Admin.Services.LicenseWorkspace
+@using Honua.Admin.Services.Publishing
 @using Honua.Admin.Services.SpatialSql
 @using Honua.Admin.Services.SpecWorkspace
 @using MudBlazor

--- a/src/Honua.Admin/wwwroot/css/publishing-workspace.css
+++ b/src/Honua.Admin/wwwroot/css/publishing-workspace.css
@@ -1,0 +1,149 @@
+.publishing-root {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 128px);
+    min-height: 560px;
+    gap: 8px;
+}
+
+.publishing-toolbar {
+    flex: 0 0 auto;
+}
+
+.publishing-grid {
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: minmax(260px, 0.85fr) minmax(360px, 1.15fr) minmax(360px, 1.1fr);
+    gap: 8px;
+    min-height: 0;
+}
+
+.publishing-pane {
+    min-width: 0;
+    min-height: 0;
+    overflow: auto;
+    border: 1px solid var(--mud-palette-divider, #d9dee3);
+    border-radius: 6px;
+    background: var(--mud-palette-surface, #ffffff);
+    padding: 12px;
+}
+
+.publishing-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.publishing-list-item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    border: 1px solid var(--mud-palette-divider, #d9dee3);
+    border-radius: 6px;
+    background: #ffffff;
+    color: #111827;
+    padding: 8px;
+    cursor: pointer;
+    text-align: left;
+}
+
+.publishing-list-item small {
+    color: #64748b;
+}
+
+.publishing-list-item-active {
+    border-color: #0f766e;
+    background: #eefaf7;
+}
+
+.publishing-section-heading {
+    margin-top: 16px;
+    margin-bottom: 8px;
+}
+
+.publishing-form-grid {
+    margin-top: 4px;
+}
+
+.publishing-protocols {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 4px 10px;
+}
+
+.publishing-validation {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.publishing-validation-row {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr);
+    gap: 8px;
+    align-items: start;
+    border: 1px solid var(--mud-palette-divider, #d9dee3);
+    border-radius: 6px;
+    padding: 8px;
+}
+
+.publishing-validation-row div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.publishing-validation-row span {
+    color: #64748b;
+    overflow-wrap: anywhere;
+}
+
+.publishing-layer-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.publishing-layer-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    gap: 8px;
+    align-items: center;
+    border: 1px solid var(--mud-palette-divider, #d9dee3);
+    border-radius: 6px;
+    padding: 8px;
+}
+
+.publishing-layer-row div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.publishing-layer-row span {
+    color: #64748b;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 1180px) {
+    .publishing-root {
+        height: auto;
+    }
+
+    .publishing-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .publishing-toolbar .mud-stack-row,
+    .publishing-layer-row {
+        grid-template-columns: 1fr;
+    }
+
+    .publishing-protocols {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -13,6 +13,7 @@
     <link href="css/license-workspace.css" rel="stylesheet" />
     <link href="css/spatial-sql.css" rel="stylesheet" />
     <link href="css/annotation-workspace.css" rel="stylesheet" />
+    <link href="css/publishing-workspace.css" rel="stylesheet" />
 </head>
 
 <body>

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -32,6 +32,16 @@ public sealed class NavMenuTests
     }
 
     [Fact]
+    public void NavMenu_registers_publishing_workspace_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/publishing", contents, System.StringComparison.Ordinal);
+        Assert.Contains("Publishing", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NavMenu_uses_a_single_MudNavMenu_so_sql_page_lives_in_the_shared_shell()
     {
         var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
@@ -46,12 +56,15 @@ public sealed class NavMenuTests
         var operatorSpec = contents.IndexOf("/operator/spec", System.StringComparison.Ordinal);
         var operatorSql = contents.IndexOf("/operator/sql", System.StringComparison.Ordinal);
         var operatorAnnotations = contents.IndexOf("/operator/annotations", System.StringComparison.Ordinal);
+        var operatorPublishing = contents.IndexOf("/operator/publishing", System.StringComparison.Ordinal);
         var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
 
         Assert.True(operatorSpec > 0);
         Assert.True(operatorSql > 0);
         Assert.True(operatorAnnotations > 0);
+        Assert.True(operatorPublishing > 0);
         Assert.True(operatorSql < menuClose);
         Assert.True(operatorAnnotations < menuClose);
+        Assert.True(operatorPublishing < menuClose);
     }
 }

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -10,6 +10,7 @@ using Honua.Admin.Models.Admin;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
@@ -119,6 +120,23 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Field review annotations");
             cut.Markup.MarkupMatchesContaining("Export");
             cut.Markup.MarkupMatchesContaining("Guest comments");
+        });
+    }
+
+    [Fact]
+    public void PublishingWorkspace_RendersConnectionsIntentAndEnvironmentState()
+    {
+        Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
+        Services.AddScoped<PublishingWorkspaceState>();
+
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.PublishingWorkspace>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Publishing workspace");
+            cut.Markup.MarkupMatchesContaining("primary-postgis");
+            cut.Markup.MarkupMatchesContaining("Environment");
+            cut.Markup.MarkupMatchesContaining("Parcels");
         });
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -11,6 +11,7 @@ using Honua.Admin.Models.Admin;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.Publishing;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
@@ -34,6 +35,7 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<IAdminTelemetry, NullAdminTelemetry>();
         Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
         Services.AddScoped<AnnotationWorkspaceState>();
+        Services.AddScoped<PublishingWorkspaceState>();
     }
 
     public static IEnumerable<object[]> TopWorkflows()
@@ -93,6 +95,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Operator.Annotations),
             "Waikiki field review",
             new[] { "[aria-label='Annotation workspace toolbar']", "[aria-label='Annotation layers']" },
+        ];
+        yield return
+        [
+            "Publishing",
+            typeof(Honua.Admin.Pages.Operator.PublishingWorkspace),
+            "primary-postgis",
+            new[] { "[aria-label='Publishing workspace toolbar']", "[aria-label='Publishing validation checks']" },
         ];
     }
 

--- a/tests/Honua.Admin.Tests/PublishingWorkspaceStateTests.cs
+++ b/tests/Honua.Admin.Tests/PublishingWorkspaceStateTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.Admin;
+using Honua.Admin.Services.Admin;
+using Honua.Admin.Services.Publishing;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class PublishingWorkspaceStateTests
+{
+    [Fact]
+    public async Task InitializeAsync_loads_connection_service_layers_tables_and_preflight()
+    {
+        var state = new PublishingWorkspaceState(new StubHonuaAdminClient());
+
+        await state.InitializeAsync();
+
+        Assert.Equal(PublishingWorkspaceStatus.Idle, state.Status);
+        Assert.NotEmpty(state.Connections);
+        Assert.NotEmpty(state.Services);
+        Assert.NotEmpty(state.Tables);
+        Assert.NotEmpty(state.Layers);
+        Assert.NotNull(state.DeployPreflight);
+        Assert.All(state.ValidationChecks, check => Assert.True(check.Passed, check.Message));
+    }
+
+    [Fact]
+    public async Task ToggleProtocol_and_SaveProtocolsAsync_persist_desired_protocols()
+    {
+        var client = new RecordingPublishingClient();
+        var state = new PublishingWorkspaceState(client);
+        await state.InitializeAsync();
+
+        state.ToggleProtocol("OData", enabled: true);
+        await state.SaveProtocolsAsync();
+
+        Assert.Contains("OData", client.LastProtocols);
+        Assert.Equal("In sync", state.ProtocolDriftLabel);
+    }
+
+    [Fact]
+    public async Task PublishAsync_maps_draft_to_publish_request()
+    {
+        var client = new RecordingPublishingClient();
+        var state = new PublishingWorkspaceState(client);
+        await state.InitializeAsync();
+        state.UseTable(new DiscoveredTable
+        {
+            Schema = "gis",
+            Table = "trails",
+            GeometryColumn = "shape",
+            GeometryType = "LineString",
+            Srid = 4326
+        });
+        state.SetDraftLayerName("Trails");
+        state.SetDraftDescription("Trail network");
+
+        var layer = await state.PublishAsync();
+
+        Assert.NotNull(layer);
+        Assert.NotNull(client.LastPublishRequest);
+        Assert.Equal("gis", client.LastPublishRequest!.Schema);
+        Assert.Equal("trails", client.LastPublishRequest.Table);
+        Assert.Equal("Trails", client.LastPublishRequest.LayerName);
+        Assert.Equal("shape", client.LastPublishRequest.GeometryColumn);
+        Assert.Equal("default", client.LastPublishRequest.ServiceName);
+    }
+
+    [Fact]
+    public async Task PublishAsync_without_table_surfaces_validation_error()
+    {
+        var state = new PublishingWorkspaceState(new EmptyTableClient());
+        await state.InitializeAsync();
+
+        var layer = await state.PublishAsync();
+
+        Assert.Null(layer);
+        Assert.Contains("Select a table", state.LastError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class RecordingPublishingClient : StubHonuaAdminClient
+    {
+        public PublishLayerRequest? LastPublishRequest { get; private set; }
+        public IReadOnlyList<string> LastProtocols { get; private set; } = Array.Empty<string>();
+
+        public override Task<LayerSummary> PublishLayerAsync(string connectionId, PublishLayerRequest request, CancellationToken cancellationToken)
+        {
+            LastPublishRequest = request;
+            return Task.FromResult(new LayerSummary
+            {
+                LayerId = 202,
+                LayerName = request.LayerName,
+                Schema = request.Schema,
+                Table = request.Table,
+                GeometryType = request.GeometryType ?? string.Empty,
+                Srid = request.Srid ?? 4326,
+                Enabled = request.Enabled,
+                ServiceName = request.ServiceName ?? "default"
+            });
+        }
+
+        public override Task<ServiceSettings> UpdateServiceProtocolsAsync(string serviceName, UpdateProtocolsRequest request, CancellationToken cancellationToken)
+        {
+            LastProtocols = request.EnabledProtocols;
+            return Task.FromResult(ServiceSettings with { EnabledProtocols = request.EnabledProtocols });
+        }
+    }
+
+    private sealed class EmptyTableClient : StubHonuaAdminClient
+    {
+        public override Task<IReadOnlyList<DiscoveredTable>> DiscoverConnectionTablesAsync(string connectionId, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<DiscoveredTable>>(Array.Empty<DiscoveredTable>());
+    }
+}


### PR DESCRIPTION
## Summary

- adds `/operator/publishing` as a guided service-publishing workspace over existing admin control-plane APIs
- introduces `PublishingWorkspaceState` for connection selection, table discovery, publish intent, protocol desired state, deploy preflight, environment comparison, and layer toggles
- wires navigation, DI, static CSS, docs, quality gates, render smoke coverage, and state unit tests

## Scope

This is the first admin workspace slice for #14. It does not close the full issue yet; connection creation is still delegated to the existing data-connections workspace, and durable GitOps desired-state reconciliation / environment promotion need server contracts before they can be made real.

## Validation

- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --filter "FullyQualifiedName~PublishingWorkspaceStateTests|FullyQualifiedName~AdminPageRenderTests.PublishingWorkspace_RendersConnectionsIntentAndEnvironmentState" --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --filter "FullyQualifiedName~AdminQualityGateTests|FullyQualifiedName~NavMenuTests" --logger "console;verbosity=minimal"`
- `dotnet test Honua.Admin.sln --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1`
- `dotnet build Honua.Admin.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic`
- `dotnet publish src/Honua.Admin/Honua.Admin.csproj --configuration Release --output ./dist --no-restore`
- local publish budget check: 33,436,794 / 62,914,560 total bytes; 28,528,817 / 47,185,920 framework bytes; 14,005,424 / 25,165,824 wasm bytes

Related to #14
