### PR TITLE
feat: add usage analytics dashboard

### DIFF
--- a/src/Honua.Admin/Models/UsageAnalytics/UsageAnalyticsModels.cs
+++ b/src/Honua.Admin/Models/UsageAnalytics/UsageAnalyticsModels.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.UsageAnalytics;
+
+public sealed record UsageAnalyticsQuery
+{
+    public string RangeKey { get; init; } = "24h";
+    public string? ServiceName { get; init; }
+    public string? LayerName { get; init; }
+    public string? Protocol { get; init; }
+}
+
+public sealed record UsageAnalyticsReport
+{
+    public DateTimeOffset GeneratedAt { get; init; }
+    public DateTimeOffset RangeStart { get; init; }
+    public DateTimeOffset RangeEnd { get; init; }
+    public string RangeLabel { get; init; } = string.Empty;
+    public string DataSource { get; init; } = string.Empty;
+    public UsageAnalyticsTotals Totals { get; init; } = new();
+    public IReadOnlyList<QueryThroughputPoint> QuerySeries { get; init; } = Array.Empty<QueryThroughputPoint>();
+    public IReadOnlyList<PopularLayerMetric> PopularLayers { get; init; } = Array.Empty<PopularLayerMetric>();
+    public IReadOnlyList<EndpointUsageMetric> PopularEndpoints { get; init; } = Array.Empty<EndpointUsageMetric>();
+    public IReadOnlyList<SlowQueryMetric> SlowQueries { get; init; } = Array.Empty<SlowQueryMetric>();
+    public IReadOnlyList<StorageGrowthMetric> StorageGrowth { get; init; } = Array.Empty<StorageGrowthMetric>();
+    public IReadOnlyList<UserActivityMetric> UserActivity { get; init; } = Array.Empty<UserActivityMetric>();
+}
+
+public sealed record UsageAnalyticsTotals
+{
+    public long TotalQueries { get; init; }
+    public double QueriesPerSecond { get; init; }
+    public int UniqueUsers { get; init; }
+    public int SlowQueryCount { get; init; }
+    public double P95LatencyMs { get; init; }
+    public long StorageBytes { get; init; }
+    public long StorageDeltaBytes { get; init; }
+}
+
+public sealed record QueryThroughputPoint
+{
+    public DateTimeOffset Timestamp { get; init; }
+    public string ServiceName { get; init; } = string.Empty;
+    public string LayerName { get; init; } = string.Empty;
+    public string Protocol { get; init; } = string.Empty;
+    public long QueryCount { get; init; }
+    public double QueriesPerSecond { get; init; }
+    public double AverageLatencyMs { get; init; }
+    public int SlowQueryCount { get; init; }
+}
+
+public sealed record PopularLayerMetric
+{
+    public string ServiceName { get; init; } = string.Empty;
+    public string LayerName { get; init; } = string.Empty;
+    public string Protocol { get; init; } = string.Empty;
+    public long QueryCount { get; init; }
+    public double QueriesPerSecond { get; init; }
+    public int UniqueUsers { get; init; }
+    public double P95LatencyMs { get; init; }
+    public double ErrorRate { get; init; }
+}
+
+public sealed record EndpointUsageMetric
+{
+    public string ServiceName { get; init; } = string.Empty;
+    public string LayerName { get; init; } = string.Empty;
+    public string Path { get; init; } = string.Empty;
+    public string Protocol { get; init; } = string.Empty;
+    public long QueryCount { get; init; }
+    public double QueriesPerSecond { get; init; }
+    public double P95LatencyMs { get; init; }
+    public double ErrorRate { get; init; }
+}
+
+public sealed record SlowQueryMetric
+{
+    public string ServiceName { get; init; } = string.Empty;
+    public string LayerName { get; init; } = string.Empty;
+    public string Protocol { get; init; } = string.Empty;
+    public string Endpoint { get; init; } = string.Empty;
+    public string QueryPattern { get; init; } = string.Empty;
+    public int Count { get; init; }
+    public double P95DurationMs { get; init; }
+    public double MaxDurationMs { get; init; }
+    public DateTimeOffset LastSeen { get; init; }
+    public string ExampleCorrelationId { get; init; } = string.Empty;
+}
+
+public sealed record StorageGrowthMetric
+{
+    public string Tenant { get; init; } = string.Empty;
+    public string ServiceName { get; init; } = string.Empty;
+    public long CurrentBytes { get; init; }
+    public long DeltaBytes { get; init; }
+    public double GrowthPercent { get; init; }
+    public int LayerCount { get; init; }
+    public IReadOnlyList<string> LayerNames { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Protocols { get; init; } = Array.Empty<string>();
+}
+
+public sealed record UserActivityMetric
+{
+    public string PrincipalId { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string Tenant { get; init; } = string.Empty;
+    public string TopService { get; init; } = string.Empty;
+    public string TopLayer { get; init; } = string.Empty;
+    public string MostUsedProtocol { get; init; } = string.Empty;
+    public long QueryCount { get; init; }
+    public int DistinctLayers { get; init; }
+    public double P95LatencyMs { get; init; }
+    public DateTimeOffset LastSeen { get; init; }
+}
+
+public sealed record UsageAnalyticsExportPayload(
+    string FileName,
+    string MimeType,
+    string Content);

--- a/src/Honua.Admin/Pages/Operator/UsageAnalytics.razor
+++ b/src/Honua.Admin/Pages/Operator/UsageAnalytics.razor
@@ -1,0 +1,441 @@
+@page "/operator/analytics"
+@using System.Globalization
+@using Honua.Admin.Models.UsageAnalytics
+@using Honua.Admin.Services.UsageAnalytics
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.JSInterop
+@attribute [Authorize]
+@inject UsageAnalyticsState State
+@inject IAdminTelemetry Telemetry
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>Usage analytics</PageTitle>
+
+<div class="usage-analytics-root" data-testid="usage-analytics-root">
+    <div class="usage-analytics-toolbar" aria-label="Usage analytics toolbar">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="usage-analytics-toolbar-row">
+            <MudText Typo="Typo.h5">
+                <MudIcon Icon="@Icons.Material.Filled.Insights" Class="mr-2" />
+                Usage analytics
+            </MudText>
+            <MudChip T="string" Size="Size.Small" Color="@StatusColor(State.Status)" Variant="Variant.Outlined" data-testid="usage-analytics-status">
+                @State.Status
+            </MudChip>
+            <MudSpacer />
+            <MudSelect T="string"
+                       Label="Range"
+                       Value="@State.RangeKey"
+                       ValueChanged="OnRangeChanged"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       Disabled="@State.IsLoading"
+                       aria-label="Analytics time range"
+                       Class="usage-analytics-range">
+                @foreach (var option in UsageAnalyticsRanges.Options)
+                {
+                    <MudSelectItem T="string" Value="@option.Key">@option.Label</MudSelectItem>
+                }
+            </MudSelect>
+            <MudButton StartIcon="@Icons.Material.Filled.Refresh"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@State.IsLoading"
+                       OnClick="RefreshAsync"
+                       data-testid="usage-analytics-refresh">
+                Refresh
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.GetApp"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@(State.Report is null || State.IsLoading)"
+                       OnClick="ExportCsvAsync"
+                       data-testid="usage-analytics-export-csv">
+                CSV
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.PictureAsPdf"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@(State.Report is null || State.IsLoading)"
+                       OnClick="ExportPdfAsync"
+                       data-testid="usage-analytics-export-pdf">
+                PDF
+            </MudButton>
+        </MudStack>
+        @if (!string.IsNullOrWhiteSpace(State.LastError))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Dense="true" Class="mt-2" data-testid="usage-analytics-error">
+                @State.LastError
+            </MudAlert>
+        }
+    </div>
+
+    @if (State.IsLoading && State.Report is null)
+    {
+        <MudGrid Class="mt-2">
+            @for (var i = 0; i < 6; i++)
+            {
+                <MudItem xs="12" sm="6" lg="2">
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="112px" Animation="Animation.Wave" />
+                </MudItem>
+            }
+        </MudGrid>
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="360px" Animation="Animation.Wave" Class="mt-2" />
+    }
+    else if (State.Report is { } report)
+    {
+        var totals = State.FilteredTotals;
+        <MudGrid Class="mt-2">
+            <MudItem xs="12" sm="6" lg="2">
+                <MudCard Elevation="1" Class="usage-analytics-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Queries</MudText>
+                        <MudText Typo="Typo.h5">@FormatNumber(totals.TotalQueries)</MudText>
+                        <MudText Typo="Typo.caption">@report.RangeLabel</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="2">
+                <MudCard Elevation="1" Class="usage-analytics-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Average QPS</MudText>
+                        <MudText Typo="Typo.h5">@FormatDecimal(totals.QueriesPerSecond)</MudText>
+                        <MudText Typo="Typo.caption">@RangeWindow(report)</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="2">
+                <MudCard Elevation="1" Class="usage-analytics-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">P95 latency</MudText>
+                        <MudText Typo="Typo.h5">@FormatLatency(totals.P95LatencyMs)</MudText>
+                        <MudText Typo="Typo.caption">Filtered peak</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="2">
+                <MudCard Elevation="1" Class="usage-analytics-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Slow queries</MudText>
+                        <MudText Typo="Typo.h5">@FormatNumber(totals.SlowQueryCount)</MudText>
+                        <MudText Typo="Typo.caption">P95 over threshold</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="2">
+                <MudCard Elevation="1" Class="usage-analytics-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Active users</MudText>
+                        <MudText Typo="Typo.h5">@FormatNumber(totals.UniqueUsers)</MudText>
+                        <MudText Typo="Typo.caption">RBAC principals</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="2">
+                <MudCard Elevation="1" Class="usage-analytics-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Storage growth</MudText>
+                        <MudText Typo="Typo.h5">@FormatBytes(totals.StorageDeltaBytes)</MudText>
+                        <MudText Typo="Typo.caption">@FormatBytes(totals.StorageBytes) total</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        </MudGrid>
+
+        <MudPaper Elevation="0" Class="usage-analytics-filterbar mt-2" aria-label="Usage analytics filters">
+            <MudSelect T="string"
+                       Label="Service"
+                       Value="@State.ServiceFilter"
+                       ValueChanged="OnServiceFilterChanged"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       aria-label="Analytics service filter">
+                @foreach (var option in State.ServiceOptions)
+                {
+                    <MudSelectItem T="string" Value="@option">@OptionLabel(option)</MudSelectItem>
+                }
+            </MudSelect>
+            <MudSelect T="string"
+                       Label="Layer"
+                       Value="@State.LayerFilter"
+                       ValueChanged="OnLayerFilterChanged"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       aria-label="Analytics layer filter">
+                @foreach (var option in State.LayerOptions)
+                {
+                    <MudSelectItem T="string" Value="@option">@OptionLabel(option)</MudSelectItem>
+                }
+            </MudSelect>
+            <MudSelect T="string"
+                       Label="Protocol"
+                       Value="@State.ProtocolFilter"
+                       ValueChanged="OnProtocolFilterChanged"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       aria-label="Analytics protocol filter">
+                @foreach (var option in State.ProtocolOptions)
+                {
+                    <MudSelectItem T="string" Value="@option">@OptionLabel(option)</MudSelectItem>
+                }
+            </MudSelect>
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="usage-analytics-filter-label">
+                @State.FilterLabel
+            </MudText>
+        </MudPaper>
+
+        <MudGrid Class="mt-2">
+            <MudItem xs="12" lg="8">
+                <MudPaper Elevation="0" Class="usage-analytics-panel">
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                        <MudIcon Icon="@Icons.Material.Filled.Speed" />
+                        <MudText Typo="Typo.h6">Queries per second</MudText>
+                        <MudSpacer />
+                        <MudText Typo="Typo.caption">@report.GeneratedAt.ToString("u", CultureInfo.InvariantCulture)</MudText>
+                    </MudStack>
+                    <div class="usage-analytics-bars" role="img" aria-label="Queries per second trend">
+                        @foreach (var bucket in State.ThroughputBuckets)
+                        {
+                            <div class="usage-analytics-bar-slot" title="@BucketTitle(bucket)">
+                                <div class="usage-analytics-bar" style="@BarStyle(bucket.PercentOfPeak)"></div>
+                                <span>@bucket.Timestamp.ToString("HH:mm", CultureInfo.InvariantCulture)</span>
+                            </div>
+                        }
+                    </div>
+                    <MudTable Items="State.ThroughputRows" Dense="true" Hover="true" Class="mt-3" aria-label="Queries per second by service layer protocol">
+                        <HeaderContent>
+                            <MudTh>Service</MudTh>
+                            <MudTh>Layer</MudTh>
+                            <MudTh>Protocol</MudTh>
+                            <MudTh>Queries</MudTh>
+                            <MudTh>QPS</MudTh>
+                            <MudTh>Avg latency</MudTh>
+                            <MudTh>Slow</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd DataLabel="Service">@context.ServiceName</MudTd>
+                            <MudTd DataLabel="Layer">@context.LayerName</MudTd>
+                            <MudTd DataLabel="Protocol">@context.Protocol</MudTd>
+                            <MudTd DataLabel="Queries">@FormatNumber(context.QueryCount)</MudTd>
+                            <MudTd DataLabel="QPS">@FormatDecimal(context.AverageQueriesPerSecond)</MudTd>
+                            <MudTd DataLabel="Avg latency">@FormatLatency(context.AverageLatencyMs)</MudTd>
+                            <MudTd DataLabel="Slow">@FormatNumber(context.SlowQueryCount)</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </MudPaper>
+            </MudItem>
+            <MudItem xs="12" lg="4">
+                <MudPaper Elevation="0" Class="usage-analytics-panel">
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                        <MudIcon Icon="@Icons.Material.Filled.Storage" />
+                        <MudText Typo="Typo.h6">Storage growth</MudText>
+                    </MudStack>
+                    <MudTable Items="State.FilteredStorageGrowth" Dense="true" Hover="true" Class="mt-2" aria-label="Storage growth by service tenant">
+                        <HeaderContent>
+                            <MudTh>Service</MudTh>
+                            <MudTh>Current</MudTh>
+                            <MudTh>Delta</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd DataLabel="Service">
+                                <MudText Typo="Typo.body2">@context.ServiceName</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Tenant - @context.LayerCount layers</MudText>
+                            </MudTd>
+                            <MudTd DataLabel="Current">@FormatBytes(context.CurrentBytes)</MudTd>
+                            <MudTd DataLabel="Delta">
+                                <MudText Typo="Typo.body2">@FormatBytes(context.DeltaBytes)</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatPercent(context.GrowthPercent / 100d)</MudText>
+                            </MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+
+        <MudTabs Class="mt-2" Elevation="0" Rounded="true" PanelClass="usage-analytics-tab-panel">
+            <MudTabPanel Text="Popular layers" Icon="@Icons.Material.Filled.TableChart">
+                <MudTable Items="State.FilteredPopularLayers" Dense="true" Hover="true" aria-label="Popular layers">
+                    <HeaderContent>
+                        <MudTh>Layer</MudTh>
+                        <MudTh>Protocol</MudTh>
+                        <MudTh>Queries</MudTh>
+                        <MudTh>QPS</MudTh>
+                        <MudTh>Users</MudTh>
+                        <MudTh>P95</MudTh>
+                        <MudTh>Error rate</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Layer">
+                            <MudText Typo="Typo.body2">@context.LayerName</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ServiceName</MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Protocol">@context.Protocol</MudTd>
+                        <MudTd DataLabel="Queries">@FormatNumber(context.QueryCount)</MudTd>
+                        <MudTd DataLabel="QPS">@FormatDecimal(context.QueriesPerSecond)</MudTd>
+                        <MudTd DataLabel="Users">@FormatNumber(context.UniqueUsers)</MudTd>
+                        <MudTd DataLabel="P95">@FormatLatency(context.P95LatencyMs)</MudTd>
+                        <MudTd DataLabel="Error rate">@FormatPercent(context.ErrorRate)</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudTabPanel>
+            <MudTabPanel Text="Endpoints" Icon="@Icons.Material.Filled.CloudQueue">
+                <MudTable Items="State.FilteredPopularEndpoints" Dense="true" Hover="true" aria-label="Popular endpoints">
+                    <HeaderContent>
+                        <MudTh>Endpoint</MudTh>
+                        <MudTh>Protocol</MudTh>
+                        <MudTh>Queries</MudTh>
+                        <MudTh>QPS</MudTh>
+                        <MudTh>P95</MudTh>
+                        <MudTh>Error rate</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Endpoint">
+                            <MudText Typo="Typo.body2">@context.Path</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ServiceName / @context.LayerName</MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Protocol">@context.Protocol</MudTd>
+                        <MudTd DataLabel="Queries">@FormatNumber(context.QueryCount)</MudTd>
+                        <MudTd DataLabel="QPS">@FormatDecimal(context.QueriesPerSecond)</MudTd>
+                        <MudTd DataLabel="P95">@FormatLatency(context.P95LatencyMs)</MudTd>
+                        <MudTd DataLabel="Error rate">@FormatPercent(context.ErrorRate)</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudTabPanel>
+            <MudTabPanel Text="Slow queries" Icon="@Icons.Material.Filled.ErrorOutline">
+                <MudTable Items="State.FilteredSlowQueries" Dense="true" Hover="true" aria-label="Slow queries">
+                    <HeaderContent>
+                        <MudTh>Query pattern</MudTh>
+                        <MudTh>Layer</MudTh>
+                        <MudTh>Count</MudTh>
+                        <MudTh>P95</MudTh>
+                        <MudTh>Max</MudTh>
+                        <MudTh>Last seen</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Query pattern">
+                            <MudText Typo="Typo.body2">@context.QueryPattern</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Endpoint</MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Layer">@context.ServiceName / @context.LayerName / @context.Protocol</MudTd>
+                        <MudTd DataLabel="Count">@FormatNumber(context.Count)</MudTd>
+                        <MudTd DataLabel="P95">@FormatLatency(context.P95DurationMs)</MudTd>
+                        <MudTd DataLabel="Max">@FormatLatency(context.MaxDurationMs)</MudTd>
+                        <MudTd DataLabel="Last seen">
+                            <MudText Typo="Typo.body2">@context.LastSeen.ToString("u", CultureInfo.InvariantCulture)</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ExampleCorrelationId</MudText>
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudTabPanel>
+            <MudTabPanel Text="Users" Icon="@Icons.Material.Filled.People">
+                <MudTable Items="State.FilteredUserActivity" Dense="true" Hover="true" aria-label="User activity">
+                    <HeaderContent>
+                        <MudTh>User</MudTh>
+                        <MudTh>Tenant</MudTh>
+                        <MudTh>Top layer</MudTh>
+                        <MudTh>Queries</MudTh>
+                        <MudTh>Layers</MudTh>
+                        <MudTh>P95</MudTh>
+                        <MudTh>Last seen</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="User">
+                            <MudText Typo="Typo.body2">@context.DisplayName</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.PrincipalId</MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Tenant">@context.Tenant</MudTd>
+                        <MudTd DataLabel="Top layer">@context.TopService / @context.TopLayer / @context.MostUsedProtocol</MudTd>
+                        <MudTd DataLabel="Queries">@FormatNumber(context.QueryCount)</MudTd>
+                        <MudTd DataLabel="Layers">@FormatNumber(context.DistinctLayers)</MudTd>
+                        <MudTd DataLabel="P95">@FormatLatency(context.P95LatencyMs)</MudTd>
+                        <MudTd DataLabel="Last seen">@context.LastSeen.ToString("u", CultureInfo.InvariantCulture)</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudTabPanel>
+        </MudTabs>
+    }
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += OnStateChanged;
+        Telemetry.PageNavigated("/operator/analytics", principalId: null);
+        await State.LoadAsync();
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= OnStateChanged;
+    }
+
+    private void OnStateChanged() => _ = InvokeAsync(StateHasChanged);
+
+    private Task RefreshAsync() => State.LoadAsync();
+
+    private async Task OnRangeChanged(string rangeKey)
+    {
+        State.SetRange(rangeKey);
+        await State.LoadAsync();
+    }
+
+    private void OnServiceFilterChanged(string serviceName) => State.SetServiceFilter(serviceName);
+
+    private void OnLayerFilterChanged(string layerName) => State.SetLayerFilter(layerName);
+
+    private void OnProtocolFilterChanged(string protocol) => State.SetProtocolFilter(protocol);
+
+    private async Task ExportCsvAsync() => await DownloadAsync(State.ExportCsv());
+
+    private async Task ExportPdfAsync() => await DownloadAsync(State.ExportPdf());
+
+    private async Task DownloadAsync(UsageAnalyticsExportPayload payload)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("usageAnalytics.downloadFile", payload.FileName, payload.MimeType, payload.Content);
+        }
+        catch
+        {
+            // Tests and pre-render do not require the browser download helper.
+        }
+    }
+
+    private static Color StatusColor(UsageAnalyticsStatus status) => status switch
+    {
+        UsageAnalyticsStatus.Loading => Color.Info,
+        UsageAnalyticsStatus.Ready => Color.Success,
+        UsageAnalyticsStatus.Error => Color.Error,
+        _ => Color.Default,
+    };
+
+    private static string OptionLabel(string value)
+        => string.Equals(value, UsageAnalyticsState.AllFilter, StringComparison.OrdinalIgnoreCase) ? "All" : value;
+
+    private static string FormatNumber(long value)
+        => value.ToString("N0", CultureInfo.InvariantCulture);
+
+    private static string FormatNumber(int value)
+        => value.ToString("N0", CultureInfo.InvariantCulture);
+
+    private static string FormatDecimal(double value)
+        => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    private static string FormatLatency(double value)
+        => $"{value.ToString("0.#", CultureInfo.InvariantCulture)} ms";
+
+    private static string FormatBytes(long bytes)
+        => UsageAnalyticsReportExporter.FormatBytes(bytes);
+
+    private static string FormatPercent(double ratio)
+        => UsageAnalyticsReportExporter.FormatPercent(ratio);
+
+    private static string BarStyle(double percent)
+        => $"height:{Math.Clamp(percent, 4d, 100d).ToString("0.#", CultureInfo.InvariantCulture)}%";
+
+    private static string BucketTitle(QueryThroughputBucket bucket)
+        => $"{bucket.Timestamp:u}: {bucket.QueriesPerSecond.ToString("0.##", CultureInfo.InvariantCulture)} QPS";
+
+    private static string RangeWindow(UsageAnalyticsReport report)
+        => $"{report.RangeStart.ToString("MM-dd HH:mm", CultureInfo.InvariantCulture)} to {report.RangeEnd.ToString("MM-dd HH:mm", CultureInfo.InvariantCulture)}";
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -11,6 +11,7 @@ using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.SpatialSql;
 using Honua.Admin.Services.SpecWorkspace;
