### PR TITLE
feat: add deploy fleet orchestration workspace

### DIFF
--- a/src/Honua.Admin/Pages/Admin/DeployControlPage.razor
+++ b/src/Honua.Admin/Pages/Admin/DeployControlPage.razor
@@ -111,7 +111,7 @@
                 </MudItem>
             </MudGrid>
             <MudStack Row="true" Spacing="1" Class="mt-3">
-                <MudButton Variant="Variant.Filled" Color="Color.Warning" StartIcon="@Icons.Material.Filled.RocketLaunch" OnClick="CreateSelectedOperationsAsync" Disabled="@(IsBusy || !State.HasSelectedTargets)">
+                <MudButton Variant="Variant.Filled" Color="Color.Warning" StartIcon="@Icons.Material.Filled.RocketLaunch" OnClick="CreateSelectedOperationsAsync" Disabled="@(IsBusy || !State.HasCreatableTargets)">
                     Create operations
                 </MudButton>
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Send" OnClick="SubmitSelectedAsync" Disabled="@(IsBusy || !State.HasSubmittableOperations)">

--- a/src/Honua.Admin/Pages/Admin/DeployControlPage.razor
+++ b/src/Honua.Admin/Pages/Admin/DeployControlPage.razor
@@ -1,193 +1,446 @@
 @page "/deploy"
+@using Microsoft.Extensions.DependencyInjection
 @using MudBlazor
 @inherits Honua.Admin.Shared.AdminPageBase
+@implements IDisposable
 
 <PageTitle>Deploy control - Honua Server Admin</PageTitle>
 
-<MudContainer MaxWidth="MaxWidth.Large" Class="mt-4">
-    <MudText Typo="Typo.h4" Class="mb-4">
-        <MudIcon Icon="@Icons.Material.Filled.RocketLaunch" Class="mr-2" />
-        Deploy control
-    </MudText>
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="mt-4">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-4">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.h4">
+                <MudIcon Icon="@Icons.Material.Filled.RocketLaunch" Class="mr-2" />
+                Deploy control
+            </MudText>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@StatusColor(State.Status)">
+                @State.Status
+            </MudChip>
+        </MudStack>
+        <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="RefreshAsync" Disabled="@IsBusy">
+            Refresh
+        </MudButton>
+    </MudStack>
 
     <ErrorBanner Message="@ErrorMessage" />
+    @if (!string.IsNullOrWhiteSpace(State.LastError))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Dense="true" Class="mb-4">
+            @State.LastError
+        </MudAlert>
+    }
 
-    <MudTabs Elevation="1" Rounded="true" PanelClass="pa-4">
-        <MudTabPanel Text="Preflight" Icon="@Icons.Material.Filled.Checklist">
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FlightTakeoff" OnClick="RunPreflightAsync" Disabled="IsLoading">
-                Run preflight
-            </MudButton>
-            @if (_preflight is not null)
-            {
-                <MudAlert Severity="@(_preflight.ReadyForCoordinatedDeploy ? Severity.Success : Severity.Warning)" Class="mt-4">
-                    @_preflight.Message
-                </MudAlert>
-                <MudSimpleTable Dense="true" Hover="true" Class="mt-3" aria-label="Deploy preflight details">
-                    <tbody>
-                        <tr><td>Status</td><td>@_preflight.Status</td></tr>
-                        <tr><td>Environment</td><td>@_preflight.Environment</td></tr>
-                        <tr><td>Deployment mode</td><td>@_preflight.DeploymentMode</td></tr>
-                        <tr><td>Instance</td><td>@_preflight.InstanceName</td></tr>
-                    </tbody>
-                </MudSimpleTable>
-            }
-        </MudTabPanel>
+    <MudGrid Class="mb-4">
+        <MudItem xs="12" md="4">
+            <MudCard Elevation="1">
+                <MudCardContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText Typo="Typo.h6">Preflight</MudText>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.HealthAndSafety" OnClick="RunPreflightAsync" Disabled="@IsBusy">
+                            Run preflight
+                        </MudButton>
+                    </MudStack>
+                    @if (State.Preflight is null)
+                    {
+                        <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                            No deploy preflight loaded.
+                        </MudAlert>
+                    }
+                    else
+                    {
+                        <MudAlert Severity="@(State.Preflight.ReadyForCoordinatedDeploy ? Severity.Success : Severity.Warning)" Dense="true" Class="mt-3">
+                            @State.Preflight.Message
+                        </MudAlert>
+                        <MudSimpleTable Dense="true" Hover="true" Class="mt-3" aria-label="Deploy preflight details">
+                            <tbody>
+                                <tr><td>Status</td><td>@State.Preflight.Status</td></tr>
+                                <tr><td>Environment</td><td>@(State.Preflight.Environment ?? "unknown")</td></tr>
+                                <tr><td>Deployment mode</td><td>@(State.Preflight.DeploymentMode ?? "unknown")</td></tr>
+                                <tr><td>Instance</td><td>@(State.Preflight.InstanceName ?? "unknown")</td></tr>
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
 
-        <MudTabPanel Text="Plan" Icon="@Icons.Material.Filled.ListAlt">
+        <MudItem xs="12" md="8">
+            <MudCard Elevation="1">
+                <MudCardContent>
+                    <MudText Typo="Typo.h6">Target inventory</MudText>
+                    <MudGrid Class="mt-1">
+                        <MudItem xs="12" sm="4">
+                            <MudTextField T="string" @bind-Value="_draftTargetId" Label="Target ID" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Deploy target ID" />
+                        </MudItem>
+                        <MudItem xs="12" sm="4">
+                            <MudTextField T="string" @bind-Value="_draftDesiredRevision" Label="Desired revision" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Deploy desired revision" />
+                        </MudItem>
+                        <MudItem xs="12" sm="4">
+                            <MudTextField T="string" @bind-Value="_draftCurrentRevision" Label="Current revision" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Deploy current revision" />
+                        </MudItem>
+                    </MudGrid>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mt-3">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" OnClick="AddTarget" Disabled="@IsBusy">
+                            Add target
+                        </MudButton>
+                        <MudButton Variant="Variant.Text" OnClick="@(() => State.SetAllSelected(true))" Disabled="@IsBusy">
+                            Select all
+                        </MudButton>
+                        <MudButton Variant="Variant.Text" OnClick="@(() => State.SetAllSelected(false))" Disabled="@IsBusy">
+                            Clear
+                        </MudButton>
+                    </MudStack>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+    </MudGrid>
+
+    <MudCard Elevation="1" Class="mb-4">
+        <MudCardContent>
             <MudGrid>
-                <MudItem xs="12" sm="4">
-                    <MudTextField @bind-Value="_targetId" Label="Target ID" Variant="Variant.Outlined" />
+                <MudItem xs="12" md="7">
+                    <MudTextField T="string" @bind-Value="_operationReason" Label="Reason" Variant="Variant.Outlined" Margin="Margin.Dense" aria-label="Deploy operation reason" />
                 </MudItem>
-                <MudItem xs="12" sm="4">
-                    <MudTextField @bind-Value="_currentRevision" Label="Current revision" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12" sm="4">
-                    <MudTextField @bind-Value="_desiredRevision" Label="Desired revision" Variant="Variant.Outlined" />
+                <MudItem xs="12" md="5">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudCheckBox T="bool" @bind-Value="_submitImmediately" Label="Submit immediately" Color="Color.Primary" aria-label="Submit deploy operations immediately" />
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.PlaylistAdd" OnClick="PlanSelectedAsync" Disabled="@(IsBusy || !State.HasSelectedTargets)">
+                            Plan selected
+                        </MudButton>
+                    </MudStack>
                 </MudItem>
             </MudGrid>
             <MudStack Row="true" Spacing="1" Class="mt-3">
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.PlaylistAdd" OnClick="PlanAsync" Disabled="IsLoading">
-                    Create plan
+                <MudButton Variant="Variant.Filled" Color="Color.Warning" StartIcon="@Icons.Material.Filled.RocketLaunch" OnClick="CreateSelectedOperationsAsync" Disabled="@(IsBusy || !State.HasSelectedTargets)">
+                    Create operations
                 </MudButton>
-                <MudButton Variant="Variant.Filled" Color="Color.Warning" StartIcon="@Icons.Material.Filled.RocketLaunch" OnClick="CreateOperationAsync" Disabled="IsLoading">
-                    Create operation
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Send" OnClick="SubmitSelectedAsync" Disabled="@(IsBusy || !State.HasSubmittableOperations)">
+                    Submit selected
+                </MudButton>
+                <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="RefreshSelectedOperationsAsync" Disabled="@(IsBusy || !State.HasRefreshableOperations)">
+                    Refresh status
+                </MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Error" StartIcon="@Icons.Material.Filled.Undo" OnClick="RollbackSelectedAsync" Disabled="@(IsBusy || !State.HasRollbackOperations)">
+                    Rollback selected
                 </MudButton>
             </MudStack>
-            @if (_plan is not null)
-            {
-                <MudAlert Severity="@(_plan.ReadyToSubmit ? Severity.Success : Severity.Warning)" Class="mt-4">
-                    Plan for @_plan.Target.TargetName (@_plan.Target.TargetId) generated.
-                </MudAlert>
-                @foreach (var warning in _plan.Warnings)
-                {
-                    <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-1">@warning</MudAlert>
-                }
-                @foreach (var blocker in _plan.BlockingReasons)
-                {
-                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-1">@blocker</MudAlert>
-                }
-            }
-        </MudTabPanel>
+        </MudCardContent>
+    </MudCard>
 
-        <MudTabPanel Text="Operations" Icon="@Icons.Material.Filled.History">
-            <MudGrid>
-                <MudItem xs="12" sm="8">
-                    <MudTextField @bind-Value="_operationId" Label="Operation ID" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12" sm="4">
-                    <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="RefreshOperationAsync" Disabled="IsLoading">
-                        Refresh
-                    </MudButton>
-                </MudItem>
-            </MudGrid>
-            <MudStack Row="true" Spacing="1" Class="mt-3">
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Send" OnClick="SubmitAsync" Disabled="IsLoading || string.IsNullOrWhiteSpace(_operationId)">
-                    Submit
-                </MudButton>
-                <MudButton Variant="Variant.Outlined" Color="Color.Error" StartIcon="@Icons.Material.Filled.Undo" OnClick="RollbackAsync" Disabled="IsLoading || string.IsNullOrWhiteSpace(_operationId)">
-                    Rollback
-                </MudButton>
-            </MudStack>
-            @if (_operation is not null)
-            {
-                <MudSimpleTable Dense="true" Hover="true" Class="mt-4" aria-label="Deploy operation details">
-                    <tbody>
-                        <tr><td>Operation</td><td>@_operation.OperationId</td></tr>
-                        <tr><td>Status</td><td>@_operation.Status</td></tr>
-                        <tr><td>Priority</td><td>@_operation.Priority</td></tr>
-                        <tr><td>Target</td><td>@_operation.Target?.TargetName</td></tr>
-                        <tr><td>Phase</td><td>@_operation.CurrentPhase</td></tr>
-                    </tbody>
-                </MudSimpleTable>
-                @if (!string.IsNullOrWhiteSpace(_operation.ErrorMessage))
-                {
-                    <MudAlert Severity="Severity.Error" Class="mt-3">@_operation.ErrorMessage</MudAlert>
-                }
-            }
-        </MudTabPanel>
-    </MudTabs>
+    @if (State.Targets.Count == 0)
+    {
+        <EmptyState Icon="@Icons.Material.Filled.RocketLaunch" Title="No deploy targets" Description="Add a target ID to begin planning." />
+    }
+    else
+    {
+        <MudTable Items="State.Targets" Dense="true" Hover="true" aria-label="Deploy fleet targets">
+            <HeaderContent>
+                <MudTh></MudTh>
+                <MudTh>Target</MudTh>
+                <MudTh>Revision</MudTh>
+                <MudTh>Plan</MudTh>
+                <MudTh>Operation</MudTh>
+                <MudTh>Rollout</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>
+                    <MudCheckBox T="bool"
+                                 Value="@context.Selected"
+                                 ValueChanged="@((bool selected) => SetSelected(context, selected))"
+                                 Color="Color.Primary"
+                                 aria-label="@($"Select deploy target {context.TargetId}")" />
+                </MudTd>
+                <MudTd>
+                    <MudText Typo="Typo.subtitle2">@context.DisplayName</MudText>
+                    <MudText Typo="Typo.caption">@context.TargetId</MudText>
+                    <MudStack Row="true" Spacing="1" Class="mt-1">
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@context.TargetKind</MudChip>
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@context.Environment</MudChip>
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@context.Backend</MudChip>
+                    </MudStack>
+                </MudTd>
+                <MudTd>
+                    <MudText Typo="Typo.body2">@RevisionText(context)</MudText>
+                    @if (!string.IsNullOrWhiteSpace(context.ResolvedTarget?.ArtifactReference))
+                    {
+                        <MudText Typo="Typo.caption">@context.ResolvedTarget.ArtifactReference</MudText>
+                    }
+                </MudTd>
+                <MudTd>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="@PlanColor(context)">
+                        @context.PlanState
+                    </MudChip>
+                    @foreach (var warning in context.Plan?.Warnings ?? Array.Empty<string>())
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Warning">@warning</MudText>
+                    }
+                    @foreach (var blocker in context.Plan?.BlockingReasons ?? Array.Empty<string>())
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Error">@blocker</MudText>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(context.LastError))
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Error">@context.LastError</MudText>
+                    }
+                </MudTd>
+                <MudTd>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@OperationColor(context.Operation?.Status)">
+                        @context.OperationState
+                    </MudChip>
+                    @if (!string.IsNullOrWhiteSpace(context.Operation?.OperationId))
+                    {
+                        <MudText Typo="Typo.caption">@context.Operation.OperationId</MudText>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(context.Operation?.CurrentPhase))
+                    {
+                        <MudText Typo="Typo.caption">@context.Operation.CurrentPhase</MudText>
+                    }
+                </MudTd>
+                <MudTd>
+                    <MudText Typo="Typo.body2">@(context.Operation?.ObservedState ?? "No observed state")</MudText>
+                    @if (!string.IsNullOrWhiteSpace(context.Operation?.ProviderOperationId))
+                    {
+                        <MudText Typo="Typo.caption">@context.Operation.ProviderOperationId</MudText>
+                    }
+                    <MudText Typo="Typo.caption">@context.LastAction</MudText>
+                    @if (context.LastUpdated is not null)
+                    {
+                        <MudText Typo="Typo.caption">@context.LastUpdated.Value.ToString("u")</MudText>
+                    }
+                </MudTd>
+                <MudTd>
+                    <MudStack Row="true" Spacing="1">
+                        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => PlanTargetAsync(context))" Disabled="@IsBusy">
+                            Plan
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => CreateOperationAsync(context))" Disabled="@(IsBusy || !context.CanCreateOperation)">
+                            Create
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => SubmitOperationAsync(context))" Disabled="@(IsBusy || !context.CanSubmit)">
+                            Submit
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => RefreshOperationAsync(context))" Disabled="@(IsBusy || !context.CanRefresh)">
+                            Status
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Error" OnClick="@(() => RollbackOperationAsync(context))" Disabled="@(IsBusy || !context.CanRollback)">
+                            Rollback
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Default" OnClick="@(() => State.RemoveTarget(context))" Disabled="@IsBusy">
+                            Remove
+                        </MudButton>
+                    </MudStack>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
 </MudContainer>
 
 @code {
-    private DeployPreflightResult? _preflight;
-    private DeployPlan? _plan;
-    private DeployOperation? _operation;
-    private string _targetId = "honua-server";
-    private string? _currentRevision;
-    private string _desiredRevision = "latest";
-    private string? _operationId;
+    [Inject] private IServiceProvider Services { get; set; } = null!;
 
-    protected override void OnInitialized()
+    private DeployOrchestrationState State { get; set; } = null!;
+    private string _draftTargetId = "honua-server";
+    private string _draftDesiredRevision = "latest";
+    private string? _draftCurrentRevision;
+    private string? _operationReason = "Operator coordinated deploy";
+    private string? _operationId = string.Empty;
+    private bool _submitImmediately;
+
+    protected override async Task OnInitializedAsync()
     {
+        State = Services.GetService<DeployOrchestrationState>() ?? new DeployOrchestrationState(AdminClient);
+        State.OnChanged += StateChanged;
         Telemetry.PageNavigated("/deploy", principalId: null);
+        await ExecuteAsync(() => State.InitializeAsync(CancellationToken.None));
     }
 
-    private async Task RunPreflightAsync()
+    public void Dispose()
     {
-        await ExecuteAsync(async () =>
+        if (State is not null)
         {
-            _preflight = await AdminClient.GetDeployPreflightAsync(CancellationToken.None);
-        });
+            State.OnChanged -= StateChanged;
+        }
     }
 