+using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -47,6 +48,11 @@ builder.Services.AddScoped<AnnotationWorkspaceState>();
 // plane APIs across connection discovery, publish intent, protocol state, and
 // deployment preflight.
 builder.Services.AddScoped<PublishingWorkspaceState>();
+
+// Usage analytics dashboard (issue #2) starts with an in-memory product
+// analytics read model while durable server-side aggregation is defined.
+builder.Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
+builder.Services.AddScoped<UsageAnalyticsState>();
 
 // Admin client + auth wiring (ticket #28 — restored from PR #17 onto the post-#27 shell).
 builder.Services.AddSingleton<AdminAuthStateProvider>();

--- a/src/Honua.Admin/Services/UsageAnalytics/IUsageAnalyticsClient.cs
+++ b/src/Honua.Admin/Services/UsageAnalytics/IUsageAnalyticsClient.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.UsageAnalytics;
+
+namespace Honua.Admin.Services.UsageAnalytics;
+
+/// <summary>
+/// Product-analytics read model for the experimental reporting dashboard.
+/// S1 ships with <see cref="StubUsageAnalyticsClient"/> so the admin workflow is
+/// usable while the durable server-side aggregation API is being defined.
+/// </summary>
+public interface IUsageAnalyticsClient
+{
+    Task<UsageAnalyticsReport> GetReportAsync(UsageAnalyticsQuery query, CancellationToken cancellationToken);
+}