-    private async Task PlanAsync()
+    private bool IsBusy => IsLoading || State.Status is DeployOrchestrationStatus.Loading
+        or DeployOrchestrationStatus.Planning
+        or DeployOrchestrationStatus.Creating
+        or DeployOrchestrationStatus.Submitting
+        or DeployOrchestrationStatus.Refreshing
+        or DeployOrchestrationStatus.RollingBack;
+
+    private Task RefreshAsync() => ExecuteAsync(() => State.InitializeAsync(CancellationToken.None));
+
+    private Task RunPreflightAsync() => RefreshAsync();
+
+    private void AddTarget()
     {
-        await ExecuteAsync(async () =>
+        if (State.AddOrUpdateTarget(_draftTargetId, _draftDesiredRevision, _draftCurrentRevision))
         {
-            _plan = await AdminClient.PlanDeployAsync(BuildPlanRequest(), CancellationToken.None);
-        });
+            _draftCurrentRevision = null;
+        }
     }
 
-    private async Task CreateOperationAsync()
+    private void SetSelected(DeployFleetTarget target, bool selected)
     {
-        await ExecuteAsync(async () =>
-        {
-            _operation = await AdminClient.CreateDeployOperationAsync(new CreateDeployOperationRequest
-            {
-                TargetId = _targetId,
-                CurrentRevision = _currentRevision,
-                DesiredRevision = _desiredRevision,
-                Reason = "Created from Honua admin UI",
-                SubmitImmediately = false,
-            }, CancellationToken.None);
-            _operationId = _operation.OperationId;
-            Snackbar.Add($"Deploy operation {_operation.OperationId} created.", Severity.Success);
-        });
+        target.Selected = selected;
     }
 
-    private async Task RefreshOperationAsync()
+    private async Task PlanSelectedAsync()
     {
-        if (string.IsNullOrWhiteSpace(_operationId)) return;
-        await ExecuteAsync(async () =>
+        await ExecuteAsync(() => State.PlanSelectedAsync(CancellationToken.None));
+        ShowBatchResult("Deploy plans generated.");
+    }
+
+    private async Task CreateSelectedOperationsAsync()
+    {
+        await ExecuteAsync(() => State.CreateOperationsForSelectedAsync(_operationReason, _submitImmediately, CancellationToken.None));
+        ShowBatchResult("Deploy operations created.");
+    }
+
+    private async Task SubmitSelectedAsync()
+    {
+        foreach (var target in State.SelectedTargets.Where(target => target.Operation is not null))
         {
-            _operation = await AdminClient.GetDeployOperationAsync(_operationId, CancellationToken.None);
-        });
+            Telemetry.DestructiveAction("submit-deploy", target.Operation!.OperationId, principalId: null);
+        }
+
+        await ExecuteAsync(() => State.SubmitSelectedAsync(_operationReason, CancellationToken.None));
+        ShowBatchResult("Deploy operations submitted.");
+    }
+
+    private async Task RefreshSelectedOperationsAsync()
+    {
+        await ExecuteAsync(() => State.RefreshSelectedAsync(CancellationToken.None));
+        ShowBatchResult("Deploy operation status refreshed.");
+    }
+
+    private async Task RollbackSelectedAsync()
+    {
+        foreach (var target in State.SelectedTargets.Where(target => target.Operation is not null))
+        {
+            Telemetry.DestructiveAction("rollback-deploy", target.Operation!.OperationId, principalId: null);
+        }
+
+        await ExecuteAsync(() => State.RollbackSelectedAsync(_operationReason, CancellationToken.None));
+        ShowBatchResult("Rollback requested.");
+    }
+
+    private async Task PlanTargetAsync(DeployFleetTarget target)
+    {
+        await ExecuteAsync(() => State.PlanTargetAsync(target, CancellationToken.None));
+        ShowBatchResult($"Plan generated for {target.TargetId}.");
+    }
+
+    private async Task CreateOperationAsync(DeployFleetTarget target)
+    {
+        await ExecuteAsync(() => State.CreateOperationAsync(target, _operationReason, _submitImmediately, CancellationToken.None));
+        ShowBatchResult($"Deploy operation created for {target.TargetId}.");
+    }
+
+    private async Task SubmitOperationAsync(DeployFleetTarget target)
+    {
+        if (target.Operation is not null)
+        {
+            Telemetry.DestructiveAction("submit-deploy", target.Operation.OperationId, principalId: null);
+        }
+
+        await ExecuteAsync(() => State.SubmitOperationAsync(target, _operationReason, CancellationToken.None));
+        ShowBatchResult($"Deploy operation submitted for {target.TargetId}.");
+    }
+
+    private async Task RefreshOperationAsync(DeployFleetTarget target)
+    {
+        await ExecuteAsync(() => State.RefreshOperationAsync(target, CancellationToken.None));
+        ShowBatchResult($"Deploy status refreshed for {target.TargetId}.");
+    }
+
+    private async Task RollbackOperationAsync(DeployFleetTarget target)
+    {
+        if (target.Operation is not null)
+        {
+            Telemetry.DestructiveAction("rollback-deploy", target.Operation.OperationId, principalId: null);
+        }
+
+        await ExecuteAsync(() => State.RollbackOperationAsync(target, _operationReason, CancellationToken.None));
+        ShowBatchResult($"Rollback requested for {target.TargetId}.");
     }
 
     private async Task SubmitAsync()
     {
         if (string.IsNullOrWhiteSpace(_operationId)) return;
+        Telemetry.DestructiveAction("submit-deploy", _operationId, principalId: null);
         await ExecuteAsync(async () =>
         {
-            Telemetry.DestructiveAction("submit-deploy", _operationId, principalId: null);
-            _operation = await AdminClient.SubmitDeployOperationAsync(_operationId, new SubmitDeployOperationRequest { Reason = "Submitted from Honua admin UI" }, CancellationToken.None);
+            await AdminClient.SubmitDeployOperationAsync(
+                _operationId,
+                new SubmitDeployOperationRequest { Reason = "Submitted from Honua admin UI" },
+                CancellationToken.None);
         });
     }
 
     private async Task RollbackAsync()
     {
         if (string.IsNullOrWhiteSpace(_operationId)) return;
+        Telemetry.DestructiveAction("rollback-deploy", _operationId, principalId: null);
         await ExecuteAsync(async () =>
         {
-            Telemetry.DestructiveAction("rollback-deploy", _operationId, principalId: null);
-            _operation = await AdminClient.RollbackDeployOperationAsync(_operationId, new RollbackDeployOperationRequest { Reason = "Rollback requested from Honua admin UI" }, CancellationToken.None);
+            await AdminClient.RollbackDeployOperationAsync(
+                _operationId,
+                new RollbackDeployOperationRequest { Reason = "Rollback requested from Honua admin UI" },
+                CancellationToken.None);
         });
     }
 