--- a/src/Honua.Admin/Services/UsageAnalytics/StubUsageAnalyticsClient.cs
+++ b/src/Honua.Admin/Services/UsageAnalytics/StubUsageAnalyticsClient.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.UsageAnalytics;
+
+namespace Honua.Admin.Services.UsageAnalytics;
+
+public sealed class StubUsageAnalyticsClient : IUsageAnalyticsClient
+{
+    private static readonly DateTimeOffset BaselineEnd = DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture);
+
+    public Task<UsageAnalyticsReport> GetReportAsync(UsageAnalyticsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var range = UsageAnalyticsRanges.Resolve(query.RangeKey);
+        var rangeEnd = BaselineEnd;
+        var rangeStart = rangeEnd - range.Duration;
+        var scale = range.Duration.TotalHours / 24d;
+
+        var series = BuildSeries(rangeStart, rangeEnd, scale);
+        var popularLayers = Scale(BuildPopularLayers(), scale).ToArray();
+        var endpoints = Scale(BuildEndpoints(), scale).ToArray();
+        var slowQueries = Scale(BuildSlowQueries(rangeEnd), scale).ToArray();
+        var storage = BuildStorage(scale).ToArray();
+        var users = Scale(BuildUsers(rangeEnd), scale).ToArray();
+
+        var report = new UsageAnalyticsReport
+        {
+            GeneratedAt = rangeEnd,
+            RangeStart = rangeStart,
+            RangeEnd = rangeEnd,
+            RangeLabel = range.Label,
+            DataSource = "preview-analytics",
+            QuerySeries = series,
+            PopularLayers = popularLayers,
+            PopularEndpoints = endpoints,
+            SlowQueries = slowQueries,
+            StorageGrowth = storage,
+            UserActivity = users,
+            Totals = new UsageAnalyticsTotals
+            {
+                TotalQueries = popularLayers.Sum(layer => layer.QueryCount),
+                QueriesPerSecond = Math.Round(series.GroupBy(point => point.Timestamp).Average(group => group.Sum(point => point.QueriesPerSecond)), 2),
+                UniqueUsers = users.Count(user => user.QueryCount > 0),
+                SlowQueryCount = slowQueries.Sum(query => query.Count),
+                P95LatencyMs = Math.Round(popularLayers.Max(layer => layer.P95LatencyMs), 1),
+                StorageBytes = storage.Sum(item => item.CurrentBytes),
+                StorageDeltaBytes = storage.Sum(item => item.DeltaBytes),
+            },
+        };
+
+        return Task.FromResult(report);
+    }
+
+    private static IReadOnlyList<QueryThroughputPoint> BuildSeries(DateTimeOffset rangeStart, DateTimeOffset rangeEnd, double scale)
+    {
+        var buckets = 12;
+        var step = TimeSpan.FromTicks((rangeEnd - rangeStart).Ticks / buckets);
+        var dimensions = new[]
+        {
+            new SeriesSeed("default", "Parcels", "FeatureServer", 9.2, 84, 3),
+            new SeriesSeed("default", "Parcels", "OGC Features", 4.7, 112, 2),
+            new SeriesSeed("imagery", "Orthophoto mosaic", "ImageServer", 3.1, 188, 4),
+            new SeriesSeed("planning", "Zoning districts", "MapServer", 1.8, 146, 1),
+            new SeriesSeed("basemap", "Address points", "OData", 1.2, 96, 1),
+        };
+
+        var points = new List<QueryThroughputPoint>(buckets * dimensions.Length);
+        for (var i = 0; i < buckets; i++)
+        {
+            var timestamp = rangeStart + TimeSpan.FromTicks(step.Ticks * (i + 1));
+            var rhythm = 0.82 + (Math.Sin(i / 1.8) + 1d) * 0.16;
+            var peak = i is >= 5 and <= 8 ? 1.22 : 1d;
+            foreach (var seed in dimensions)
+            {
+                var qps = seed.BaseQps * rhythm * peak * Math.Clamp(scale, 0.35, 8d);
+                points.Add(new QueryThroughputPoint
+                {
+                    Timestamp = timestamp,
+                    ServiceName = seed.ServiceName,
+                    LayerName = seed.LayerName,
+                    Protocol = seed.Protocol,
+                    QueryCount = Math.Max(1, (long)Math.Round(qps * step.TotalSeconds)),
+                    QueriesPerSecond = Math.Round(qps, 2),
+                    AverageLatencyMs = Math.Round(seed.AverageLatencyMs * (1 + (i % 4) * 0.04), 1),
+                    SlowQueryCount = Math.Max(0, (int)Math.Round(seed.BaseSlowCount * rhythm * Math.Max(1, scale / 2d))),
+                });
+            }
+        }
+
+        return points;
+    }
+
+    private static IEnumerable<PopularLayerMetric> BuildPopularLayers()
+    {
+        yield return new PopularLayerMetric { ServiceName = "default", LayerName = "Parcels", Protocol = "FeatureServer", QueryCount = 796_000, QueriesPerSecond = 9.21, UniqueUsers = 82, P95LatencyMs = 214, ErrorRate = 0.003 };
+        yield return new PopularLayerMetric { ServiceName = "default", LayerName = "Parcels", Protocol = "OGC Features", QueryCount = 405_000, QueriesPerSecond = 4.69, UniqueUsers = 44, P95LatencyMs = 248, ErrorRate = 0.006 };
+        yield return new PopularLayerMetric { ServiceName = "imagery", LayerName = "Orthophoto mosaic", Protocol = "ImageServer", QueryCount = 268_000, QueriesPerSecond = 3.10, UniqueUsers = 27, P95LatencyMs = 436, ErrorRate = 0.011 };
+        yield return new PopularLayerMetric { ServiceName = "planning", LayerName = "Zoning districts", Protocol = "MapServer", QueryCount = 156_000, QueriesPerSecond = 1.81, UniqueUsers = 19, P95LatencyMs = 326, ErrorRate = 0.004 };
+        yield return new PopularLayerMetric { ServiceName = "basemap", LayerName = "Address points", Protocol = "OData", QueryCount = 104_000, QueriesPerSecond = 1.20, UniqueUsers = 13, P95LatencyMs = 184, ErrorRate = 0.001 };
+    }
+
+    private static IEnumerable<EndpointUsageMetric> BuildEndpoints()
+    {
+        yield return new EndpointUsageMetric { ServiceName = "default", LayerName = "Parcels", Path = "/rest/services/default/FeatureServer/101/query", Protocol = "FeatureServer", QueryCount = 668_000, QueriesPerSecond = 7.73, P95LatencyMs = 220, ErrorRate = 0.002 };
+        yield return new EndpointUsageMetric { ServiceName = "default", LayerName = "Parcels", Path = "/ogc/features/collections/parcels/items", Protocol = "OGC Features", QueryCount = 405_000, QueriesPerSecond = 4.69, P95LatencyMs = 248, ErrorRate = 0.006 };
+        yield return new EndpointUsageMetric { ServiceName = "imagery", LayerName = "Orthophoto mosaic", Path = "/rest/services/imagery/ImageServer/query", Protocol = "ImageServer", QueryCount = 198_000, QueriesPerSecond = 2.29, P95LatencyMs = 436, ErrorRate = 0.011 };
+        yield return new EndpointUsageMetric { ServiceName = "planning", LayerName = "Zoning districts", Path = "/rest/services/planning/MapServer/export", Protocol = "MapServer", QueryCount = 131_000, QueriesPerSecond = 1.52, P95LatencyMs = 326, ErrorRate = 0.004 };
+        yield return new EndpointUsageMetric { ServiceName = "basemap", LayerName = "Address points", Path = "/odata/basemap/AddressPoints", Protocol = "OData", QueryCount = 104_000, QueriesPerSecond = 1.20, P95LatencyMs = 184, ErrorRate = 0.001 };
+    }
+
+    private static IEnumerable<SlowQueryMetric> BuildSlowQueries(DateTimeOffset rangeEnd)
+    {
+        yield return new SlowQueryMetric
+        {
+            ServiceName = "imagery",
+            LayerName = "Orthophoto mosaic",
+            Protocol = "ImageServer",
+            Endpoint = "/rest/services/imagery/ImageServer/query",
+            QueryPattern = "large mosaic query without bbox",
+            Count = 47,
+            P95DurationMs = 2_840,
+            MaxDurationMs = 5_904,
+            LastSeen = rangeEnd.AddMinutes(-17),
+            ExampleCorrelationId = "corr-img-7041",
+        };
+        yield return new SlowQueryMetric
+        {
+            ServiceName = "default",
+            LayerName = "Parcels",
+            Protocol = "OGC Features",
+            Endpoint = "/ogc/features/collections/parcels/items",
+            QueryPattern = "contains filter over unbounded geometry",
+            Count = 31,
+            P95DurationMs = 1_720,
+            MaxDurationMs = 3_210,
+            LastSeen = rangeEnd.AddMinutes(-43),
+            ExampleCorrelationId = "corr-ogc-1882",
+        };
+        yield return new SlowQueryMetric
+        {
+            ServiceName = "planning",
+            LayerName = "Zoning districts",
+            Protocol = "MapServer",
+            Endpoint = "/rest/services/planning/MapServer/export",
+            QueryPattern = "high-DPI export over full extent",
+            Count = 18,
+            P95DurationMs = 1_420,
+            MaxDurationMs = 2_160,
+            LastSeen = rangeEnd.AddHours(-3),
+            ExampleCorrelationId = "corr-map-5097",
+        };
+    }
+
+    private static IEnumerable<StorageGrowthMetric> BuildStorage(double scale)
+    {
+        yield return new StorageGrowthMetric
+        {
+            Tenant = "enterprise",
+            ServiceName = "default",
+            CurrentBytes = 824_633_720_832,
+            DeltaBytes = (long)(19_327_352_832 * scale),
+            GrowthPercent = 2.4 * scale,
+            LayerCount = 9,
+            LayerNames = ["Parcels"],
+            Protocols = ["FeatureServer", "OGC Features"],
+        };
+        yield return new StorageGrowthMetric
+        {
+            Tenant = "enterprise",
+            ServiceName = "imagery",
+            CurrentBytes = 1_942_337_060_864,
+            DeltaBytes = (long)(54_706_470_912 * scale),
+            GrowthPercent = 2.9 * scale,
+            LayerCount = 3,
+            LayerNames = ["Orthophoto mosaic"],
+            Protocols = ["ImageServer"],
+        };
+        yield return new StorageGrowthMetric
+        {
+            Tenant = "planning",
+            ServiceName = "planning",
+            CurrentBytes = 218_405_060_096,
+            DeltaBytes = (long)(4_831_838_208 * scale),
+            GrowthPercent = 2.3 * scale,
+            LayerCount = 5,
+            LayerNames = ["Zoning districts"],
+            Protocols = ["MapServer"],
+        };
+    }
+
+    private static IEnumerable<UserActivityMetric> BuildUsers(DateTimeOffset rangeEnd)
+    {
+        yield return new UserActivityMetric { PrincipalId = "aad:1738", DisplayName = "Kai Ito", Tenant = "enterprise", TopService = "default", TopLayer = "Parcels", MostUsedProtocol = "FeatureServer", QueryCount = 142_000, DistinctLayers = 8, P95LatencyMs = 221, LastSeen = rangeEnd.AddMinutes(-4) };
+        yield return new UserActivityMetric { PrincipalId = "aad:9914", DisplayName = "Malia Santos", Tenant = "enterprise", TopService = "imagery", TopLayer = "Orthophoto mosaic", MostUsedProtocol = "ImageServer", QueryCount = 88_000, DistinctLayers = 4, P95LatencyMs = 462, LastSeen = rangeEnd.AddMinutes(-28) };
+        yield return new UserActivityMetric { PrincipalId = "svc:tiles-worker", DisplayName = "Tiles worker", Tenant = "enterprise", TopService = "default", TopLayer = "Parcels", MostUsedProtocol = "OGC Features", QueryCount = 72_000, DistinctLayers = 2, P95LatencyMs = 248, LastSeen = rangeEnd.AddMinutes(-11) };
+        yield return new UserActivityMetric { PrincipalId = "aad:4417", DisplayName = "Noel Park", Tenant = "planning", TopService = "planning", TopLayer = "Zoning districts", MostUsedProtocol = "MapServer", QueryCount = 39_000, DistinctLayers = 5, P95LatencyMs = 338, LastSeen = rangeEnd.AddHours(-1) };
+    }
+
+    private static IEnumerable<PopularLayerMetric> Scale(IEnumerable<PopularLayerMetric> metrics, double scale)
+        => metrics.Select(metric => metric with
+        {
+            QueryCount = Math.Max(1, (long)Math.Round(metric.QueryCount * scale)),
+            QueriesPerSecond = Math.Round(metric.QueriesPerSecond * Math.Clamp(scale, 0.35, 8d), 2),
+            UniqueUsers = Math.Max(1, (int)Math.Round(metric.UniqueUsers * Math.Clamp(scale, 0.5, 4d))),
+        });
+
+    private static IEnumerable<EndpointUsageMetric> Scale(IEnumerable<EndpointUsageMetric> metrics, double scale)
+        => metrics.Select(metric => metric with
+        {
+            QueryCount = Math.Max(1, (long)Math.Round(metric.QueryCount * scale)),
+            QueriesPerSecond = Math.Round(metric.QueriesPerSecond * Math.Clamp(scale, 0.35, 8d), 2),
+        });
+
+    private static IEnumerable<SlowQueryMetric> Scale(IEnumerable<SlowQueryMetric> metrics, double scale)
+        => metrics.Select(metric => metric with { Count = Math.Max(1, (int)Math.Round(metric.Count * scale)) });
+
+    private static IEnumerable<UserActivityMetric> Scale(IEnumerable<UserActivityMetric> metrics, double scale)
+        => metrics.Select(metric => metric with { QueryCount = Math.Max(1, (long)Math.Round(metric.QueryCount * scale)) });
+
+    private sealed record SeriesSeed(
+        string ServiceName,
+        string LayerName,
+        string Protocol,
+        double BaseQps,
+        double AverageLatencyMs,
+        int BaseSlowCount);
+}