-    private DeployPlanRequest BuildPlanRequest() => new()
+    private void ShowBatchResult(string successMessage)
     {
-        TargetId = _targetId,
-        CurrentRevision = _currentRevision,
-        DesiredRevision = _desiredRevision,
+        if (State.LastError is null)
+        {
+            Snackbar.Add(successMessage, Severity.Success);
+        }
+        else
+        {
+            Snackbar.Add(State.LastError, Severity.Warning);
+        }
+    }
+
+    private void StateChanged() => InvokeAsync(StateHasChanged);
+
+    private static string RevisionText(DeployFleetTarget target)
+        => string.IsNullOrWhiteSpace(target.CurrentRevision)
+            ? target.DesiredRevision
+            : $"{target.CurrentRevision} -> {target.DesiredRevision}";
+
+    private static Color StatusColor(DeployOrchestrationStatus status) => status switch
+    {
+        DeployOrchestrationStatus.Error => Color.Error,
+        DeployOrchestrationStatus.Loading => Color.Info,
+        DeployOrchestrationStatus.Planning => Color.Info,
+        DeployOrchestrationStatus.Creating => Color.Info,
+        DeployOrchestrationStatus.Submitting => Color.Info,
+        DeployOrchestrationStatus.Refreshing => Color.Info,
+        DeployOrchestrationStatus.RollingBack => Color.Warning,
+        _ => Color.Default
+    };
+
+    private static Color PlanColor(DeployFleetTarget target)
+    {
+        if (target.LastError is not null) return Color.Error;
+        if (target.Plan is null) return Color.Default;
+        if (target.Plan.BlockingReasons.Count > 0) return Color.Error;
+        if (target.Plan.RequiresApproval) return Color.Warning;
+        return target.Plan.ReadyToSubmit ? Color.Success : Color.Warning;
+    }
+
+    private static Color OperationColor(string? status) => status?.ToLowerInvariant() switch
+    {
+        "succeeded" => Color.Success,
+        "submitted" => Color.Info,
+        "reconciling" => Color.Info,
+        "rollbackrequested" => Color.Warning,
+        "failed" => Color.Error,
+        "cancelled" => Color.Error,
+        _ => Color.Default
     };
 }

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -53,6 +53,7 @@ builder.Services.AddTransient<AdminAuthHandler>();
 builder.Services.AddTransient<GlobalErrorHandler>();
 builder.Services.AddScoped<IAdminTelemetry, LoggingAdminTelemetry>();
 builder.Services.AddScoped<IAdminRealtimeConnection, AdminRealtimeConnection>();
+builder.Services.AddScoped<DeployOrchestrationState>();
 
 // While the real honua-server is reachable the typed HttpClient routes through the
 // auth + global-error handlers. Until then (default `appsettings.json` ships no

--- a/src/Honua.Admin/Services/Admin/DeployOrchestrationState.cs
+++ b/src/Honua.Admin/Services/Admin/DeployOrchestrationState.cs
@@ -1,0 +1,467 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.Admin;
+
+namespace Honua.Admin.Services.Admin;
+
+public enum DeployOrchestrationStatus
+{
+    Idle,
+    Loading,
+    Planning,
+    Creating,
+    Submitting,
+    Refreshing,
+    RollingBack,
+    Error
+}
+
+public sealed class DeployFleetTarget
+{
+    public DeployFleetTarget(string targetId, string desiredRevision, string? currentRevision = null)
+    {
+        TargetId = targetId;
+        DesiredRevision = desiredRevision;
+        CurrentRevision = currentRevision;
+    }
+
+    public string TargetId { get; private set; }
+
+    public string DesiredRevision { get; private set; }
+
+    public string? CurrentRevision { get; private set; }
+
+    public bool Selected { get; set; } = true;
+
+    public DeployPlan? Plan { get; internal set; }
+
+    public DeployOperation? Operation { get; internal set; }
+
+    public string? LastError { get; internal set; }
+
+    public string LastAction { get; internal set; } = "Awaiting plan";
+
+    public DateTimeOffset? LastUpdated { get; internal set; }
+
+    public DeployPlanTarget? ResolvedTarget => Operation?.Target ?? Plan?.Target;
+
+    public string DisplayName => string.IsNullOrWhiteSpace(ResolvedTarget?.TargetName)
+        ? TargetId
+        : ResolvedTarget!.TargetName;
+
+    public string TargetKind => EmptyAsUnknown(ResolvedTarget?.TargetKind);
+
+    public string Environment => EmptyAsUnknown(ResolvedTarget?.Environment);
+
+    public string Backend => EmptyAsUnknown(ResolvedTarget?.Backend);
+
+    public string PlanState
+    {
+        get
+        {
+            if (LastError is not null) return "Error";
+            if (Plan is null) return "Not planned";
+            if (Plan.BlockingReasons.Count > 0) return "Blocked";
+            if (Plan.RequiresApproval) return "Approval required";
+            return Plan.ReadyToSubmit ? "Ready" : "Review";
+        }
+    }
+
+    public string OperationState => Operation?.Status ?? "No operation";
+
+    public bool CanCreateOperation => Plan?.ReadyToSubmit == true && Plan.BlockingReasons.Count == 0;
+
+    public bool CanSubmit => !string.IsNullOrWhiteSpace(Operation?.OperationId);
+
+    public bool CanRefresh => !string.IsNullOrWhiteSpace(Operation?.OperationId);
+
+    public bool CanRollback =>
+        !string.IsNullOrWhiteSpace(Operation?.OperationId) &&
+        (Plan?.Capabilities?.SupportsRollback ?? true);
+
+    public void UpdateDraft(string targetId, string desiredRevision, string? currentRevision)
+    {
+        TargetId = targetId;
+        DesiredRevision = desiredRevision;
+        CurrentRevision = currentRevision;
+        Plan = null;
+        Operation = null;
+        LastError = null;
+        LastAction = "Awaiting plan";
+        LastUpdated = null;
+    }
+
+    private static string EmptyAsUnknown(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "unknown" : value;
+}
+
+public sealed class DeployOrchestrationState
+{
+    private readonly IHonuaAdminClient _client;
+    private readonly List<DeployFleetTarget> _targets = [];
+
+    public DeployOrchestrationState(IHonuaAdminClient client)
+    {
+        _client = client;
+    }
+
+    public DeployOrchestrationStatus Status { get; private set; } = DeployOrchestrationStatus.Idle;
+
+    public string? LastError { get; private set; }
+
+    public DeployPreflightResult? Preflight { get; private set; }
+
+    public IReadOnlyList<DeployFleetTarget> Targets => _targets;
+
+    public IReadOnlyList<DeployFleetTarget> SelectedTargets => _targets
+        .Where(target => target.Selected)
+        .ToArray();
+
+    public bool HasSelectedTargets => _targets.Any(target => target.Selected);
+
+    public bool HasRefreshableOperations => _targets.Any(target => target.Selected && target.CanRefresh);
+
+    public bool HasSubmittableOperations => _targets.Any(target => target.Selected && target.CanSubmit);
+
+    public bool HasRollbackOperations => _targets.Any(target => target.Selected && target.CanRollback);
+
+    public event Action? OnChanged;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        SetStatus(DeployOrchestrationStatus.Loading);
+
+        try
+        {
+            Preflight = await _client.GetDeployPreflightAsync(cancellationToken).ConfigureAwait(false);
+            if (_targets.Count == 0)
+            {
+                _targets.Add(new DeployFleetTarget("honua-server", "latest"));
+            }
+
+            LastError = null;
+            Status = DeployOrchestrationStatus.Idle;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Status = DeployOrchestrationStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    public bool AddOrUpdateTarget(string? targetId, string? desiredRevision, string? currentRevision)
+    {
+        var normalizedTargetId = NormalizeRequired(targetId);
+        var normalizedDesiredRevision = NormalizeRequired(desiredRevision);
+        var normalizedCurrentRevision = NormalizeOptional(currentRevision);
+
+        if (normalizedTargetId is null || normalizedDesiredRevision is null)
+        {
+            LastError = "Target ID and desired revision are required.";
+            Notify();
+            return false;
+        }
+
+        var existing = _targets.FirstOrDefault(target =>
+            string.Equals(target.TargetId, normalizedTargetId, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null)
+        {
+            existing.UpdateDraft(normalizedTargetId, normalizedDesiredRevision, normalizedCurrentRevision);
+            existing.Selected = true;
+        }
+        else
+        {
+            _targets.Add(new DeployFleetTarget(normalizedTargetId, normalizedDesiredRevision, normalizedCurrentRevision));
+        }
+
+        LastError = null;
+        Notify();
+        return true;
+    }
+
+    public void RemoveTarget(DeployFleetTarget target)
+    {
+        _targets.Remove(target);
+        if (_targets.Count == 0)
+        {
+            _targets.Add(new DeployFleetTarget("honua-server", "latest"));
+        }
+
+        LastError = null;
+        Notify();
+    }
+
+    public void SetAllSelected(bool selected)
+    {
+        foreach (var target in _targets)
+        {
+            target.Selected = selected;
+        }
+
+        Notify();
+    }
+
+    public Task PlanTargetAsync(DeployFleetTarget target, CancellationToken cancellationToken = default)
+        => RunTargetOperationAsync(
+            DeployOrchestrationStatus.Planning,
+            target,
+            (item, token) => PlanTargetCoreAsync(item, token),
+            cancellationToken);
+
+    public Task PlanSelectedAsync(CancellationToken cancellationToken = default)
+        => RunSelectedOperationAsync(
+            DeployOrchestrationStatus.Planning,
+            (target, token) => PlanTargetCoreAsync(target, token),
+            cancellationToken);
+
+    public Task CreateOperationAsync(
+        DeployFleetTarget target,
+        string? reason,
+        bool submitImmediately,
+        CancellationToken cancellationToken = default)
+        => RunTargetOperationAsync(
+            DeployOrchestrationStatus.Creating,
+            target,
+            (item, token) => CreateOperationCoreAsync(item, reason, submitImmediately, token),
+            cancellationToken);
+
+    public Task CreateOperationsForSelectedAsync(
+        string? reason,
+        bool submitImmediately,
+        CancellationToken cancellationToken = default)
+        => RunSelectedOperationAsync(
+            DeployOrchestrationStatus.Creating,
+            (target, token) => CreateOperationCoreAsync(target, reason, submitImmediately, token),
+            cancellationToken);
+
+    public Task SubmitOperationAsync(
+        DeployFleetTarget target,
+        string? reason,
+        CancellationToken cancellationToken = default)
+        => RunTargetOperationAsync(
+            DeployOrchestrationStatus.Submitting,
+            target,
+            (item, token) => SubmitOperationCoreAsync(item, reason, token),
+            cancellationToken);
+
+    public Task SubmitSelectedAsync(string? reason, CancellationToken cancellationToken = default)
+        => RunSelectedOperationAsync(
+            DeployOrchestrationStatus.Submitting,
+            (target, token) => SubmitOperationCoreAsync(target, reason, token),
+            cancellationToken);
+
+    public Task RefreshOperationAsync(DeployFleetTarget target, CancellationToken cancellationToken = default)
+        => RunTargetOperationAsync(
+            DeployOrchestrationStatus.Refreshing,
+            target,
+            (item, token) => RefreshOperationCoreAsync(item, token),
+            cancellationToken);
+
+    public Task RefreshSelectedAsync(CancellationToken cancellationToken = default)
+        => RunSelectedOperationAsync(
+            DeployOrchestrationStatus.Refreshing,
+            (target, token) => RefreshOperationCoreAsync(target, token),
+            cancellationToken);
+
+    public Task RollbackOperationAsync(
+        DeployFleetTarget target,
+        string? reason,
+        CancellationToken cancellationToken = default)
+        => RunTargetOperationAsync(
+            DeployOrchestrationStatus.RollingBack,
+            target,
+            (item, token) => RollbackOperationCoreAsync(item, reason, token),
+            cancellationToken);
+
+    public Task RollbackSelectedAsync(string? reason, CancellationToken cancellationToken = default)
+        => RunSelectedOperationAsync(
+            DeployOrchestrationStatus.RollingBack,
+            (target, token) => RollbackOperationCoreAsync(target, reason, token),
+            cancellationToken);
+
+    private async Task RunSelectedOperationAsync(
+        DeployOrchestrationStatus status,
+        Func<DeployFleetTarget, CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        var selected = SelectedTargets;
+        if (selected.Count == 0)
+        {
+            LastError = "Select at least one deploy target.";
+            Notify();
+            return;
+        }
+
+        SetStatus(status);
+        foreach (var target in selected)
+        {
+            await ExecuteTargetOperationAsync(target, operation, cancellationToken).ConfigureAwait(false);
+        }
+
+        CompleteBatch();
+    }
+
+    private async Task RunTargetOperationAsync(
+        DeployOrchestrationStatus status,
+        DeployFleetTarget target,
+        Func<DeployFleetTarget, CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        SetStatus(status);
+        await ExecuteTargetOperationAsync(target, operation, cancellationToken).ConfigureAwait(false);
+        CompleteBatch();
+    }
+
+    private async Task ExecuteTargetOperationAsync(
+        DeployFleetTarget target,
+        Func<DeployFleetTarget, CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        target.LastError = null;
+        try
+        {
+            await operation(target, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            target.LastError = ex.Message;
+            target.LastAction = "Action failed";
+            target.LastUpdated = DateTimeOffset.UtcNow;
+        }
+
+        Notify();
+    }
+
+    private async Task PlanTargetCoreAsync(DeployFleetTarget target, CancellationToken cancellationToken)
+    {
+        target.Plan = await _client.PlanDeployAsync(
+            new DeployPlanRequest
+            {
+                TargetId = target.TargetId,
+                DesiredRevision = target.DesiredRevision,
+                CurrentRevision = target.CurrentRevision,
+            },
+            cancellationToken).ConfigureAwait(false);
+        target.LastAction = "Plan generated";
+        target.LastUpdated = target.Plan.GeneratedAt == default
+            ? DateTimeOffset.UtcNow
+            : target.Plan.GeneratedAt;
+    }
+
+    private async Task CreateOperationCoreAsync(
+        DeployFleetTarget target,
+        string? reason,
+        bool submitImmediately,
+        CancellationToken cancellationToken)
+    {
+        target.Operation = await _client.CreateDeployOperationAsync(
+            new CreateDeployOperationRequest
+            {
+                TargetId = target.TargetId,
+                DesiredRevision = target.DesiredRevision,
+                CurrentRevision = target.CurrentRevision,
+                Reason = NormalizeOptional(reason) ?? "Created from Honua admin deploy workspace",
+                SubmitImmediately = submitImmediately,
+            },
+            cancellationToken).ConfigureAwait(false);
+        target.LastAction = submitImmediately ? "Operation created and submitted" : "Operation created";
+        target.LastUpdated = target.Operation.UpdatedAt == default
+            ? DateTimeOffset.UtcNow
+            : target.Operation.UpdatedAt;
+    }
+
+    private async Task SubmitOperationCoreAsync(
+        DeployFleetTarget target,
+        string? reason,
+        CancellationToken cancellationToken)
+    {
+        var operationId = target.Operation?.OperationId;
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            target.LastError = "Create an operation before submitting.";
+            return;
+        }
+
+        target.Operation = await _client.SubmitDeployOperationAsync(
+            operationId,
+            new SubmitDeployOperationRequest { Reason = NormalizeOptional(reason) ?? "Submitted from Honua admin deploy workspace" },
+            cancellationToken).ConfigureAwait(false);
+        target.LastAction = "Operation submitted";
+        target.LastUpdated = target.Operation.UpdatedAt == default
+            ? DateTimeOffset.UtcNow
+            : target.Operation.UpdatedAt;
+    }
+
+    private async Task RefreshOperationCoreAsync(DeployFleetTarget target, CancellationToken cancellationToken)
+    {
+        var operationId = target.Operation?.OperationId;
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            target.LastError = "No operation ID is available for refresh.";
+            return;
+        }
+
+        target.Operation = await _client.GetDeployOperationAsync(operationId, cancellationToken).ConfigureAwait(false);
+        target.LastAction = "Operation refreshed";
+        target.LastUpdated = target.Operation.UpdatedAt == default
+            ? DateTimeOffset.UtcNow
+            : target.Operation.UpdatedAt;
+    }
+
+    private async Task RollbackOperationCoreAsync(
+        DeployFleetTarget target,
+        string? reason,
+        CancellationToken cancellationToken)
+    {
+        var operationId = target.Operation?.OperationId;
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            target.LastError = "No operation ID is available for rollback.";
+            return;
+        }
+
+        target.Operation = await _client.RollbackDeployOperationAsync(
+            operationId,
+            new RollbackDeployOperationRequest { Reason = NormalizeOptional(reason) ?? "Rollback requested from Honua admin deploy workspace" },
+            cancellationToken).ConfigureAwait(false);
+        target.LastAction = "Rollback requested";
+        target.LastUpdated = target.Operation.UpdatedAt == default
+            ? DateTimeOffset.UtcNow
+            : target.Operation.UpdatedAt;
+    }
+
+    private void SetStatus(DeployOrchestrationStatus status)
+    {
+        Status = status;
+        LastError = null;
+        Notify();
+    }
+
+    private void CompleteBatch()
+    {
+        LastError = _targets.Any(target => target.LastError is not null)
+            ? "One or more deploy target actions failed."
+            : null;
+        Status = LastError is null ? DeployOrchestrationStatus.Idle : DeployOrchestrationStatus.Error;
+        Notify();
+    }
+
+    private void Notify() => OnChanged?.Invoke();
+
+    private static string? NormalizeRequired(string? value)
+    {
+        var normalized = NormalizeOptional(value);
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Honua.Admin/Services/Admin/DeployOrchestrationState.cs
+++ b/src/Honua.Admin/Services/Admin/DeployOrchestrationState.cs
@@ -148,6 +148,11 @@ public sealed class DeployOrchestrationState
             LastError = null;
             Status = DeployOrchestrationStatus.Idle;
         }
+        catch (OperationCanceledException)
+        {
+            ResetAfterCancellation();
+            throw;
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             Status = DeployOrchestrationStatus.Error;
@@ -300,13 +305,21 @@ public sealed class DeployOrchestrationState
             return;
         }
 
-        SetStatus(status);
-        foreach (var target in selected)
+        try
         {
-            await ExecuteTargetOperationAsync(target, operation, cancellationToken).ConfigureAwait(false);
-        }
+            SetStatus(status);
+            foreach (var target in selected)
+            {
+                await ExecuteTargetOperationAsync(target, operation, cancellationToken).ConfigureAwait(false);
+            }
 
-        CompleteBatch();
+            CompleteBatch();
+        }
+        catch (OperationCanceledException)
+        {
+            ResetAfterCancellation();
+            throw;
+        }
     }
 
     private async Task RunTargetOperationAsync(
@@ -315,9 +328,17 @@ public sealed class DeployOrchestrationState
         Func<DeployFleetTarget, CancellationToken, Task> operation,
         CancellationToken cancellationToken)
     {
-        SetStatus(status);
-        await ExecuteTargetOperationAsync(target, operation, cancellationToken).ConfigureAwait(false);
-        CompleteBatch();
+        try
+        {
+            SetStatus(status);
+            await ExecuteTargetOperationAsync(target, operation, cancellationToken).ConfigureAwait(false);
+            CompleteBatch();
+        }
+        catch (OperationCanceledException)
+        {
+            ResetAfterCancellation();
+            throw;
+        }
     }
 
     private async Task ExecuteTargetOperationAsync(
@@ -451,6 +472,13 @@ public sealed class DeployOrchestrationState
             ? "One or more deploy target actions failed."
             : null;
         Status = LastError is null ? DeployOrchestrationStatus.Idle : DeployOrchestrationStatus.Error;
+        Notify();
+    }
+
+    private void ResetAfterCancellation()
+    {
+        LastError = null;
+        Status = DeployOrchestrationStatus.Idle;
         Notify();
     }
 