--- a/src/Honua.Admin/Services/UsageAnalytics/UsageAnalyticsReportExporter.cs
+++ b/src/Honua.Admin/Services/UsageAnalytics/UsageAnalyticsReportExporter.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Honua.Admin.Models.UsageAnalytics;
+
+namespace Honua.Admin.Services.UsageAnalytics;
+
+public static class UsageAnalyticsReportExporter
+{
+    public static UsageAnalyticsExportPayload ToCsv(UsageAnalyticsExportView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        var builder = new StringBuilder();
+        AppendRow(builder, "Honua usage analytics", view.Report.RangeLabel);
+        AppendRow(builder, "Generated", view.Report.GeneratedAt.ToString("u", CultureInfo.InvariantCulture));
+        AppendRow(builder, "Filters", view.FilterLabel);
+        builder.AppendLine();
+
+        AppendRow(builder, "Summary");
+        AppendRow(builder, "Total queries", view.Totals.TotalQueries.ToString(CultureInfo.InvariantCulture));
+        AppendRow(builder, "Average QPS", view.Totals.QueriesPerSecond.ToString("0.##", CultureInfo.InvariantCulture));
+        AppendRow(builder, "Unique users", view.Totals.UniqueUsers.ToString(CultureInfo.InvariantCulture));
+        AppendRow(builder, "Slow queries", view.Totals.SlowQueryCount.ToString(CultureInfo.InvariantCulture));
+        AppendRow(builder, "P95 latency ms", view.Totals.P95LatencyMs.ToString("0.#", CultureInfo.InvariantCulture));
+        AppendRow(builder, "Storage", FormatBytes(view.Totals.StorageBytes));
+        AppendRow(builder, "Storage growth", FormatBytes(view.Totals.StorageDeltaBytes));
+        builder.AppendLine();
+
+        AppendRow(builder, "Popular layers");
+        AppendRow(builder, "Service", "Layer", "Protocol", "Queries", "QPS", "Users", "P95 ms", "Error rate");
+        foreach (var layer in view.PopularLayers)
+        {
+            AppendRow(
+                builder,
+                layer.ServiceName,
+                layer.LayerName,
+                layer.Protocol,
+                layer.QueryCount.ToString(CultureInfo.InvariantCulture),
+                layer.QueriesPerSecond.ToString("0.##", CultureInfo.InvariantCulture),
+                layer.UniqueUsers.ToString(CultureInfo.InvariantCulture),
+                layer.P95LatencyMs.ToString("0.#", CultureInfo.InvariantCulture),
+                FormatPercent(layer.ErrorRate));
+        }
+        builder.AppendLine();
+
+        AppendRow(builder, "Popular endpoints");
+        AppendRow(builder, "Service", "Layer", "Path", "Protocol", "Queries", "QPS", "P95 ms", "Error rate");
+        foreach (var endpoint in view.PopularEndpoints)
+        {
+            AppendRow(
+                builder,
+                endpoint.ServiceName,
+                endpoint.LayerName,
+                endpoint.Path,
+                endpoint.Protocol,
+                endpoint.QueryCount.ToString(CultureInfo.InvariantCulture),
+                endpoint.QueriesPerSecond.ToString("0.##", CultureInfo.InvariantCulture),
+                endpoint.P95LatencyMs.ToString("0.#", CultureInfo.InvariantCulture),
+                FormatPercent(endpoint.ErrorRate));
+        }
+        builder.AppendLine();
+
+        AppendRow(builder, "Slow queries");
+        AppendRow(builder, "Service", "Layer", "Protocol", "Endpoint", "Pattern", "Count", "P95 ms", "Max ms", "Last seen", "Correlation");
+        foreach (var query in view.SlowQueries)
+        {
+            AppendRow(
+                builder,
+                query.ServiceName,
+                query.LayerName,
+                query.Protocol,
+                query.Endpoint,
+                query.QueryPattern,
+                query.Count.ToString(CultureInfo.InvariantCulture),
+                query.P95DurationMs.ToString("0.#", CultureInfo.InvariantCulture),
+                query.MaxDurationMs.ToString("0.#", CultureInfo.InvariantCulture),
+                query.LastSeen.ToString("u", CultureInfo.InvariantCulture),
+                query.ExampleCorrelationId);
+        }
+        builder.AppendLine();
+
+        AppendRow(builder, "Storage growth");
+        AppendRow(builder, "Tenant", "Service", "Current", "Delta", "Growth", "Layers");
+        foreach (var storage in view.StorageGrowth)
+        {
+            AppendRow(
+                builder,
+                storage.Tenant,
+                storage.ServiceName,
+                FormatBytes(storage.CurrentBytes),
+                FormatBytes(storage.DeltaBytes),
+                FormatPercent(storage.GrowthPercent / 100d),
+                storage.LayerCount.ToString(CultureInfo.InvariantCulture));
+        }
+        builder.AppendLine();
+
+        AppendRow(builder, "User activity");
+        AppendRow(builder, "Principal", "Display name", "Tenant", "Service", "Layer", "Protocol", "Queries", "Distinct layers", "P95 ms", "Last seen");
+        foreach (var user in view.UserActivity)
+        {
+            AppendRow(
+                builder,
+                user.PrincipalId,
+                user.DisplayName,
+                user.Tenant,
+                user.TopService,
+                user.TopLayer,
+                user.MostUsedProtocol,
+                user.QueryCount.ToString(CultureInfo.InvariantCulture),
+                user.DistinctLayers.ToString(CultureInfo.InvariantCulture),
+                user.P95LatencyMs.ToString("0.#", CultureInfo.InvariantCulture),
+                user.LastSeen.ToString("u", CultureInfo.InvariantCulture));
+        }
+
+        return new UsageAnalyticsExportPayload(
+            $"honua-usage-analytics-{view.Report.RangeEnd:yyyyMMddHHmm}.csv",
+            "text/csv",
+            builder.ToString());
+    }
+
+    public static UsageAnalyticsExportPayload ToPdf(UsageAnalyticsExportView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        var lines = new List<string>
+        {
+            "Honua Usage Analytics",
+            $"Range: {view.Report.RangeLabel}",
+            $"Generated: {view.Report.GeneratedAt:u}",
+            $"Filters: {view.FilterLabel}",
+            string.Empty,
+            $"Total queries: {view.Totals.TotalQueries:N0}",
+            $"Average QPS: {view.Totals.QueriesPerSecond:0.##}",
+            $"Unique users: {view.Totals.UniqueUsers:N0}",
+            $"Slow queries: {view.Totals.SlowQueryCount:N0}",
+            $"P95 latency: {view.Totals.P95LatencyMs:0.#} ms",
+            $"Storage: {FormatBytes(view.Totals.StorageBytes)} ({FormatBytes(view.Totals.StorageDeltaBytes)} growth)",
+            string.Empty,
+            "Top layers",
+        };
+
+        lines.AddRange(view.PopularLayers.Take(8).Select(layer =>
+            $"{layer.ServiceName}/{layer.LayerName} {layer.Protocol}: {layer.QueryCount:N0} queries, {layer.P95LatencyMs:0.#} ms p95"));
+
+        lines.Add(string.Empty);
+        lines.Add("Slow queries");
+        lines.AddRange(view.SlowQueries.Take(6).Select(query =>
+            $"{query.ServiceName}/{query.LayerName} {query.Protocol}: {query.Count:N0} hits, {query.P95DurationMs:0.#} ms p95"));
+
+        lines.Add(string.Empty);
+        lines.Add("User activity");
+        lines.AddRange(view.UserActivity.Take(6).Select(user =>
+            $"{user.DisplayName} ({user.PrincipalId}): {user.QueryCount:N0} queries, {user.DistinctLayers:N0} layers"));
+
+        return new UsageAnalyticsExportPayload(
+            $"honua-usage-analytics-{view.Report.RangeEnd:yyyyMMddHHmm}.pdf",
+            "application/pdf",
+            BuildPdf(lines));
+    }
+
+    public static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB", "PB"];
+        double value = bytes;
+        var index = 0;
+        while (Math.Abs(value) >= 1024 && index < units.Length - 1)
+        {
+            value /= 1024;
+            index++;
+        }
+
+        return $"{value:0.#} {units[index]}";
+    }
+
+    public static string FormatPercent(double ratio)
+        => $"{ratio * 100:0.##}%";
+
+    private static void AppendRow(StringBuilder builder, params string[] values)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append(EscapeCsv(values[i]));
+        }
+
+        builder.AppendLine();
+    }
+
+    private static string EscapeCsv(string value)
+    {
+        value = NeutralizeSpreadsheetFormula(value);
+
+        if (!value.Contains('"', StringComparison.Ordinal) &&
+            !value.Contains(',', StringComparison.Ordinal) &&
+            !value.Contains('\n', StringComparison.Ordinal) &&
+            !value.Contains('\r', StringComparison.Ordinal))
+        {
+            return value;
+        }
+
+        return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    private static string NeutralizeSpreadsheetFormula(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var trimmed = value.TrimStart();
+        if (trimmed.Length == 0)
+        {
+            return value;
+        }
+
+        return trimmed[0] is '=' or '+' or '-' or '@'
+            ? $"'{value}"
+            : value;
+    }
+
+    private static string BuildPdf(IReadOnlyList<string> lines)
+    {
+        var text = new StringBuilder();
+        text.AppendLine("BT");
+        text.AppendLine("/F1 11 Tf");
+        text.AppendLine("50 760 Td");
+        text.AppendLine("14 TL");
+        foreach (var line in lines.Take(44))
+        {
+            text.Append(EncodePdfText(line)).AppendLine(" Tj");
+            text.AppendLine("T*");
+        }
+
+        text.AppendLine("ET");
+        var content = text.ToString();
+
+        var toUnicode = BuildToUnicodeMap(lines);
+        var objects = new[]
+        {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type0 /BaseFont /ArialUnicodeMS /Encoding /Identity-H /DescendantFonts [6 0 R] /ToUnicode 8 0 R >>",
+            $"<< /Length {Encoding.ASCII.GetByteCount(content)} >>\nstream\n{content}endstream",
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /ArialUnicodeMS /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 7 0 R /CIDToGIDMap /Identity /DW 600 >>",
+            "<< /Type /FontDescriptor /FontName /ArialUnicodeMS /Flags 32 /FontBBox [-1000 -300 2000 1100] /ItalicAngle 0 /Ascent 1000 /Descent -300 /CapHeight 700 /StemV 80 >>",
+            $"<< /Length {Encoding.ASCII.GetByteCount(toUnicode)} >>\nstream\n{toUnicode}endstream",
+        };
+
+        var pdf = new StringBuilder("%PDF-1.4\n");
+        var offsets = new List<int> { 0 };
+        foreach (var (obj, index) in objects.Select((obj, index) => (obj, index)))
+        {
+            offsets.Add(Encoding.ASCII.GetByteCount(pdf.ToString()));
+            pdf.Append(index + 1)
+                .Append(" 0 obj\n")
+                .Append(obj)
+                .Append("\nendobj\n");
+        }
+
+        var xrefOffset = Encoding.ASCII.GetByteCount(pdf.ToString());
+        pdf.Append("xref\n")
+            .Append("0 ")
+            .Append(objects.Length + 1)
+            .Append('\n')
+            .Append("0000000000 65535 f \n");
+
+        foreach (var offset in offsets.Skip(1))
+        {
+            pdf.Append(offset.ToString("D10", CultureInfo.InvariantCulture)).Append(" 00000 n \n");
+        }
+
+        pdf.Append("trailer\n")
+            .Append("<< /Size ")
+            .Append(objects.Length + 1)
+            .Append(" /Root 1 0 R >>\n")
+            .Append("startxref\n")
+            .Append(xrefOffset)
+            .Append("\n%%EOF\n");
+
+        return pdf.ToString();
+    }
+
+    private static string EncodePdfText(string value)
+    {
+        var bytes = Encoding.BigEndianUnicode.GetBytes(value);
+        var encoded = new StringBuilder(2 + bytes.Length * 2);
+        encoded.Append('<');
+        foreach (var valueByte in bytes)
+        {
+            encoded.Append(valueByte.ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        encoded.Append('>');
+        return encoded.ToString();
+    }
+
+    private static string BuildToUnicodeMap(IReadOnlyList<string> lines)
+    {
+        var chars = lines
+            .SelectMany(line => line)
+            .Distinct()
+            .OrderBy(ch => ch)
+            .ToArray();
+
+        var builder = new StringBuilder();
+        builder.AppendLine("/CIDInit /ProcSet findresource begin");
+        builder.AppendLine("12 dict begin");
+        builder.AppendLine("begincmap");
+        builder.AppendLine("/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def");
+        builder.AppendLine("/CMapName /HonuaUsageAnalytics def");
+        builder.AppendLine("/CMapType 2 def");
+        builder.AppendLine("1 begincodespacerange");
+        builder.AppendLine("<0000> <FFFF>");
+        builder.AppendLine("endcodespacerange");
+
+        foreach (var chunk in chars.Chunk(100))
+        {
+            builder.Append(chunk.Length.ToString(CultureInfo.InvariantCulture)).AppendLine(" beginbfchar");
+            foreach (var ch in chunk)
+            {
+                var code = ((int)ch).ToString("X4", CultureInfo.InvariantCulture);
+                builder.Append('<').Append(code).Append("> <").Append(code).AppendLine(">");
+            }
+
+            builder.AppendLine("endbfchar");
+        }
+
+        builder.AppendLine("endcmap");
+        builder.AppendLine("CMapName currentdict /CMap defineresource pop");
+        builder.AppendLine("end");
+        builder.AppendLine("end");
+        return builder.ToString();
+    }
+}
+
+public sealed record UsageAnalyticsExportView(
+    UsageAnalyticsReport Report,
+    UsageAnalyticsTotals Totals,
+    IReadOnlyList<PopularLayerMetric> PopularLayers,
+    IReadOnlyList<EndpointUsageMetric> PopularEndpoints,
+    IReadOnlyList<SlowQueryMetric> SlowQueries,
+    IReadOnlyList<StorageGrowthMetric> StorageGrowth,
+    IReadOnlyList<UserActivityMetric> UserActivity,
+    string FilterLabel);

--- a/src/Honua.Admin/Services/UsageAnalytics/UsageAnalyticsState.cs
+++ b/src/Honua.Admin/Services/UsageAnalytics/UsageAnalyticsState.cs
@@ -1,0 +1,425 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.UsageAnalytics;
+
+namespace Honua.Admin.Services.UsageAnalytics;
+
+public enum UsageAnalyticsStatus
+{
+    Idle,
+    Loading,
+    Ready,
+    Error
+}
+
+public sealed record UsageAnalyticsRangeOption(string Key, string Label, TimeSpan Duration);
+
+public sealed record QueryThroughputBucket(
+    DateTimeOffset Timestamp,
+    long QueryCount,
+    double QueriesPerSecond,
+    double AverageLatencyMs,
+    int SlowQueryCount,
+    double PercentOfPeak);
+
+public sealed record QueryThroughputAggregate(
+    string ServiceName,
+    string LayerName,
+    string Protocol,
+    long QueryCount,
+    double AverageQueriesPerSecond,
+    double AverageLatencyMs,
+    int SlowQueryCount);
+
+public static class UsageAnalyticsRanges
+{
+    public const string LastHour = "1h";
+    public const string Last24Hours = "24h";
+    public const string Last7Days = "7d";
+    public const string Last30Days = "30d";
+
+    public static IReadOnlyList<UsageAnalyticsRangeOption> Options { get; } =
+    [
+        new(LastHour, "1 hour", TimeSpan.FromHours(1)),
+        new(Last24Hours, "24 hours", TimeSpan.FromHours(24)),
+        new(Last7Days, "7 days", TimeSpan.FromDays(7)),
+        new(Last30Days, "30 days", TimeSpan.FromDays(30)),
+    ];
+
+    public static UsageAnalyticsRangeOption Resolve(string? key)
+        => Options.FirstOrDefault(option => string.Equals(option.Key, key, StringComparison.OrdinalIgnoreCase))
+            ?? Options[1];
+}
+
+public sealed class UsageAnalyticsState
+{
+    public const string AllFilter = "\u001Fhonua-all";
+
+    private readonly IUsageAnalyticsClient _client;
+    private int _loadVersion;
+
+    public UsageAnalyticsState(IUsageAnalyticsClient client)
+    {
+        _client = client;
+    }
+
+    public UsageAnalyticsStatus Status { get; private set; } = UsageAnalyticsStatus.Idle;
+
+    public string RangeKey { get; private set; } = UsageAnalyticsRanges.Last24Hours;
+
+    public string ServiceFilter { get; private set; } = AllFilter;
+
+    public string LayerFilter { get; private set; } = AllFilter;
+
+    public string ProtocolFilter { get; private set; } = AllFilter;
+
+    public string? LastError { get; private set; }
+
+    public UsageAnalyticsReport? Report { get; private set; }
+
+    public event Action? OnChanged;
+
+    public bool IsLoading => Status == UsageAnalyticsStatus.Loading;
+
+    public UsageAnalyticsTotals FilteredTotals
+    {
+        get
+        {
+            if (Report is null)
+            {
+                return new UsageAnalyticsTotals();
+            }
+
+            var buckets = ThroughputBuckets;
+            var layers = FilteredPopularLayers;
+            var storage = FilteredStorageGrowth;
+            var users = FilteredUserActivity;
+            var slowQueries = FilteredSlowQueries;
+
+            return new UsageAnalyticsTotals
+            {
+                TotalQueries = layers.Count == 0
+                    ? ThroughputSeries.Sum(point => point.QueryCount)
+                    : layers.Sum(layer => layer.QueryCount),
+                QueriesPerSecond = buckets.Count == 0 ? 0 : Math.Round(buckets.Average(bucket => bucket.QueriesPerSecond), 2),
+                UniqueUsers = users.Count,
+                SlowQueryCount = slowQueries.Sum(query => query.Count),
+                P95LatencyMs = layers.Count == 0 ? 0 : Math.Round(layers.Max(layer => layer.P95LatencyMs), 1),
+                StorageBytes = storage.Sum(item => item.CurrentBytes),
+                StorageDeltaBytes = storage.Sum(item => item.DeltaBytes),
+            };
+        }
+    }
+
+    public IReadOnlyList<QueryThroughputPoint> ThroughputSeries
+        => Report?.QuerySeries.Where(Matches).ToArray() ?? Array.Empty<QueryThroughputPoint>();
+
+    public IReadOnlyList<QueryThroughputBucket> ThroughputBuckets
+    {
+        get
+        {
+            var buckets = ThroughputSeries
+                .GroupBy(point => point.Timestamp)
+                .OrderBy(group => group.Key)
+                .Select(group => new QueryThroughputBucket(
+                    group.Key,
+                    group.Sum(point => point.QueryCount),
+                    Math.Round(group.Sum(point => point.QueriesPerSecond), 2),
+                    Math.Round(group.Average(point => point.AverageLatencyMs), 1),
+                    group.Sum(point => point.SlowQueryCount),
+                    PercentOfPeak: 0))
+                .ToArray();
+
+            var peak = buckets.Length == 0 ? 0 : buckets.Max(bucket => bucket.QueriesPerSecond);
+            if (peak <= 0)
+            {
+                return buckets;
+            }
+
+            return buckets
+                .Select(bucket => bucket with { PercentOfPeak = Math.Round(bucket.QueriesPerSecond / peak * 100d, 1) })
+                .ToArray();
+        }
+    }
+
+    public IReadOnlyList<QueryThroughputAggregate> ThroughputRows
+        => ThroughputSeries
+            .GroupBy(point => new { point.ServiceName, point.LayerName, point.Protocol })
+            .Select(group => new QueryThroughputAggregate(
+                group.Key.ServiceName,
+                group.Key.LayerName,
+                group.Key.Protocol,
+                group.Sum(point => point.QueryCount),
+                Math.Round(group.Average(point => point.QueriesPerSecond), 2),
+                Math.Round(group.Average(point => point.AverageLatencyMs), 1),
+                group.Sum(point => point.SlowQueryCount)))
+            .OrderByDescending(row => row.QueryCount)
+            .ToArray();
+
+    public IReadOnlyList<PopularLayerMetric> FilteredPopularLayers
+        => Report?.PopularLayers
+            .Where(Matches)
+            .OrderByDescending(layer => layer.QueryCount)
+            .ToArray() ?? Array.Empty<PopularLayerMetric>();
+
+    public IReadOnlyList<EndpointUsageMetric> FilteredPopularEndpoints
+        => Report?.PopularEndpoints
+            .Where(Matches)
+            .OrderByDescending(endpoint => endpoint.QueryCount)
+            .ToArray() ?? Array.Empty<EndpointUsageMetric>();
+
+    public IReadOnlyList<SlowQueryMetric> FilteredSlowQueries
+        => Report?.SlowQueries
+            .Where(Matches)
+            .OrderByDescending(query => query.P95DurationMs)
+            .ToArray() ?? Array.Empty<SlowQueryMetric>();
+
+    public IReadOnlyList<StorageGrowthMetric> FilteredStorageGrowth
+        => Report?.StorageGrowth
+            .Where(Matches)
+            .OrderByDescending(storage => storage.DeltaBytes)
+            .ToArray() ?? Array.Empty<StorageGrowthMetric>();
+
+    public IReadOnlyList<UserActivityMetric> FilteredUserActivity
+        => Report?.UserActivity
+            .Where(Matches)
+            .OrderByDescending(user => user.QueryCount)
+            .ToArray() ?? Array.Empty<UserActivityMetric>();
+
+    public IReadOnlyList<string> ServiceOptions
+        => BuildOptions(Report is null
+            ? []
+            : Report.QuerySeries.Select(point => point.ServiceName)
+                .Concat(Report.StorageGrowth.Select(storage => storage.ServiceName))
+                .Concat(Report.UserActivity.Select(user => user.TopService)));
+
+    public IReadOnlyList<string> LayerOptions
+        => BuildOptions(Report is null
+            ? []
+            : Report.QuerySeries
+                .Where(point => MatchesFilter(ServiceFilter, point.ServiceName) && MatchesFilter(ProtocolFilter, point.Protocol))
+                .Select(point => point.LayerName)
+                .Concat(Report.UserActivity
+                    .Where(user => MatchesFilter(ServiceFilter, user.TopService) && MatchesFilter(ProtocolFilter, user.MostUsedProtocol))
+                    .Select(user => user.TopLayer)));
+
+    public IReadOnlyList<string> ProtocolOptions
+        => BuildOptions(Report is null
+            ? []
+            : Report.QuerySeries
+                .Where(point => MatchesFilter(ServiceFilter, point.ServiceName) && MatchesFilter(LayerFilter, point.LayerName))
+                .Select(point => point.Protocol)
+                .Concat(Report.PopularEndpoints
+                    .Where(endpoint => MatchesFilter(ServiceFilter, endpoint.ServiceName) && MatchesFilter(LayerFilter, endpoint.LayerName))
+                    .Select(endpoint => endpoint.Protocol))
+                .Concat(Report.UserActivity
+                    .Where(user => MatchesFilter(ServiceFilter, user.TopService) && MatchesFilter(LayerFilter, user.TopLayer))
+                    .Select(user => user.MostUsedProtocol)));
+
+    public string FilterLabel
+    {
+        get
+        {
+            var parts = new[]
+            {
+                FormatFilter("service", ServiceFilter),
+                FormatFilter("layer", LayerFilter),
+                FormatFilter("protocol", ProtocolFilter),
+            }.Where(part => part is not null);
+
+            var label = string.Join(", ", parts);
+            return string.IsNullOrWhiteSpace(label) ? "all services, layers, protocols" : label;
+        }
+    }
+
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var version = Interlocked.Increment(ref _loadVersion);
+        Status = UsageAnalyticsStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var report = await _client.GetReportAsync(BuildQuery(), cancellationToken).ConfigureAwait(false);
+            if (version != Volatile.Read(ref _loadVersion))
+            {
+                return;
+            }
+
+            Report = report;
+            Status = UsageAnalyticsStatus.Ready;
+        }
+        catch (OperationCanceledException)
+        {
+            if (version == Volatile.Read(ref _loadVersion))
+            {
+                Status = UsageAnalyticsStatus.Idle;
+            }
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (version != Volatile.Read(ref _loadVersion))
+            {
+                return;
+            }
+
+            Status = UsageAnalyticsStatus.Error;
+            LastError = ex.Message;
+        }
+        finally
+        {
+            if (version == Volatile.Read(ref _loadVersion))
+            {
+                Notify();
+            }
+        }
+    }
+
+    public void SetRange(string rangeKey)
+    {
+        RangeKey = UsageAnalyticsRanges.Resolve(rangeKey).Key;
+        Notify();
+    }
+
+    public void SetServiceFilter(string? serviceName)
+    {
+        ServiceFilter = NormalizeFilter(serviceName);
+        if (!ProtocolOptions.Contains(ProtocolFilter, StringComparer.OrdinalIgnoreCase))
+        {
+            ProtocolFilter = AllFilter;
+        }
+
+        if (!LayerOptions.Contains(LayerFilter, StringComparer.OrdinalIgnoreCase))
+        {
+            LayerFilter = AllFilter;
+        }
+
+        Notify();
+    }
+
+    public void SetLayerFilter(string? layerName)
+    {
+        LayerFilter = NormalizeFilter(layerName);
+        if (!ProtocolOptions.Contains(ProtocolFilter, StringComparer.OrdinalIgnoreCase))
+        {
+            ProtocolFilter = AllFilter;
+        }
+
+        Notify();
+    }
+
+    public void SetProtocolFilter(string? protocol)
+    {
+        ProtocolFilter = NormalizeFilter(protocol);
+        if (!LayerOptions.Contains(LayerFilter, StringComparer.OrdinalIgnoreCase))
+        {
+            LayerFilter = AllFilter;
+        }
+
+        Notify();
+    }
+
+    public UsageAnalyticsExportPayload ExportCsv()
+        => UsageAnalyticsReportExporter.ToCsv(BuildExportView());
+
+    public UsageAnalyticsExportPayload ExportPdf()
+        => UsageAnalyticsReportExporter.ToPdf(BuildExportView());
+
+    private UsageAnalyticsQuery BuildQuery()
+        => new()
+        {
+            RangeKey = RangeKey,
+            ServiceName = FilterOrNull(ServiceFilter),
+            LayerName = FilterOrNull(LayerFilter),
+            Protocol = FilterOrNull(ProtocolFilter),
+        };
+
+    private UsageAnalyticsExportView BuildExportView()
+    {
+        if (Report is null)
+        {
+            throw new InvalidOperationException("Usage analytics has not loaded.");
+        }
+
+        return new UsageAnalyticsExportView(
+            Report,
+            FilteredTotals,
+            FilteredPopularLayers,
+            FilteredPopularEndpoints,
+            FilteredSlowQueries,
+            FilteredStorageGrowth,
+            FilteredUserActivity,
+            FilterLabel);
+    }
+
+    private bool Matches(QueryThroughputPoint point)
+        => MatchesFilter(ServiceFilter, point.ServiceName) &&
+            MatchesFilter(LayerFilter, point.LayerName) &&
+            MatchesFilter(ProtocolFilter, point.Protocol);
+
+    private bool Matches(PopularLayerMetric layer)
+        => MatchesFilter(ServiceFilter, layer.ServiceName) &&
+            MatchesFilter(LayerFilter, layer.LayerName) &&
+            MatchesFilter(ProtocolFilter, layer.Protocol);
+
+    private bool Matches(EndpointUsageMetric endpoint)
+        => MatchesFilter(ServiceFilter, endpoint.ServiceName) &&
+            MatchesFilter(LayerFilter, endpoint.LayerName) &&
+            MatchesFilter(ProtocolFilter, endpoint.Protocol);
+
+    private bool Matches(SlowQueryMetric query)
+        => MatchesFilter(ServiceFilter, query.ServiceName) &&
+            MatchesFilter(LayerFilter, query.LayerName) &&
+            MatchesFilter(ProtocolFilter, query.Protocol);
+
+    private bool Matches(StorageGrowthMetric storage)
+        => MatchesFilter(ServiceFilter, storage.ServiceName) &&
+            MatchesFilter(LayerFilter, storage.LayerNames) &&
+            MatchesFilter(ProtocolFilter, storage.Protocols);
+
+    private bool Matches(UserActivityMetric user)
+        => MatchesFilter(ServiceFilter, user.TopService) &&
+            MatchesFilter(LayerFilter, user.TopLayer) &&
+            MatchesFilter(ProtocolFilter, user.MostUsedProtocol);
+
+    private static bool MatchesFilter(string filter, string value)
+        => string.Equals(filter, AllFilter, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(filter, value, StringComparison.OrdinalIgnoreCase);
+
+    private static bool MatchesFilter(string filter, IReadOnlyList<string> values)
+        => string.Equals(filter, AllFilter, StringComparison.OrdinalIgnoreCase) ||
+            values.Contains(filter, StringComparer.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<string> BuildOptions(IEnumerable<string> values)
+    {
+        var options = new List<string> { AllFilter };
+        options.AddRange(values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase));
+        return options;
+    }
+
+    private static string NormalizeFilter(string? value)
+        => string.IsNullOrWhiteSpace(value) ? AllFilter : value;
+
+    private static string? FilterOrNull(string filter)
+        => string.Equals(filter, AllFilter, StringComparison.OrdinalIgnoreCase) ? null : filter;
+
+    private static string? FormatFilter(string name, string value)
+        => string.Equals(value, AllFilter, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : string.Create(CultureInfo.InvariantCulture, $"{name}: {value}");
+
+    private void Notify() => OnChanged?.Invoke();
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -23,6 +23,9 @@
     <MudNavLink Href="/operator/publishing" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Publish">
         Publishing
     </MudNavLink>
+    <MudNavLink Href="/operator/analytics" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Insights">
+        Usage analytics
+    </MudNavLink>
 
     <MudNavGroup Title="Operations" Icon="@Icons.Material.Filled.Settings" Expanded="true">
         <MudNavLink Href="/operator/operations" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">

--- a/src/Honua.Admin/wwwroot/css/usage-analytics.css
+++ b/src/Honua.Admin/wwwroot/css/usage-analytics.css
@@ -1,0 +1,108 @@
+.usage-analytics-root {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+}
+
+.usage-analytics-toolbar,
+.usage-analytics-filterbar,
+.usage-analytics-panel {
+    border: 1px solid var(--mud-palette-divider, #d9dee3);
+    border-radius: 6px;
+    background: var(--mud-palette-surface, #ffffff);
+}
+
+.usage-analytics-toolbar {
+    padding: 12px;
+}
+
+.usage-analytics-toolbar-row {
+    flex-wrap: wrap;
+}
+
+.usage-analytics-range {
+    width: 160px;
+}
+
+.usage-analytics-filterbar {
+    display: grid;
+    grid-template-columns: minmax(180px, 220px) minmax(180px, 260px) minmax(180px, 220px) minmax(160px, 1fr);
+    gap: 8px;
+    align-items: center;
+    padding: 10px 12px;
+}
+
+.usage-analytics-filter-label {
+    overflow-wrap: anywhere;
+}
+
+.usage-analytics-metric {
+    min-height: 112px;
+}
+
+.usage-analytics-panel {
+    padding: 12px;
+    min-height: 100%;
+    overflow: auto;
+}
+
+.usage-analytics-bars {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(28px, 1fr));
+    gap: 6px;
+    height: 168px;
+    align-items: end;
+    padding: 12px 4px 0;
+}
+
+.usage-analytics-bar-slot {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-end;
+    gap: 4px;
+    min-width: 0;
+    height: 100%;
+}
+
+.usage-analytics-bar {
+    min-height: 6px;
+    border-radius: 4px 4px 0 0;
+    background: linear-gradient(180deg, #0f766e 0%, #2563eb 100%);
+}
+
+.usage-analytics-bar-slot span {
+    color: #64748b;
+    font-size: 11px;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+}
+
+.usage-analytics-tab-panel {
+    padding: 12px;
+}
+
+@media (max-width: 980px) {
+    .usage-analytics-filterbar {
+        grid-template-columns: 1fr;
+    }
+
+    .usage-analytics-range {
+        width: 100%;
+        max-width: 220px;
+    }
+}
+
+@media (max-width: 720px) {
+    .usage-analytics-root {
+        padding: 8px;
+    }
+
+    .usage-analytics-bars {
+        grid-template-columns: repeat(6, minmax(28px, 1fr));
+        height: 150px;
+    }
+}

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -14,6 +14,7 @@
     <link href="css/spatial-sql.css" rel="stylesheet" />
     <link href="css/annotation-workspace.css" rel="stylesheet" />
     <link href="css/publishing-workspace.css" rel="stylesheet" />
+    <link href="css/usage-analytics.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -41,6 +42,7 @@
     <script src="js/spec-workspace-interop.js"></script>
     <script src="js/spatial-sql-interop.js"></script>
     <script src="js/annotation-workspace-interop.js"></script>
+    <script src="js/usage-analytics-interop.js"></script>
 </body>
 
 </html>

--- a/src/Honua.Admin/wwwroot/js/usage-analytics-interop.js
+++ b/src/Honua.Admin/wwwroot/js/usage-analytics-interop.js
@@ -1,0 +1,17 @@
+window.usageAnalytics = (function () {
+    function downloadFile(filename, mimeType, content) {
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    return {
+        downloadFile
+    };
+})();

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -42,6 +42,16 @@ public sealed class NavMenuTests
     }
 
     [Fact]
+    public void NavMenu_registers_usage_analytics_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/analytics", contents, System.StringComparison.Ordinal);
+        Assert.Contains("Usage analytics", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NavMenu_uses_a_single_MudNavMenu_so_sql_page_lives_in_the_shared_shell()
     {
         var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
@@ -57,14 +67,17 @@ public sealed class NavMenuTests
         var operatorSql = contents.IndexOf("/operator/sql", System.StringComparison.Ordinal);
         var operatorAnnotations = contents.IndexOf("/operator/annotations", System.StringComparison.Ordinal);
         var operatorPublishing = contents.IndexOf("/operator/publishing", System.StringComparison.Ordinal);
+        var operatorAnalytics = contents.IndexOf("/operator/analytics", System.StringComparison.Ordinal);
         var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
 
         Assert.True(operatorSpec > 0);
         Assert.True(operatorSql > 0);
         Assert.True(operatorAnnotations > 0);
         Assert.True(operatorPublishing > 0);
+        Assert.True(operatorAnalytics > 0);
         Assert.True(operatorSql < menuClose);
         Assert.True(operatorAnnotations < menuClose);
         Assert.True(operatorPublishing < menuClose);
+        Assert.True(operatorAnalytics < menuClose);
     }
 }

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -12,6 +12,7 @@ using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.Publishing;
+using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
@@ -29,6 +30,8 @@ public sealed class AdminPageRenderTests : TestContext
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddScoped<IAdminTelemetry, NullAdminTelemetry>();
+        Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
+        Services.AddScoped<UsageAnalyticsState>();
         Services.AddTestRealtime();
     }
 
@@ -176,6 +179,22 @@ public sealed class AdminPageRenderTests : TestContext
         {
             cut.Markup.MarkupMatchesContaining("Recent errors unavailable");
             Assert.False(cut.Markup.Contains("No recent errors loaded.", StringComparison.OrdinalIgnoreCase), cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void UsageAnalytics_RendersMetricsDrilldownsAndExports()
+    {
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.UsageAnalytics>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Usage analytics");
+            cut.Markup.MarkupMatchesContaining("Queries per second");
+            cut.Markup.MarkupMatchesContaining("Popular layers");
+            cut.Markup.MarkupMatchesContaining("Parcels");
+            cut.Markup.MarkupMatchesContaining("CSV");
+            cut.Markup.MarkupMatchesContaining("PDF");
         });
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -12,6 +12,7 @@ using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.Publishing;
+using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
@@ -36,6 +37,8 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
         Services.AddScoped<AnnotationWorkspaceState>();
         Services.AddScoped<PublishingWorkspaceState>();
+        Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
+        Services.AddScoped<UsageAnalyticsState>();
         Services.AddTestRealtime();
     }
 
@@ -103,6 +106,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Operator.PublishingWorkspace),
             "primary-postgis",
             new[] { "[aria-label='Publishing workspace toolbar']", "[aria-label='Publishing validation checks']" },
+        ];
+        yield return
+        [
+            "Usage analytics",
+            typeof(Honua.Admin.Pages.Operator.UsageAnalytics),
+            "Queries per second",
+            new[] { "[aria-label='Usage analytics toolbar']", "[aria-label='Popular layers']" },
         ];
     }
 

--- a/tests/Honua.Admin.Tests/UsageAnalyticsStateTests.cs
+++ b/tests/Honua.Admin.Tests/UsageAnalyticsStateTests.cs
@@ -1,0 +1,350 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.UsageAnalytics;
+using Honua.Admin.Services.UsageAnalytics;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class UsageAnalyticsStateTests
+{
+    [Fact]
+    public async Task LoadAsync_populates_default_dashboard_metrics()
+    {
+        var state = new UsageAnalyticsState(new StubUsageAnalyticsClient());
+
+        await state.LoadAsync();
+
+        Assert.Equal(UsageAnalyticsStatus.Ready, state.Status);
+        Assert.NotNull(state.Report);
+        Assert.True(state.FilteredTotals.TotalQueries > 0);
+        Assert.Contains("default", state.ServiceOptions);
+        Assert.Contains("FeatureServer", state.ProtocolOptions);
+        Assert.Contains("Parcels", state.LayerOptions);
+        Assert.NotEmpty(state.ThroughputBuckets);
+        Assert.NotEmpty(state.ThroughputRows);
+    }
+
+    [Fact]
+    public async Task Filters_scope_layers_endpoints_slow_queries_and_users()
+    {
+        var state = new UsageAnalyticsState(new StubUsageAnalyticsClient());
+        await state.LoadAsync();
+
+        state.SetServiceFilter("imagery");
+        state.SetLayerFilter("Orthophoto mosaic");
+        state.SetProtocolFilter("ImageServer");
+
+        Assert.All(state.FilteredPopularLayers, layer =>
+        {
+            Assert.Equal("imagery", layer.ServiceName);
+            Assert.Equal("ImageServer", layer.Protocol);
+        });
+        Assert.All(state.FilteredPopularEndpoints, endpoint =>
+        {
+            Assert.Equal("imagery", endpoint.ServiceName);
+            Assert.Equal("Orthophoto mosaic", endpoint.LayerName);
+        });
+        Assert.All(state.FilteredSlowQueries, query => Assert.Equal("imagery", query.ServiceName));
+        Assert.All(state.FilteredUserActivity, user => Assert.Equal("imagery", user.TopService));
+        var storage = Assert.Single(state.FilteredStorageGrowth);
+        Assert.Equal("imagery", storage.ServiceName);
+        Assert.Contains("Orthophoto mosaic", storage.LayerNames);
+        Assert.Contains("ImageServer", storage.Protocols);
+        Assert.Equal(storage.CurrentBytes, state.FilteredTotals.StorageBytes);
+        Assert.Equal(storage.DeltaBytes, state.FilteredTotals.StorageDeltaBytes);
+        Assert.All(state.ThroughputRows, row => Assert.Equal("ImageServer", row.Protocol));
+    }
+
+    [Fact]
+    public async Task Storage_filters_honor_layer_and_protocol_membership()
+    {
+        var state = new UsageAnalyticsState(new StubUsageAnalyticsClient());
+        await state.LoadAsync();
+
+        state.SetProtocolFilter("ImageServer");
+
+        var imageStorage = Assert.Single(state.FilteredStorageGrowth);
+        Assert.Equal("imagery", imageStorage.ServiceName);
+        Assert.Equal(imageStorage.CurrentBytes, state.FilteredTotals.StorageBytes);
+
+        state.SetProtocolFilter(UsageAnalyticsState.AllFilter);
+        state.SetLayerFilter("Parcels");
+
+        var parcelStorage = Assert.Single(state.FilteredStorageGrowth);
+        Assert.Equal("default", parcelStorage.ServiceName);
+        Assert.Contains("FeatureServer", parcelStorage.Protocols);
+        Assert.Equal(parcelStorage.CurrentBytes, state.FilteredTotals.StorageBytes);
+    }
+
+    [Fact]
+    public async Task FilteredTotals_query_count_uses_filtered_aggregate_counts()
+    {
+        var state = new UsageAnalyticsState(new StubUsageAnalyticsClient());
+        state.SetRange(UsageAnalyticsRanges.Last7Days);
+        await state.LoadAsync();
+
+        Assert.Equal(
+            state.FilteredPopularLayers.Sum(layer => layer.QueryCount),
+            state.FilteredTotals.TotalQueries);
+        Assert.NotEqual(
+            state.ThroughputSeries.Sum(point => point.QueryCount),
+            state.FilteredTotals.TotalQueries);
+
+        state.SetServiceFilter("imagery");
+
+        Assert.Equal(
+            state.FilteredPopularLayers.Sum(layer => layer.QueryCount),
+            state.FilteredTotals.TotalQueries);
+    }
+
+    [Fact]
+    public async Task ShortRange_slow_query_counts_scale_down_with_the_selected_window()
+    {
+        var client = new StubUsageAnalyticsClient();
+
+        var lastHour = await client.GetReportAsync(new UsageAnalyticsQuery { RangeKey = UsageAnalyticsRanges.LastHour }, CancellationToken.None);
+        var lastDay = await client.GetReportAsync(new UsageAnalyticsQuery { RangeKey = UsageAnalyticsRanges.Last24Hours }, CancellationToken.None);
+
+        Assert.True(
+            lastHour.SlowQueries.Sum(query => query.Count) < lastDay.SlowQueries.Sum(query => query.Count),
+            "Short analytics windows should not keep 24-hour slow-query counts.");
+    }
+
+    [Fact]
+    public async Task ExportCsvAndPdf_use_filtered_report_payloads()
+    {
+        var state = new UsageAnalyticsState(new StubUsageAnalyticsClient());
+        await state.LoadAsync();
+
+        state.SetServiceFilter("planning");
+
+        var csv = state.ExportCsv();
+        var pdf = state.ExportPdf();
+
+        Assert.Equal("text/csv", csv.MimeType);
+        Assert.Contains("service: planning", csv.Content);
+        Assert.Contains("Zoning districts", csv.Content);
+        Assert.DoesNotContain("Orthophoto mosaic", csv.Content);
+
+        Assert.Equal("application/pdf", pdf.MimeType);
+        Assert.StartsWith("%PDF-1.4", pdf.Content, StringComparison.Ordinal);
+        Assert.Contains(PdfHex("Filters: service: planning"), pdf.Content);
+        Assert.Contains("/Subtype /Type0", pdf.Content);
+        Assert.Contains("/Encoding /Identity-H", pdf.Content);
+        Assert.Contains("/ToUnicode", pdf.Content);
+    }
+
+    [Fact]
+    public async Task ServiceAndLayerFilters_clear_incompatible_protocol_filter()
+    {
+        var state = new UsageAnalyticsState(new StubUsageAnalyticsClient());
+        await state.LoadAsync();
+
+        state.SetProtocolFilter("FeatureServer");
+        state.SetServiceFilter("imagery");
+
+        Assert.Equal(UsageAnalyticsState.AllFilter, state.ProtocolFilter);
+        Assert.Contains("ImageServer", state.ProtocolOptions);
+        Assert.DoesNotContain("FeatureServer", state.ProtocolOptions);
+
+        state.SetProtocolFilter("ImageServer");
+        state.SetLayerFilter("Parcels");
+
+        Assert.Equal(UsageAnalyticsState.AllFilter, state.ProtocolFilter);
+    }
+
+    [Fact]
+    public async Task LiteralAllValues_are_filterable_data_values_not_wildcards()
+    {
+        var state = new UsageAnalyticsState(new FixedUsageAnalyticsClient(new UsageAnalyticsReport
+        {
+            QuerySeries =
+            [
+                new QueryThroughputPoint
+                {
+                    Timestamp = DateTimeOffset.Parse("2026-04-25T01:00:00Z"),
+                    ServiceName = "all",
+                    LayerName = "all",
+                    Protocol = "all",
+                    QueryCount = 7,
+                    QueriesPerSecond = 1,
+                },
+                new QueryThroughputPoint
+                {
+                    Timestamp = DateTimeOffset.Parse("2026-04-25T01:00:00Z"),
+                    ServiceName = "default",
+                    LayerName = "Parcels",
+                    Protocol = "FeatureServer",
+                    QueryCount = 11,
+                    QueriesPerSecond = 2,
+                },
+            ],
+        }));
+
+        await state.LoadAsync();
+        state.SetServiceFilter("all");
+        state.SetLayerFilter("all");
+        state.SetProtocolFilter("all");
+
+        var point = Assert.Single(state.ThroughputSeries);
+        Assert.Equal("all", point.ServiceName);
+        Assert.Equal(7, point.QueryCount);
+    }
+
+    [Fact]
+    public void ExportCsv_escapes_management_report_fields()
+    {
+        var report = new UsageAnalyticsReport
+        {
+            GeneratedAt = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            RangeStart = DateTimeOffset.Parse("2026-04-24T12:00:00Z"),
+            RangeEnd = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            RangeLabel = "24 hours",
+        };
+        var view = new UsageAnalyticsExportView(
+            report,
+            new UsageAnalyticsTotals { TotalQueries = 12 },
+            new[]
+            {
+                new PopularLayerMetric
+                {
+                    ServiceName = "default",
+                    LayerName = "Parcels, historical",
+                    Protocol = "FeatureServer",
+                    QueryCount = 12,
+                },
+            },
+            Array.Empty<EndpointUsageMetric>(),
+            Array.Empty<SlowQueryMetric>(),
+            Array.Empty<StorageGrowthMetric>(),
+            new[]
+            {
+                new UserActivityMetric
+                {
+                    PrincipalId = "@external",
+                    DisplayName = "=cmd|' /C calc'!A0",
+                    Tenant = "default",
+                },
+            },
+            "all services");
+
+        var csv = UsageAnalyticsReportExporter.ToCsv(view);
+
+        Assert.Contains("\"Parcels, historical\"", csv.Content);
+        Assert.Contains("'=cmd|' /C calc'!A0", csv.Content);
+        Assert.Contains("'@external", csv.Content);
+    }
+
+    [Fact]
+    public void ExportPdf_preserves_non_ascii_report_text()
+    {
+        var displayName = string.Concat("M", "\u0101", "lia ", "\u5C71", "\u7530");
+        var report = new UsageAnalyticsReport
+        {
+            GeneratedAt = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            RangeStart = DateTimeOffset.Parse("2026-04-24T12:00:00Z"),
+            RangeEnd = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            RangeLabel = "24 hours",
+        };
+        var view = new UsageAnalyticsExportView(
+            report,
+            new UsageAnalyticsTotals(),
+            Array.Empty<PopularLayerMetric>(),
+            Array.Empty<EndpointUsageMetric>(),
+            Array.Empty<SlowQueryMetric>(),
+            Array.Empty<StorageGrowthMetric>(),
+            new[]
+            {
+                new UserActivityMetric
+                {
+                    PrincipalId = "aad:9914",
+                    DisplayName = displayName,
+                },
+            },
+            "all services");
+
+        var pdf = UsageAnalyticsReportExporter.ToPdf(view);
+
+        Assert.Contains(PdfHexBody(displayName), pdf.Content);
+    }
+
+    [Fact]
+    public async Task LoadAsync_does_not_allow_stale_result_to_overwrite_newer_load()
+    {
+        var first = new TaskCompletionSource<UsageAnalyticsReport>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new GatedUsageAnalyticsClient(first.Task, Task.FromResult(Report("new")));
+        var state = new UsageAnalyticsState(client);
+
+        var staleLoad = state.LoadAsync();
+        await state.LoadAsync();
+        first.SetResult(Report("old"));
+        await staleLoad;
+
+        Assert.Equal("new", state.Report?.RangeLabel);
+        Assert.Equal(UsageAnalyticsStatus.Ready, state.Status);
+    }
+
+    private static UsageAnalyticsReport Report(string label)
+        => new()
+        {
+            RangeLabel = label,
+            RangeStart = DateTimeOffset.Parse("2026-04-25T00:00:00Z"),
+            RangeEnd = DateTimeOffset.Parse("2026-04-25T01:00:00Z"),
+            GeneratedAt = DateTimeOffset.Parse("2026-04-25T01:00:00Z"),
+            QuerySeries =
+            [
+                new QueryThroughputPoint
+                {
+                    Timestamp = DateTimeOffset.Parse("2026-04-25T01:00:00Z"),
+                    ServiceName = "default",
+                    LayerName = "Parcels",
+                    Protocol = "FeatureServer",
+                    QueryCount = 10,
+                    QueriesPerSecond = 1,
+                },
+            ],
+        };
+
+    private sealed class GatedUsageAnalyticsClient : IUsageAnalyticsClient
+    {
+        private readonly Queue<Task<UsageAnalyticsReport>> _responses;
+
+        public GatedUsageAnalyticsClient(params Task<UsageAnalyticsReport>[] responses)
+        {
+            _responses = new Queue<Task<UsageAnalyticsReport>>(responses);
+        }
+
+        public Task<UsageAnalyticsReport> GetReportAsync(UsageAnalyticsQuery query, CancellationToken cancellationToken)
+            => _responses.Dequeue();
+    }
+
+    private sealed class FixedUsageAnalyticsClient : IUsageAnalyticsClient
+    {
+        private readonly UsageAnalyticsReport _report;
+
+        public FixedUsageAnalyticsClient(UsageAnalyticsReport report)
+        {
+            _report = report;
+        }
+
+        public Task<UsageAnalyticsReport> GetReportAsync(UsageAnalyticsQuery query, CancellationToken cancellationToken)
+            => Task.FromResult(_report);
+    }
+
+    private static string PdfHex(string value)
+        => "<" + PdfHexBody(value) + ">";
+
+    private static string PdfHexBody(string value)
+    {
+        var bytes = Encoding.BigEndianUnicode.GetBytes(value);
+        return string.Concat(bytes.Select(valueByte => valueByte.ToString("X2")));
+    }
+}


### PR DESCRIPTION
## Summary
- adds the experimental `/operator/analytics` dashboard with range selection, service/layer/protocol filters, QPS trend, popular layer/endpoint, slow query, storage, and user activity drill-downs
- adds a stub product analytics client/state/export surface for the first-pass reporting workflow while durable server aggregation is defined
- wires nav, CSS/JS download interop, and render/quality/state tests for CSV/PDF exports and stale-load protection

Closes #2

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"
- git diff --check