--- a/src/Honua.Admin/Services/Admin/DeployOrchestrationState.cs
+++ b/src/Honua.Admin/Services/Admin/DeployOrchestrationState.cs
@@ -125,6 +125,8 @@ public sealed class DeployOrchestrationState
 
     public bool HasSelectedTargets => _targets.Any(target => target.Selected);
 
+    public bool HasCreatableTargets => _targets.Any(target => target.Selected && target.CanCreateOperation);
+
     public bool HasRefreshableOperations => _targets.Any(target => target.Selected && target.CanRefresh);
 
     public bool HasSubmittableOperations => _targets.Any(target => target.Selected && target.CanSubmit);
@@ -244,6 +246,8 @@ public sealed class DeployOrchestrationState
         CancellationToken cancellationToken = default)
         => RunSelectedOperationAsync(
             DeployOrchestrationStatus.Creating,
+            static target => target.CanCreateOperation,
+            "Select at least one deploy target with a ready plan.",
             (target, token) => CreateOperationCoreAsync(target, reason, submitImmediately, token),
             cancellationToken);
 
@@ -260,6 +264,8 @@ public sealed class DeployOrchestrationState
     public Task SubmitSelectedAsync(string? reason, CancellationToken cancellationToken = default)
         => RunSelectedOperationAsync(
             DeployOrchestrationStatus.Submitting,
+            static target => target.CanSubmit,
+            "Select at least one deploy operation to submit.",
             (target, token) => SubmitOperationCoreAsync(target, reason, token),
             cancellationToken);
 
@@ -273,6 +279,8 @@ public sealed class DeployOrchestrationState
     public Task RefreshSelectedAsync(CancellationToken cancellationToken = default)
         => RunSelectedOperationAsync(
             DeployOrchestrationStatus.Refreshing,
+            static target => target.CanRefresh,
+            "Select at least one deploy operation to refresh.",
             (target, token) => RefreshOperationCoreAsync(target, token),
             cancellationToken);
 
@@ -289,6 +297,8 @@ public sealed class DeployOrchestrationState
     public Task RollbackSelectedAsync(string? reason, CancellationToken cancellationToken = default)
         => RunSelectedOperationAsync(
             DeployOrchestrationStatus.RollingBack,
+            static target => target.CanRollback,
+            "Select at least one deploy operation that supports rollback.",
             (target, token) => RollbackOperationCoreAsync(target, reason, token),
             cancellationToken);
 
@@ -296,11 +306,26 @@ public sealed class DeployOrchestrationState
         DeployOrchestrationStatus status,
         Func<DeployFleetTarget, CancellationToken, Task> operation,
         CancellationToken cancellationToken)
+        => await RunSelectedOperationAsync(
+            status,
+            static _ => true,
+            "Select at least one deploy target.",
+            operation,
+            cancellationToken).ConfigureAwait(false);
+
+    private async Task RunSelectedOperationAsync(
+        DeployOrchestrationStatus status,
+        Func<DeployFleetTarget, bool> isEligible,
+        string noEligibleTargetsMessage,
+        Func<DeployFleetTarget, CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
     {
-        var selected = SelectedTargets;
-        if (selected.Count == 0)
+        var selected = SelectedTargets
+            .Where(isEligible)
+            .ToArray();
+        if (selected.Length == 0)
         {
-            LastError = "Select at least one deploy target.";
+            LastError = noEligibleTargetsMessage;
             Notify();
             return;
         }

--- a/tests/Honua.Admin.Tests/DeployOrchestrationStateTests.cs
+++ b/tests/Honua.Admin.Tests/DeployOrchestrationStateTests.cs
@@ -71,6 +71,27 @@ public sealed class DeployOrchestrationStateTests
         Assert.Contains(target.Operation.OperationId, client.RollbackOperationIds);
     }
 
+    [Fact]
+    public async Task InitializeAsync_when_canceled_restores_idle_status_before_rethrowing()
+    {
+        var state = new DeployOrchestrationState(new CancelingDeployClient(cancelPreflight: true));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => state.InitializeAsync());
+
+        Assert.Equal(DeployOrchestrationStatus.Idle, state.Status);
+    }
+
+    [Fact]
+    public async Task Target_operation_when_canceled_restores_idle_status_before_rethrowing()
+    {
+        var state = new DeployOrchestrationState(new CancelingDeployClient(cancelPlan: true));
+        await state.InitializeAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => state.PlanSelectedAsync());
+
+        Assert.Equal(DeployOrchestrationStatus.Idle, state.Status);
+    }
+
     private sealed class RecordingDeployClient : StubHonuaAdminClient
     {
         private int _operationSequence;
@@ -157,5 +178,18 @@ public sealed class DeployOrchestrationStateTests
                 CurrentRevision = currentRevision,
                 DesiredRevision = desiredRevision,
             };
+    }
+
+    private sealed class CancelingDeployClient(bool cancelPreflight = false, bool cancelPlan = false) : StubHonuaAdminClient
+    {
+        public override Task<DeployPreflightResult> GetDeployPreflightAsync(CancellationToken cancellationToken)
+            => cancelPreflight
+                ? Task.FromCanceled<DeployPreflightResult>(new CancellationToken(canceled: true))
+                : base.GetDeployPreflightAsync(cancellationToken);
+
+        public override Task<DeployPlan> PlanDeployAsync(DeployPlanRequest request, CancellationToken cancellationToken)
+            => cancelPlan
+                ? Task.FromCanceled<DeployPlan>(new CancellationToken(canceled: true))
+                : base.PlanDeployAsync(request, cancellationToken);
     }
 }

--- a/tests/Honua.Admin.Tests/DeployOrchestrationStateTests.cs
+++ b/tests/Honua.Admin.Tests/DeployOrchestrationStateTests.cs
@@ -72,6 +72,28 @@ public sealed class DeployOrchestrationStateTests
     }
 
     [Fact]
+    public async Task SubmitSelectedAsync_skips_selected_targets_without_operations()
+    {
+        var client = new RecordingDeployClient();
+        var state = new DeployOrchestrationState(client);
+        await state.InitializeAsync();
+        await state.PlanSelectedAsync();
+        await state.CreateOperationsForSelectedAsync("promote candidate", submitImmediately: false);
+        state.AddOrUpdateTarget("prod-api", "sha256:abc123", currentRevision: null);
+
+        await state.SubmitSelectedAsync("approval granted");
+
+        Assert.Null(state.LastError);
+        Assert.Equal(DeployOrchestrationStatus.Idle, state.Status);
+        var submittedId = Assert.Single(client.SubmittedOperationIds);
+        Assert.StartsWith("deploy-honua-server-", submittedId, StringComparison.Ordinal);
+        Assert.Contains(state.Targets, target =>
+            target.TargetId == "prod-api" &&
+            target.Operation is null &&
+            target.LastError is null);
+    }
+
+    [Fact]
     public async Task InitializeAsync_when_canceled_restores_idle_status_before_rethrowing()
     {
         var state = new DeployOrchestrationState(new CancelingDeployClient(cancelPreflight: true));

--- a/tests/Honua.Admin.Tests/DeployOrchestrationStateTests.cs
+++ b/tests/Honua.Admin.Tests/DeployOrchestrationStateTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.Admin;
+using Honua.Admin.Services.Admin;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class DeployOrchestrationStateTests
+{
+    [Fact]
+    public async Task InitializeAsync_loads_preflight_and_seeds_default_target()
+    {
+        var state = new DeployOrchestrationState(new RecordingDeployClient());
+
+        await state.InitializeAsync();
+
+        Assert.Equal(DeployOrchestrationStatus.Idle, state.Status);
+        Assert.NotNull(state.Preflight);
+        var target = Assert.Single(state.Targets);
+        Assert.Equal("honua-server", target.TargetId);
+        Assert.Equal("latest", target.DesiredRevision);
+    }
+
+    [Fact]
+    public async Task PlanSelectedAsync_resolves_each_selected_target_through_server_plan_api()
+    {
+        var client = new RecordingDeployClient();
+        var state = new DeployOrchestrationState(client);
+        await state.InitializeAsync();
+        state.AddOrUpdateTarget("prod-api", "sha256:abc123", "sha256:old");
+
+        await state.PlanSelectedAsync();
+
+        Assert.Equal(DeployOrchestrationStatus.Idle, state.Status);
+        Assert.Contains("honua-server", client.PlannedTargets);
+        Assert.Contains("prod-api", client.PlannedTargets);
+        Assert.All(state.Targets, target => Assert.NotNull(target.Plan));
+        Assert.Contains(state.Targets, target =>
+            target.TargetId == "prod-api" &&
+            target.Plan?.Target.CurrentRevision == "sha256:old" &&
+            target.Plan.Target.DesiredRevision == "sha256:abc123");
+    }
+
+    [Fact]
+    public async Task Create_submit_refresh_and_rollback_selected_track_durable_operation_ids()
+    {
+        var client = new RecordingDeployClient();
+        var state = new DeployOrchestrationState(client);
+        await state.InitializeAsync();
+        await state.PlanSelectedAsync();
+
+        await state.CreateOperationsForSelectedAsync("promote candidate", submitImmediately: false);
+        var target = Assert.Single(state.Targets);
+        Assert.NotNull(target.Operation);
+        Assert.StartsWith("deploy-honua-server-", target.Operation!.OperationId, StringComparison.Ordinal);
+        Assert.Equal("Planned", target.Operation.Status);
+
+        await state.SubmitSelectedAsync("approval granted");
+        Assert.Equal("Submitted", target.Operation.Status);
+        Assert.Contains(target.Operation.OperationId, client.SubmittedOperationIds);
+
+        await state.RefreshSelectedAsync();
+        Assert.Equal("Reconciling", target.Operation.Status);
+        Assert.Equal("Provider accepted operation.", target.Operation.CurrentPhase);
+
+        await state.RollbackSelectedAsync("verification failed");
+        Assert.Equal("RollbackRequested", target.Operation.Status);
+        Assert.Contains(target.Operation.OperationId, client.RollbackOperationIds);
+    }
+
+    private sealed class RecordingDeployClient : StubHonuaAdminClient
+    {
+        private int _operationSequence;
+
+        public List<string> PlannedTargets { get; } = [];
+
+        public List<string> SubmittedOperationIds { get; } = [];
+
+        public List<string> RollbackOperationIds { get; } = [];
+
+        public override Task<DeployPlan> PlanDeployAsync(DeployPlanRequest request, CancellationToken cancellationToken)
+        {
+            PlannedTargets.Add(request.TargetId);
+            return Task.FromResult(new DeployPlan
+            {
+                Target = Target(request.TargetId, request.DesiredRevision, request.CurrentRevision),
+                ReadyToSubmit = true,
+                BackendRegistered = true,
+                Capabilities = new DeployBackendCapabilities
+                {
+                    SupportsRollback = true,
+                    SupportsProgressPolling = true,
+                    SupportsTrafficShifting = true,
+                    SupportsRevisionPinning = true,
+                },
+                GeneratedAt = DateTimeOffset.Parse("2026-04-27T10:00:00Z"),
+            });
+        }
+
+        public override Task<DeployOperation> CreateDeployOperationAsync(CreateDeployOperationRequest request, CancellationToken cancellationToken)
+        {
+            _operationSequence++;
+            return Task.FromResult(new DeployOperation
+            {
+                OperationId = $"deploy-{request.TargetId}-{_operationSequence}",
+                Kind = "Deploy",
+                Status = "Planned",
+                Priority = "Normal",
+                Target = Target(request.TargetId, request.DesiredRevision, request.CurrentRevision),
+                Reason = request.Reason,
+                CreatedAt = DateTimeOffset.Parse("2026-04-27T10:01:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-27T10:01:00Z"),
+            });
+        }
+
+        public override Task<DeployOperation> SubmitDeployOperationAsync(string operationId, SubmitDeployOperationRequest request, CancellationToken cancellationToken)
+        {
+            SubmittedOperationIds.Add(operationId);
+            return Task.FromResult(Operation(operationId, "Submitted", "Submitted to provider.", request.Reason));
+        }
+
+        public override Task<DeployOperation> GetDeployOperationAsync(string operationId, CancellationToken cancellationToken)
+            => Task.FromResult(Operation(operationId, "Reconciling", "Provider accepted operation.", reason: null));
+
+        public override Task<DeployOperation> RollbackDeployOperationAsync(string operationId, RollbackDeployOperationRequest request, CancellationToken cancellationToken)
+        {
+            RollbackOperationIds.Add(operationId);
+            return Task.FromResult(Operation(operationId, "RollbackRequested", "Rollback requested.", request.Reason));
+        }
+
+        private static DeployOperation Operation(string operationId, string status, string phase, string? reason)
+            => new()
+            {
+                OperationId = operationId,
+                Kind = "Deploy",
+                Status = status,
+                Priority = "Normal",
+                Target = Target("honua-server", "latest", currentRevision: null),
+                CurrentPhase = phase,
+                ObservedState = status,
+                Reason = reason,
+                CreatedAt = DateTimeOffset.Parse("2026-04-27T10:01:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-27T10:02:00Z"),
+            };
+
+        private static DeployPlanTarget Target(string targetId, string desiredRevision, string? currentRevision)
+            => new()
+            {
+                TargetId = targetId,
+                TargetName = targetId == "honua-server" ? "Honua Server" : "Production API",
+                TargetKind = "Kubernetes",
+                Backend = "honua-gitops-kubernetes",
+                Environment = targetId == "honua-server" ? "dev" : "prod",
+                CurrentRevision = currentRevision,
+                DesiredRevision = desiredRevision,
+            };
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DeployOrchestrationState` for fleet target rows, deploy preflight, plan, create, submit, status refresh, and rollback flows over the existing control-plane deploy APIs.
- Rework `/deploy` into a fleet workspace with target inventory, resolved server target metadata, durable operation IDs, rollout state, and per-target/bulk action entry points.
- Add unit coverage for target planning and operation lifecycle orchestration.

## Validation
- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal"`
- `dotnet test Honua.Admin.sln --configuration Release --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1`
- `dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic`

Closes #16
