### PR TITLE
feat: add print service workspace

### DIFF
--- a/src/Honua.Admin/Models/PrintService/PrintServiceModels.cs
+++ b/src/Honua.Admin/Models/PrintService/PrintServiceModels.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.PrintService;
+
+public static class PrintOutputFormats
+{
+    public const string Pdf = "PDF";
+    public const string Png = "PNG";
+
+    public static IReadOnlyList<string> Options { get; } = [Pdf, Png];
+}
+
+public static class PrintJobStatuses
+{
+    public const string Queued = "Queued";
+    public const string Rendering = "Rendering";
+    public const string Complete = "Complete";
+    public const string Failed = "Failed";
+}
+
+public sealed record PrintServiceSnapshot
+{
+    public DateTimeOffset GeneratedAt { get; init; }
+    public IReadOnlyList<PrintLayoutTemplate> Templates { get; init; } = Array.Empty<PrintLayoutTemplate>();
+    public IReadOnlyList<PrintMapLayer> Layers { get; init; } = Array.Empty<PrintMapLayer>();
+    public IReadOnlyList<PrintJobSummary> Jobs { get; init; } = Array.Empty<PrintJobSummary>();
+}
+
+public sealed record PrintLayoutTemplate
+{
+    public string TemplateId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string PageSize { get; init; } = string.Empty;
+    public string Orientation { get; init; } = string.Empty;
+    public double WidthInches { get; init; }
+    public double HeightInches { get; init; }
+    public string RequiredEdition { get; init; } = "Community";
+    public string DefaultFormat { get; init; } = PrintOutputFormats.Pdf;
+    public bool SupportsAtlas { get; init; }
+    public bool IncludeLegendByDefault { get; init; } = true;
+    public bool IncludeScaleBarByDefault { get; init; } = true;
+    public bool IncludeNorthArrowByDefault { get; init; } = true;
+    public bool IncludeOverviewMapByDefault { get; init; }
+}
+
+public sealed record PrintMapLayer
+{
+    public string LayerId { get; init; } = string.Empty;
+    public string ServiceName { get; init; } = string.Empty;
+    public string LayerName { get; init; } = string.Empty;
+    public string Protocol { get; init; } = string.Empty;
+    public string GeometryType { get; init; } = string.Empty;
+    public string SymbolColor { get; init; } = "#2563eb";
+    public string Attribution { get; init; } = string.Empty;
+    public long FeatureCount { get; init; }
+    public bool VisibleByDefault { get; init; } = true;
+}
+
+public sealed record PrintJobRequest
+{
+    public string TemplateId { get; init; } = string.Empty;
+    public string Format { get; init; } = PrintOutputFormats.Pdf;
+    public string Title { get; init; } = string.Empty;
+    public string Subtitle { get; init; } = string.Empty;
+    public string Author { get; init; } = string.Empty;
+    public int ScaleDenominator { get; init; }
+    public bool IncludeLegend { get; init; }
+    public bool IncludeScaleBar { get; init; }
+    public bool IncludeNorthArrow { get; init; }
+    public bool IncludeOverviewMap { get; init; }
+    public bool BatchAtlas { get; init; }
+    public IReadOnlyList<string> VisibleLayerIds { get; init; } = Array.Empty<string>();
+}
+
+public sealed record PrintPreviewDocument
+{
+    public DateTimeOffset GeneratedAt { get; init; }
+    public string TemplateId { get; init; } = string.Empty;
+    public string TemplateName { get; init; } = string.Empty;
+    public string Format { get; init; } = PrintOutputFormats.Pdf;
+    public string Title { get; init; } = string.Empty;
+    public string Subtitle { get; init; } = string.Empty;
+    public string Author { get; init; } = string.Empty;
+    public string ExportUrl { get; init; } = string.Empty;
+    public double WidthInches { get; init; }
+    public double HeightInches { get; init; }
+    public int ScaleDenominator { get; init; }
+    public int PageCount { get; init; }
+    public long EstimatedFileSizeBytes { get; init; }
+    public IReadOnlyList<PrintPreviewLayer> Layers { get; init; } = Array.Empty<PrintPreviewLayer>();
+    public IReadOnlyList<PrintLayoutElement> Elements { get; init; } = Array.Empty<PrintLayoutElement>();
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+}
+
+public sealed record PrintPreviewLayer
+{
+    public string LayerId { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string Protocol { get; init; } = string.Empty;
+    public string SymbolColor { get; init; } = "#2563eb";
+    public long FeatureCount { get; init; }
+}
+
+public sealed record PrintLayoutElement
+{
+    public string Name { get; init; } = string.Empty;
+    public string Position { get; init; } = string.Empty;
+}
+
+public sealed record PrintJobSummary
+{
+    public string JobId { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string TemplateName { get; init; } = string.Empty;
+    public string Format { get; init; } = PrintOutputFormats.Pdf;
+    public string Status { get; init; } = PrintJobStatuses.Queued;
+    public int PageCount { get; init; } = 1;
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? CompletedAt { get; init; }
+    public string FileName { get; init; } = string.Empty;
+}
+
+public sealed record PrintExportPayload(
+    string FileName,
+    string MimeType,
+    string Content);

--- a/src/Honua.Admin/Pages/Operator/PrintService.razor
+++ b/src/Honua.Admin/Pages/Operator/PrintService.razor
@@ -1,0 +1,440 @@
+@page "/operator/print"
+@using System.Globalization
+@using Honua.Admin.Models.PrintService
+@using Honua.Admin.Services.PrintService
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.JSInterop
+@attribute [Authorize]
+@inject PrintServiceState State
+@inject IAdminTelemetry Telemetry
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>Print service</PageTitle>
+
+<div class="print-service-root" data-testid="print-service-root">
+    <div class="print-service-toolbar" aria-label="Print service toolbar">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="print-service-toolbar-row">
+            <MudText Typo="Typo.h5">
+                <MudIcon Icon="@Icons.Material.Filled.Print" Class="mr-2" />
+                Print service
+            </MudText>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@StatusColor(State.Status)" data-testid="print-service-status">
+                @State.Status
+            </MudChip>
+            <MudSpacer />
+            <MudButton StartIcon="@Icons.Material.Filled.Refresh"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@State.IsLoading"
+                       OnClick="RefreshPreviewAsync"
+                       data-testid="print-service-preview">
+                Preview
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Queue"
+                       Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Size="Size.Small"
+                       Disabled="@State.IsLoading"
+                       OnClick="QueueExportAsync"
+                       data-testid="print-service-queue">
+                Queue export
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.GetApp"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@(State.Preview is null || State.IsLoading)"
+                       OnClick="DownloadPreviewAsync"
+                       data-testid="print-service-download-preview">
+                Download preview
+            </MudButton>
+        </MudStack>
+        @if (!string.IsNullOrWhiteSpace(State.LastError))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Dense="true" Class="mt-2" data-testid="print-service-error">
+                @State.LastError
+            </MudAlert>
+        }
+    </div>
+
+    @if (State.IsLoading && State.Preview is null)
+    {
+        <MudGrid Class="mt-2">
+            @for (var i = 0; i < 4; i++)
+            {
+                <MudItem xs="12" sm="6" lg="3">
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="112px" Animation="Animation.Wave" />
+                </MudItem>
+            }
+        </MudGrid>
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="480px" Animation="Animation.Wave" Class="mt-2" />
+    }
+    else
+    {
+        <MudGrid Class="mt-2">
+            <MudItem xs="12" sm="6" lg="3">
+                <MudCard Elevation="1" Class="print-service-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Templates</MudText>
+                        <MudText Typo="Typo.h5">@State.Templates.Count.ToString("N0", CultureInfo.InvariantCulture)</MudText>
+                        <MudText Typo="Typo.caption">@State.SelectedTemplate?.RequiredEdition edition ready</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="3">
+                <MudCard Elevation="1" Class="print-service-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Visible layers</MudText>
+                        <MudText Typo="Typo.h5">@State.VisibleLayerCount.ToString("N0", CultureInfo.InvariantCulture)</MudText>
+                        <MudText Typo="Typo.caption">Legend inputs</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="3">
+                <MudCard Elevation="1" Class="print-service-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Pages</MudText>
+                        <MudText Typo="Typo.h5">@((State.Preview?.PageCount ?? 0).ToString("N0", CultureInfo.InvariantCulture))</MudText>
+                        <MudText Typo="Typo.caption">Single map or atlas</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="6" lg="3">
+                <MudCard Elevation="1" Class="print-service-metric">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Estimate</MudText>
+                        <MudText Typo="Typo.h5">@FormatBytes(State.Preview?.EstimatedFileSizeBytes ?? 0)</MudText>
+                        <MudText Typo="Typo.caption">@State.OutputFormat output</MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        </MudGrid>
+
+        <MudGrid Class="mt-2">
+            <MudItem xs="12" lg="4">
+                <MudPaper Elevation="0" Class="print-service-panel" aria-label="Print layout options">
+                    <MudText Typo="Typo.h6" Class="mb-2">Layout options</MudText>
+                    <MudSelect T="string"
+                               Label="Template"
+                               Value="@State.TemplateId"
+                               ValueChanged="OnTemplateChanged"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense"
+                               aria-label="Print template">
+                        @foreach (var template in State.Templates)
+                        {
+                            <MudSelectItem T="string" Value="@template.TemplateId">@template.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudSelect T="string"
+                               Label="Format"
+                               Value="@State.OutputFormat"
+                               ValueChanged="OnFormatChanged"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense"
+                               Class="mt-2"
+                               aria-label="Print output format">
+                        @foreach (var format in PrintOutputFormats.Options)
+                        {
+                            <MudSelectItem T="string" Value="@format">@format</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudTextField T="string"
+                                  Label="Title"
+                                  Value="@State.Title"
+                                  ValueChanged="@((string value) => State.SetTitle(value))"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Class="mt-2"
+                                  aria-label="Print title" />
+                    <MudTextField T="string"
+                                  Label="Subtitle"
+                                  Value="@State.Subtitle"
+                                  ValueChanged="@((string value) => State.SetSubtitle(value))"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Class="mt-2"
+                                  aria-label="Print subtitle" />
+                    <MudTextField T="string"
+                                  Label="Author"
+                                  Value="@State.Author"
+                                  ValueChanged="@((string value) => State.SetAuthor(value))"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Class="mt-2"
+                                  aria-label="Print author" />
+                    <MudNumericField T="int"
+                                     Label="Scale denominator"
+                                     Value="@State.ScaleDenominator"
+                                     ValueChanged="@((int value) => State.SetScaleDenominator(value))"
+                                     Min="100"
+                                     Max="10000000"
+                                     Variant="Variant.Outlined"
+                                     Margin="Margin.Dense"
+                                     Class="mt-2"
+                                     aria-label="Print scale denominator" />
+                    <div class="print-service-option-grid mt-2">
+                        <MudCheckBox T="bool"
+                                     Value="@State.IncludeLegend"
+                                     ValueChanged="@((bool value) => State.SetIncludeLegend(value))"
+                                     Label="Legend"
+                                     Color="Color.Primary"
+                                     aria-label="Include legend" />
+                        <MudCheckBox T="bool"
+                                     Value="@State.IncludeScaleBar"
+                                     ValueChanged="@((bool value) => State.SetIncludeScaleBar(value))"
+                                     Label="Scale bar"
+                                     Color="Color.Primary"
+                                     aria-label="Include scale bar" />
+                        <MudCheckBox T="bool"
+                                     Value="@State.IncludeNorthArrow"
+                                     ValueChanged="@((bool value) => State.SetIncludeNorthArrow(value))"
+                                     Label="North arrow"
+                                     Color="Color.Primary"
+                                     aria-label="Include north arrow" />
+                        <MudCheckBox T="bool"
+                                     Value="@State.IncludeOverviewMap"
+                                     ValueChanged="@((bool value) => State.SetIncludeOverviewMap(value))"
+                                     Label="Overview"
+                                     Color="Color.Primary"
+                                     aria-label="Include overview map" />
+                        <MudCheckBox T="bool"
+                                     Value="@State.BatchAtlas"
+                                     ValueChanged="@((bool value) => State.SetBatchAtlas(value))"
+                                     Label="Batch atlas"
+                                     Disabled="@(State.SelectedTemplate?.SupportsAtlas != true)"
+                                     Color="Color.Primary"
+                                     aria-label="Enable batch atlas" />
+                    </div>
+                </MudPaper>
+
+                <MudPaper Elevation="0" Class="print-service-panel mt-2" aria-label="Print visible layers">
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+                        <MudIcon Icon="@Icons.Material.Filled.Layers" />
+                        <MudText Typo="Typo.h6">Layers</MudText>
+                    </MudStack>
+                    <MudTable Items="State.Layers" Dense="true" Hover="true" aria-label="Print layer selection">
+                        <HeaderContent>
+                            <MudTh>Visible</MudTh>
+                            <MudTh>Layer</MudTh>
+                            <MudTh>Protocol</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd DataLabel="Visible">
+                                <MudCheckBox T="bool"
+                                             Value="@State.IsLayerVisible(context.LayerId)"
+                                             ValueChanged="@((bool visible) => OnLayerVisibilityChanged(context.LayerId, visible))"
+                                             Color="Color.Primary"
+                                             aria-label="@($"Toggle {context.LayerName}")" />
+                            </MudTd>
+                            <MudTd DataLabel="Layer">
+                                <MudText Typo="Typo.body2">@context.LayerName</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ServiceName - @context.GeometryType</MudText>
+                            </MudTd>
+                            <MudTd DataLabel="Protocol">@context.Protocol</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </MudPaper>
+            </MudItem>
+
+            <MudItem xs="12" lg="8">
+                <MudPaper Elevation="0" Class="print-service-panel" aria-label="Print preview">
+                    @if (State.Preview is { } preview)
+                    {
+                        <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+                            <MudIcon Icon="@Icons.Material.Filled.Map" />
+                            <MudText Typo="Typo.h6">Preview</MudText>
+                            <MudSpacer />
+                            <MudText Typo="Typo.caption">@preview.ExportUrl</MudText>
+                        </MudStack>
+                        @if (preview.Warnings.Count > 0)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" Class="mb-2" data-testid="print-service-preview-warning">
+                                @string.Join(" ", preview.Warnings)
+                            </MudAlert>
+                        }
+                        <div class="print-service-preview-wrap">
+                            <div class="print-service-sheet" style="@SheetStyle(preview)">
+                                <div class="print-service-title-block">
+                                    <strong>@State.Title</strong>
+                                    <span>@State.Subtitle</span>
+                                </div>
+                                <div class="print-service-map-frame">
+                                    @foreach (var layer in preview.Layers)
+                                    {
+                                        <div class="print-service-map-band" style="@BandStyle(layer.SymbolColor)">
+                                            <span>@layer.DisplayName</span>
+                                        </div>
+                                    }
+                                    @if (preview.Layers.Count == 0)
+                                    {
+                                        <span class="print-service-empty-map">No visible layers</span>
+                                    }
+                                </div>
+                                @if (State.IncludeNorthArrow)
+                                {
+                                    <div class="print-service-north" title="North arrow">N</div>
+                                }
+                                @if (State.IncludeLegend)
+                                {
+                                    <div class="print-service-legend" aria-label="Preview legend">
+                                        @foreach (var layer in preview.Layers)
+                                        {
+                                            <div>
+                                                <span style="@LegendSwatchStyle(layer.SymbolColor)"></span>
+                                                <em>@layer.DisplayName</em>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                                @if (State.IncludeScaleBar)
+                                {
+                                    <div class="print-service-scale">1:@preview.ScaleDenominator.ToString("N0", CultureInfo.InvariantCulture)</div>
+                                }
+                                @if (State.IncludeOverviewMap)
+                                {
+                                    <div class="print-service-overview">Overview</div>
+                                }
+                                <div class="print-service-attribution">@State.Author</div>
+                            </div>
+                        </div>
+                    }
+                </MudPaper>
+
+                <MudGrid Class="mt-2">
+                    <MudItem xs="12" md="6">
+                        <MudPaper Elevation="0" Class="print-service-panel" aria-label="Print template catalog">
+                            <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+                                <MudIcon Icon="@Icons.Material.Filled.ViewQuilt" />
+                                <MudText Typo="Typo.h6">Templates</MudText>
+                            </MudStack>
+                            <MudTable Items="State.Templates" Dense="true" Hover="true" aria-label="Print layout templates">
+                                <HeaderContent>
+                                    <MudTh>Name</MudTh>
+                                    <MudTh>Page</MudTh>
+                                    <MudTh>Edition</MudTh>
+                                    <MudTh>Atlas</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Name">@context.Name</MudTd>
+                                    <MudTd DataLabel="Page">@context.PageSize / @context.Orientation</MudTd>
+                                    <MudTd DataLabel="Edition">@context.RequiredEdition</MudTd>
+                                    <MudTd DataLabel="Atlas">@(context.SupportsAtlas ? "Yes" : "No")</MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        </MudPaper>
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudPaper Elevation="0" Class="print-service-panel" aria-label="Print queue panel">
+                            <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+                                <MudIcon Icon="@Icons.Material.Filled.Queue" />
+                                <MudText Typo="Typo.h6">Queue</MudText>
+                            </MudStack>
+                            <MudTable Items="State.Jobs" Dense="true" Hover="true" aria-label="Print job queue">
+                                <HeaderContent>
+                                    <MudTh>Job</MudTh>
+                                    <MudTh>Template</MudTh>
+                                    <MudTh>Status</MudTh>
+                                    <MudTh>Pages</MudTh>
+                                    <MudTh>File</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Job">
+                                        <MudText Typo="Typo.body2">@context.Title</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@context.JobId</MudText>
+                                    </MudTd>
+                                    <MudTd DataLabel="Template">@context.TemplateName</MudTd>
+                                    <MudTd DataLabel="Status">@context.Status</MudTd>
+                                    <MudTd DataLabel="Pages">@context.PageCount.ToString("N0", CultureInfo.InvariantCulture)</MudTd>
+                                    <MudTd DataLabel="File">@context.FileName</MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        </MudPaper>
+                    </MudItem>
+                </MudGrid>
+            </MudItem>
+        </MudGrid>
+    }
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += OnStateChanged;
+        Telemetry.PageNavigated("/operator/print", principalId: null);
+        await State.LoadAsync();
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= OnStateChanged;
+    }
+
+    private void OnStateChanged() => _ = InvokeAsync(StateHasChanged);
+
+    private async Task RefreshPreviewAsync() => await State.RefreshPreviewAsync();
+
+    private async Task QueueExportAsync() => await State.QueueExportAsync();
+
+    private async Task OnTemplateChanged(string templateId)
+    {
+        State.SetTemplate(templateId);
+        await State.RefreshPreviewAsync();
+    }
+
+    private async Task OnFormatChanged(string format)
+    {
+        State.SetOutputFormat(format);
+        await State.RefreshPreviewAsync();
+    }
+
+    private void OnLayerVisibilityChanged(string layerId, bool visible) => State.SetLayerVisibility(layerId, visible);
+
+    private async Task DownloadPreviewAsync()
+    {
+        try
+        {
+            var payload = State.ExportPreviewManifest();
+            await JS.InvokeVoidAsync("printService.downloadFile", payload.FileName, payload.MimeType, payload.Content);
+        }
+        catch
+        {
+            // Tests and pre-render do not require the browser download helper.
+        }
+    }
+
+    private static Color StatusColor(PrintServiceStatus status) => status switch
+    {
+        PrintServiceStatus.Loading => Color.Info,
+        PrintServiceStatus.Ready => Color.Success,
+        PrintServiceStatus.Error => Color.Error,
+        _ => Color.Default,
+    };
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB"];
+        var size = (double)Math.Max(0, bytes);
+        var unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+
+        return $"{size.ToString(size >= 10 || unit == 0 ? "0" : "0.0", CultureInfo.InvariantCulture)} {units[unit]}";
+    }
+
+    private static string SheetStyle(PrintPreviewDocument preview)
+    {
+        var ratio = preview.WidthInches <= 0 || preview.HeightInches <= 0 ? 0.77 : preview.WidthInches / preview.HeightInches;
+        return $"aspect-ratio:{ratio.ToString("0.###", CultureInfo.InvariantCulture)}";
+    }
+
+    private static string BandStyle(string color) => $"border-left-color:{color};background:{ColorWithAlpha(color)}";
+
+    private static string LegendSwatchStyle(string color) => $"background:{color}";
+
+    private static string ColorWithAlpha(string color)
+        => color.Length == 7 && color[0] == '#' ? $"{color}1f" : "rgba(37,99,235,0.12)";
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -8,6 +8,7 @@ using Honua.Admin.Services.DataConnections.Providers;
 using Honua.Admin.Services.Identity;
 using Honua.Admin.Services.LicenseWorkspace;
 using Honua.Admin.Services.Operations;
+using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.SpatialSql;
 using Honua.Admin.Services.SpecWorkspace;
@@ -53,6 +54,11 @@ builder.Services.AddScoped<PublishingWorkspaceState>();
 // analytics read model while durable server-side aggregation is defined.
 builder.Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
 builder.Services.AddScoped<UsageAnalyticsState>();
+
+// Print service workspace (issue #3) exposes the admin-side template, preview,
+// and queue workflow while server-side render endpoints are wired separately.
+builder.Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
+builder.Services.AddScoped<PrintServiceState>();
 
 // Admin client + auth wiring (ticket #28 — restored from PR #17 onto the post-#27 shell).
 builder.Services.AddSingleton<AdminAuthStateProvider>();

--- a/src/Honua.Admin/Services/PrintService/IPrintServiceClient.cs
+++ b/src/Honua.Admin/Services/PrintService/IPrintServiceClient.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.PrintService;
+
+namespace Honua.Admin.Services.PrintService;
+
+public interface IPrintServiceClient
+{
+    Task<PrintServiceSnapshot> GetSnapshotAsync(CancellationToken cancellationToken);
+
+    Task<PrintPreviewDocument> PreviewAsync(PrintJobRequest request, CancellationToken cancellationToken);
+
+    Task<PrintJobSummary> QueueExportAsync(PrintJobRequest request, CancellationToken cancellationToken);
+}

--- a/src/Honua.Admin/Services/PrintService/PrintServiceState.cs
+++ b/src/Honua.Admin/Services/PrintService/PrintServiceState.cs
@@ -1,0 +1,401 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.PrintService;
+
+namespace Honua.Admin.Services.PrintService;
+
+public enum PrintServiceStatus
+{
+    Idle,
+    Loading,
+    Ready,
+    Error
+}
+
+public sealed class PrintServiceState
+{
+    private readonly IPrintServiceClient _client;
+    private readonly HashSet<string> _visibleLayerIds = new(StringComparer.OrdinalIgnoreCase);
+    private int _loadVersion;
+    private int _previewVersion;
+
+    public PrintServiceState(IPrintServiceClient client)
+    {
+        _client = client;
+    }
+
+    public PrintServiceStatus Status { get; private set; } = PrintServiceStatus.Idle;
+
+    public string? LastError { get; private set; }
+
+    public PrintServiceSnapshot? Snapshot { get; private set; }
+
+    public PrintPreviewDocument? Preview { get; private set; }
+
+    public string TemplateId { get; private set; } = string.Empty;
+
+    public string OutputFormat { get; private set; } = PrintOutputFormats.Pdf;
+
+    public string Title { get; private set; } = "Planning commission map";
+
+    public string Subtitle { get; private set; } = "Parcels, zoning, and imagery context";
+
+    public string Author { get; private set; } = "Honua operator";
+
+    public int ScaleDenominator { get; private set; } = 24000;
+
+    public bool IncludeLegend { get; private set; } = true;
+
+    public bool IncludeScaleBar { get; private set; } = true;
+
+    public bool IncludeNorthArrow { get; private set; } = true;
+
+    public bool IncludeOverviewMap { get; private set; }
+
+    public bool BatchAtlas { get; private set; }
+
+    public event Action? OnChanged;
+
+    public bool IsLoading => Status == PrintServiceStatus.Loading;
+
+    public IReadOnlyList<PrintLayoutTemplate> Templates => Snapshot?.Templates ?? Array.Empty<PrintLayoutTemplate>();
+
+    public IReadOnlyList<PrintMapLayer> Layers => Snapshot?.Layers ?? Array.Empty<PrintMapLayer>();
+
+    public IReadOnlyList<PrintMapLayer> VisibleLayers
+        => Layers.Where(layer => _visibleLayerIds.Contains(layer.LayerId)).ToArray();
+
+    public IReadOnlyList<PrintJobSummary> Jobs { get; private set; } = Array.Empty<PrintJobSummary>();
+
+    public PrintLayoutTemplate? SelectedTemplate
+        => Templates.FirstOrDefault(template => string.Equals(template.TemplateId, TemplateId, StringComparison.OrdinalIgnoreCase));
+
+    public int VisibleLayerCount => _visibleLayerIds.Count;
+
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var version = Interlocked.Increment(ref _loadVersion);
+        Status = PrintServiceStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var snapshot = await _client.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+            if (version != Volatile.Read(ref _loadVersion))
+            {
+                return;
+            }
+
+            Snapshot = snapshot;
+            Jobs = snapshot.Jobs.OrderByDescending(job => job.CreatedAt).ToArray();
+            ApplyInitialSelection();
+            var previewVersion = Interlocked.Increment(ref _previewVersion);
+            var preview = await _client.PreviewAsync(BuildRequest(), cancellationToken).ConfigureAwait(false);
+            if (version != Volatile.Read(ref _loadVersion) ||
+                previewVersion != Volatile.Read(ref _previewVersion))
+            {
+                return;
+            }
+
+            Preview = preview;
+            Status = PrintServiceStatus.Ready;
+        }
+        catch (OperationCanceledException)
+        {
+            if (version == Volatile.Read(ref _loadVersion))
+            {
+                Status = PrintServiceStatus.Idle;
+            }
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (version == Volatile.Read(ref _loadVersion))
+            {
+                Status = PrintServiceStatus.Error;
+                LastError = ex.Message;
+            }
+        }
+        finally
+        {
+            if (version == Volatile.Read(ref _loadVersion))
+            {
+                Notify();
+            }
+        }
+    }
+
+    public async Task RefreshPreviewAsync(CancellationToken cancellationToken = default)
+    {
+        if (Snapshot is null)
+        {
+            await LoadAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var version = Interlocked.Increment(ref _previewVersion);
+        Status = PrintServiceStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var preview = await _client.PreviewAsync(BuildRequest(), cancellationToken).ConfigureAwait(false);
+            if (version != Volatile.Read(ref _previewVersion))
+            {
+                return;
+            }
+
+            Preview = preview;
+            Status = PrintServiceStatus.Ready;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (version == Volatile.Read(ref _previewVersion))
+            {
+                Status = PrintServiceStatus.Error;
+                LastError = ex.Message;
+            }
+        }
+        finally
+        {
+            if (version == Volatile.Read(ref _previewVersion))
+            {
+                Notify();
+            }
+        }
+    }
+
+    public async Task QueueExportAsync(CancellationToken cancellationToken = default)
+    {
+        if (Snapshot is null)
+        {
+            await LoadAsync(cancellationToken).ConfigureAwait(false);
+            if (Snapshot is null)
+            {
+                return;
+            }
+        }
+
+        var version = Interlocked.Increment(ref _previewVersion);
+        Status = PrintServiceStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var request = BuildRequest();
+            var job = await _client.QueueExportAsync(request, cancellationToken).ConfigureAwait(false);
+            Jobs = Jobs.Prepend(job).ToArray();
+            var preview = await _client.PreviewAsync(request, cancellationToken).ConfigureAwait(false);
+            if (version != Volatile.Read(ref _previewVersion))
+            {
+                return;
+            }
+
+            Preview = preview;
+            Status = PrintServiceStatus.Ready;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (version == Volatile.Read(ref _previewVersion))
+            {
+                Status = PrintServiceStatus.Error;
+                LastError = ex.Message;
+            }
+        }
+        finally
+        {
+            if (version == Volatile.Read(ref _previewVersion))
+            {
+                Notify();
+            }
+        }
+    }
+
+    public void SetTemplate(string? templateId)
+    {
+        var template = Templates.FirstOrDefault(item => string.Equals(item.TemplateId, templateId, StringComparison.OrdinalIgnoreCase))
+            ?? Templates.FirstOrDefault();
+        if (template is null)
+        {
+            return;
+        }
+
+        TemplateId = template.TemplateId;
+        OutputFormat = template.DefaultFormat;
+        IncludeLegend = template.IncludeLegendByDefault;
+        IncludeScaleBar = template.IncludeScaleBarByDefault;
+        IncludeNorthArrow = template.IncludeNorthArrowByDefault;
+        IncludeOverviewMap = template.IncludeOverviewMapByDefault;
+        if (!template.SupportsAtlas)
+        {
+            BatchAtlas = false;
+        }
+
+        Notify();
+    }
+
+    public void SetOutputFormat(string? format)
+    {
+        OutputFormat = PrintOutputFormats.Options.FirstOrDefault(option => string.Equals(option, format, StringComparison.OrdinalIgnoreCase))
+            ?? PrintOutputFormats.Pdf;
+        Notify();
+    }
+
+    public void SetTitle(string? title)
+    {
+        Title = string.IsNullOrWhiteSpace(title) ? "Untitled map export" : title;
+        Notify();
+    }
+
+    public void SetSubtitle(string? subtitle)
+    {
+        Subtitle = subtitle ?? string.Empty;
+        Notify();
+    }
+
+    public void SetAuthor(string? author)
+    {
+        Author = string.IsNullOrWhiteSpace(author) ? "Honua operator" : author;
+        Notify();
+    }
+
+    public void SetScaleDenominator(int value)
+    {
+        ScaleDenominator = Math.Clamp(value, 100, 10_000_000);
+        Notify();
+    }
+
+    public void SetIncludeLegend(bool value)
+    {
+        IncludeLegend = value;
+        Notify();
+    }
+
+    public void SetIncludeScaleBar(bool value)
+    {
+        IncludeScaleBar = value;
+        Notify();
+    }
+
+    public void SetIncludeNorthArrow(bool value)
+    {
+        IncludeNorthArrow = value;
+        Notify();
+    }
+
+    public void SetIncludeOverviewMap(bool value)
+    {
+        IncludeOverviewMap = value;
+        Notify();
+    }
+
+    public void SetBatchAtlas(bool value)
+    {
+        BatchAtlas = value && SelectedTemplate?.SupportsAtlas == true;
+        Notify();
+    }
+
+    public void SetLayerVisibility(string layerId, bool visible)
+    {
+        if (visible)
+        {
+            _visibleLayerIds.Add(layerId);
+        }
+        else
+        {
+            _visibleLayerIds.Remove(layerId);
+        }
+
+        Notify();
+    }
+
+    public bool IsLayerVisible(string layerId) => _visibleLayerIds.Contains(layerId);
+
+    public PrintExportPayload ExportPreviewManifest()
+    {
+        if (Preview is null)
+        {
+            throw new InvalidOperationException("Print preview has not loaded.");
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("Honua print preview");
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Generated: {Preview.GeneratedAt:u}"));
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Title: {Preview.Title}"));
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Template: {Preview.TemplateName}"));
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Format: {Preview.Format}"));
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Scale: 1:{Preview.ScaleDenominator:N0}"));
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Pages: {Preview.PageCount:N0}"));
+        builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Export URL: {Preview.ExportUrl}"));
+        builder.AppendLine("Layers:");
+        foreach (var layer in Preview.Layers)
+        {
+            builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"- {layer.DisplayName} ({layer.Protocol})"));
+        }
+
+        var slug = Slugify(Preview.Title);
+        return new PrintExportPayload($"{slug}-preview.txt", "text/plain", builder.ToString());
+    }
+
+    private void ApplyInitialSelection()
+    {
+        if (string.IsNullOrWhiteSpace(TemplateId) ||
+            !Templates.Any(template => string.Equals(template.TemplateId, TemplateId, StringComparison.OrdinalIgnoreCase)))
+        {
+            SetTemplate(Templates.FirstOrDefault()?.TemplateId);
+        }
+
+        var validLayerIds = Layers.Select(layer => layer.LayerId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _visibleLayerIds.RemoveWhere(layerId => !validLayerIds.Contains(layerId));
+
+        if (_visibleLayerIds.Count == 0)
+        {
+            foreach (var layer in Layers.Where(layer => layer.VisibleByDefault))
+            {
+                _visibleLayerIds.Add(layer.LayerId);
+            }
+        }
+    }
+
+    private PrintJobRequest BuildRequest()
+        => new()
+        {
+            TemplateId = TemplateId,
+            Format = OutputFormat,
+            Title = Title,
+            Subtitle = Subtitle,
+            Author = Author,
+            ScaleDenominator = ScaleDenominator,
+            IncludeLegend = IncludeLegend,
+            IncludeScaleBar = IncludeScaleBar,
+            IncludeNorthArrow = IncludeNorthArrow,
+            IncludeOverviewMap = IncludeOverviewMap,
+            BatchAtlas = BatchAtlas,
+            VisibleLayerIds = _visibleLayerIds.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray(),
+        };
+
+    private static string Slugify(string value)
+    {
+        var chars = value
+            .Trim()
+            .ToLowerInvariant()
+            .Select(ch => char.IsLetterOrDigit(ch) ? ch : '-')
+            .ToArray();
+        var compact = string.Join("-", new string(chars).Split('-', StringSplitOptions.RemoveEmptyEntries));
+        return string.IsNullOrWhiteSpace(compact) ? "honua-map-export" : compact;
+    }
+
+    private void Notify() => OnChanged?.Invoke();
+}

--- a/src/Honua.Admin/Services/PrintService/StubPrintServiceClient.cs
+++ b/src/Honua.Admin/Services/PrintService/StubPrintServiceClient.cs
@@ -1,0 +1,292 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.PrintService;
+
+namespace Honua.Admin.Services.PrintService;
+
+public sealed class StubPrintServiceClient : IPrintServiceClient
+{
+    private static readonly DateTimeOffset BaselineNow = DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture);
+    private int _jobSequence = 320;
+
+    public Task<PrintServiceSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new PrintServiceSnapshot
+        {
+            GeneratedAt = BaselineNow,
+            Templates = Templates,
+            Layers = Layers,
+            Jobs =
+            [
+                new PrintJobSummary
+                {
+                    JobId = "print-319",
+                    Title = "Planning commission packet",
+                    TemplateName = "Tabloid landscape",
+                    Format = PrintOutputFormats.Pdf,
+                    Status = PrintJobStatuses.Complete,
+                    PageCount = 12,
+                    CreatedAt = BaselineNow.AddMinutes(-42),
+                    CompletedAt = BaselineNow.AddMinutes(-39),
+                    FileName = "planning-commission-packet.pdf",
+                },
+                new PrintJobSummary
+                {
+                    JobId = "print-318",
+                    Title = "Field inspection map",
+                    TemplateName = "Letter portrait",
+                    Format = PrintOutputFormats.Png,
+                    Status = PrintJobStatuses.Rendering,
+                    PageCount = 1,
+                    CreatedAt = BaselineNow.AddMinutes(-8),
+                    FileName = "field-inspection-map.png",
+                },
+            ],
+        });
+    }
+
+    public Task<PrintPreviewDocument> PreviewAsync(PrintJobRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(BuildPreview(request, BaselineNow));
+    }
+
+    public Task<PrintJobSummary> QueueExportAsync(PrintJobRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var preview = BuildPreview(request, BaselineNow);
+        var jobId = Interlocked.Increment(ref _jobSequence);
+        var slug = Slugify(string.IsNullOrWhiteSpace(request.Title) ? "honua-map-export" : request.Title);
+        var extension = string.Equals(request.Format, PrintOutputFormats.Png, StringComparison.OrdinalIgnoreCase) ? "png" : "pdf";
+
+        return Task.FromResult(new PrintJobSummary
+        {
+            JobId = string.Create(CultureInfo.InvariantCulture, $"print-{jobId}"),
+            Title = preview.Title,
+            TemplateName = preview.TemplateName,
+            Format = preview.Format,
+            Status = request.BatchAtlas ? PrintJobStatuses.Queued : PrintJobStatuses.Complete,
+            PageCount = preview.PageCount,
+            CreatedAt = BaselineNow.AddMinutes(jobId - 320),
+            CompletedAt = request.BatchAtlas ? null : BaselineNow.AddMinutes(jobId - 320).AddSeconds(18),
+            FileName = $"{slug}.{extension}",
+        });
+    }
+
+    private static PrintPreviewDocument BuildPreview(PrintJobRequest request, DateTimeOffset now)
+    {
+        var template = Templates.FirstOrDefault(item => string.Equals(item.TemplateId, request.TemplateId, StringComparison.OrdinalIgnoreCase))
+            ?? Templates[0];
+        var selectedIds = request.VisibleLayerIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var selectedLayers = Layers
+            .Where(layer => selectedIds.Contains(layer.LayerId))
+            .Select(layer => new PrintPreviewLayer
+            {
+                LayerId = layer.LayerId,
+                DisplayName = $"{layer.ServiceName} / {layer.LayerName}",
+                Protocol = layer.Protocol,
+                SymbolColor = layer.SymbolColor,
+                FeatureCount = layer.FeatureCount,
+            })
+            .ToArray();
+        var elements = BuildElements(request).ToArray();
+        var warnings = BuildWarnings(request, selectedLayers, template).ToArray();
+        var pageCount = request.BatchAtlas ? Math.Max(1, selectedLayers.Length * 3) : 1;
+
+        return new PrintPreviewDocument
+        {
+            GeneratedAt = now,
+            TemplateId = template.TemplateId,
+            TemplateName = template.Name,
+            Format = NormalizeFormat(request.Format),
+            Title = string.IsNullOrWhiteSpace(request.Title) ? "Untitled map export" : request.Title.Trim(),
+            Subtitle = request.Subtitle.Trim(),
+            Author = string.IsNullOrWhiteSpace(request.Author) ? "Honua operator" : request.Author.Trim(),
+            ExportUrl = BuildExportUrl(template, request),
+            WidthInches = template.WidthInches,
+            HeightInches = template.HeightInches,
+            ScaleDenominator = request.ScaleDenominator,
+            PageCount = pageCount,
+            EstimatedFileSizeBytes = EstimateBytes(template, selectedLayers.Length, elements.Length, pageCount, request.Format),
+            Layers = selectedLayers,
+            Elements = elements,
+            Warnings = warnings,
+        };
+    }
+
+    private static IEnumerable<PrintLayoutElement> BuildElements(PrintJobRequest request)
+    {
+        yield return new PrintLayoutElement { Name = "Map frame", Position = "center" };
+        yield return new PrintLayoutElement { Name = "Title block", Position = "top" };
+        if (request.IncludeLegend)
+        {
+            yield return new PrintLayoutElement { Name = "Legend", Position = "right" };
+        }
+
+        if (request.IncludeScaleBar)
+        {
+            yield return new PrintLayoutElement { Name = "Scale bar", Position = "bottom-left" };
+        }
+
+        if (request.IncludeNorthArrow)
+        {
+            yield return new PrintLayoutElement { Name = "North arrow", Position = "top-right" };
+        }
+
+        if (request.IncludeOverviewMap)
+        {
+            yield return new PrintLayoutElement { Name = "Overview map", Position = "bottom-right" };
+        }
+    }
+
+    private static IEnumerable<string> BuildWarnings(PrintJobRequest request, IReadOnlyCollection<PrintPreviewLayer> selectedLayers, PrintLayoutTemplate template)
+    {
+        if (selectedLayers.Count == 0)
+        {
+            yield return "No visible layers selected.";
+        }
+
+        if (request.BatchAtlas && !template.SupportsAtlas)
+        {
+            yield return "Selected template does not support atlas output.";
+        }
+
+        if (request.ScaleDenominator < 500)
+        {
+            yield return "Scale denominator is unusually detailed for server-side rendering.";
+        }
+    }
+
+    private static string BuildExportUrl(PrintLayoutTemplate template, PrintJobRequest request)
+    {
+        var format = string.Equals(request.Format, PrintOutputFormats.Png, StringComparison.OrdinalIgnoreCase) ? "png" : "pdf";
+        var layout = Uri.EscapeDataString(template.TemplateId);
+        return $"/rest/services/default/MapServer/export?format={format}&layout={layout}";
+    }
+
+    private static long EstimateBytes(PrintLayoutTemplate template, int layerCount, int elementCount, int pageCount, string format)
+    {
+        var formatMultiplier = string.Equals(format, PrintOutputFormats.Png, StringComparison.OrdinalIgnoreCase) ? 1.4 : 1d;
+        var pageArea = template.WidthInches * template.HeightInches;
+        return (long)Math.Round((96_000 + pageArea * 1_800 + layerCount * 44_000 + elementCount * 8_500) * pageCount * formatMultiplier);
+    }
+
+    private static string NormalizeFormat(string format)
+        => string.Equals(format, PrintOutputFormats.Png, StringComparison.OrdinalIgnoreCase)
+            ? PrintOutputFormats.Png
+            : PrintOutputFormats.Pdf;
+
+    private static string Slugify(string value)
+    {
+        var chars = value
+            .Trim()
+            .ToLowerInvariant()
+            .Select(ch => char.IsLetterOrDigit(ch) ? ch : '-')
+            .ToArray();
+        var compact = string.Join("-", new string(chars).Split('-', StringSplitOptions.RemoveEmptyEntries));
+        return string.IsNullOrWhiteSpace(compact) ? "honua-map-export" : compact;
+    }
+
+    private static IReadOnlyList<PrintLayoutTemplate> Templates { get; } =
+    [
+        new PrintLayoutTemplate
+        {
+            TemplateId = "letter-portrait",
+            Name = "Letter portrait",
+            PageSize = "Letter",
+            Orientation = "Portrait",
+            WidthInches = 8.5,
+            HeightInches = 11,
+            RequiredEdition = "Community",
+            DefaultFormat = PrintOutputFormats.Pdf,
+            SupportsAtlas = false,
+            IncludeOverviewMapByDefault = false,
+        },
+        new PrintLayoutTemplate
+        {
+            TemplateId = "tabloid-landscape",
+            Name = "Tabloid landscape",
+            PageSize = "Tabloid",
+            Orientation = "Landscape",
+            WidthInches = 17,
+            HeightInches = 11,
+            RequiredEdition = "Community",
+            DefaultFormat = PrintOutputFormats.Pdf,
+            SupportsAtlas = true,
+            IncludeOverviewMapByDefault = true,
+        },
+        new PrintLayoutTemplate
+        {
+            TemplateId = "a3-atlas",
+            Name = "A3 atlas",
+            PageSize = "A3",
+            Orientation = "Landscape",
+            WidthInches = 16.5,
+            HeightInches = 11.7,
+            RequiredEdition = "Pro",
+            DefaultFormat = PrintOutputFormats.Pdf,
+            SupportsAtlas = true,
+            IncludeOverviewMapByDefault = true,
+        },
+    ];
+
+    private static IReadOnlyList<PrintMapLayer> Layers { get; } =
+    [
+        new PrintMapLayer
+        {
+            LayerId = "default:parcels",
+            ServiceName = "default",
+            LayerName = "Parcels",
+            Protocol = "FeatureServer",
+            GeometryType = "Polygon",
+            SymbolColor = "#2563eb",
+            Attribution = "County cadastral source",
+            FeatureCount = 184_220,
+        },
+        new PrintMapLayer
+        {
+            LayerId = "planning:zoning",
+            ServiceName = "planning",
+            LayerName = "Zoning districts",
+            Protocol = "MapServer",
+            GeometryType = "Polygon",
+            SymbolColor = "#16a34a",
+            Attribution = "Planning department",
+            FeatureCount = 2_918,
+        },
+        new PrintMapLayer
+        {
+            LayerId = "imagery:orthophoto",
+            ServiceName = "imagery",
+            LayerName = "Orthophoto mosaic",
+            Protocol = "ImageServer",
+            GeometryType = "Raster",
+            SymbolColor = "#64748b",
+            Attribution = "State imagery program",
+            FeatureCount = 1,
+        },
+        new PrintMapLayer
+        {
+            LayerId = "basemap:addresses",
+            ServiceName = "basemap",
+            LayerName = "Address points",
+            Protocol = "OData",
+            GeometryType = "Point",
+            SymbolColor = "#dc2626",
+            Attribution = "Address authority",
+            FeatureCount = 72_104,
+            VisibleByDefault = false,
+        },
+    ];
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -26,6 +26,9 @@
     <MudNavLink Href="/operator/analytics" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Insights">
         Usage analytics
     </MudNavLink>
+    <MudNavLink Href="/operator/print" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Print">
+        Print service
+    </MudNavLink>
 
     <MudNavGroup Title="Operations" Icon="@Icons.Material.Filled.Settings" Expanded="true">
         <MudNavLink Href="/operator/operations" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">

--- a/src/Honua.Admin/wwwroot/css/print-service.css
+++ b/src/Honua.Admin/wwwroot/css/print-service.css
@@ -1,0 +1,201 @@
+.print-service-root {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+}
+
+.print-service-toolbar,
+.print-service-panel {
+    border: 1px solid var(--mud-palette-divider, #d9dee3);
+    border-radius: 6px;
+    background: var(--mud-palette-surface, #ffffff);
+}
+
+.print-service-toolbar,
+.print-service-panel,
+.print-service-tab-panel {
+    padding: 12px;
+}
+
+.print-service-toolbar-row {
+    flex-wrap: wrap;
+}
+
+.print-service-metric {
+    min-height: 112px;
+}
+
+.print-service-option-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2px 8px;
+}
+
+.print-service-preview-wrap {
+    display: flex;
+    justify-content: center;
+    overflow: auto;
+    padding: 8px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+}
+
+.print-service-sheet {
+    position: relative;
+    width: min(100%, 820px);
+    min-width: 320px;
+    background: #ffffff;
+    border: 1px solid #94a3b8;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+    padding: 18px;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    gap: 10px;
+}
+
+.print-service-title-block {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.print-service-title-block strong {
+    font-size: 18px;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.print-service-title-block span {
+    color: #475569;
+    font-size: 12px;
+    overflow-wrap: anywhere;
+}
+
+.print-service-map-frame {
+    position: relative;
+    min-height: 260px;
+    border: 1px solid #64748b;
+    background:
+        linear-gradient(90deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px),
+        #eef2f7;
+    background-size: 48px 48px;
+    overflow: hidden;
+}
+
+.print-service-map-band {
+    min-height: 46px;
+    margin: 12px;
+    border-left: 8px solid #2563eb;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    color: #0f172a;
+    font-size: 12px;
+    overflow-wrap: anywhere;
+}
+
+.print-service-empty-map {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: #64748b;
+}
+
+.print-service-north,
+.print-service-overview,
+.print-service-scale,
+.print-service-legend,
+.print-service-attribution {
+    position: absolute;
+    border: 1px solid #cbd5e1;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 4px;
+    color: #0f172a;
+    font-size: 11px;
+}
+
+.print-service-north {
+    top: 66px;
+    right: 28px;
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+}
+
+.print-service-legend {
+    right: 28px;
+    top: 112px;
+    max-width: 230px;
+    padding: 8px;
+    display: grid;
+    gap: 4px;
+}
+
+.print-service-legend div {
+    display: grid;
+    grid-template-columns: 12px minmax(0, 1fr);
+    gap: 6px;
+    align-items: center;
+}
+
+.print-service-legend span {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    display: block;
+}
+
+.print-service-legend em {
+    font-style: normal;
+    overflow-wrap: anywhere;
+}
+
+.print-service-scale {
+    left: 28px;
+    bottom: 38px;
+    padding: 5px 10px;
+}
+
+.print-service-overview {
+    right: 28px;
+    bottom: 38px;
+    width: 112px;
+    height: 76px;
+    display: grid;
+    place-items: center;
+}
+
+.print-service-attribution {
+    left: 18px;
+    right: 18px;
+    bottom: 10px;
+    padding: 3px 6px;
+    color: #475569;
+}
+
+@media (max-width: 720px) {
+    .print-service-root {
+        padding: 8px;
+    }
+
+    .print-service-option-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .print-service-sheet {
+        min-width: 280px;
+        padding: 12px;
+    }
+
+    .print-service-legend {
+        max-width: 170px;
+    }
+}

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -15,6 +15,7 @@
     <link href="css/annotation-workspace.css" rel="stylesheet" />
     <link href="css/publishing-workspace.css" rel="stylesheet" />
     <link href="css/usage-analytics.css" rel="stylesheet" />
+    <link href="css/print-service.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -43,6 +44,7 @@
     <script src="js/spatial-sql-interop.js"></script>
     <script src="js/annotation-workspace-interop.js"></script>
     <script src="js/usage-analytics-interop.js"></script>
+    <script src="js/print-service-interop.js"></script>
 </body>
 
 </html>

--- a/src/Honua.Admin/wwwroot/js/print-service-interop.js
+++ b/src/Honua.Admin/wwwroot/js/print-service-interop.js
@@ -1,0 +1,17 @@
+window.printService = (function () {
+    function downloadFile(filename, mimeType, content) {
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    return {
+        downloadFile
+    };
+})();

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -52,6 +52,16 @@ public sealed class NavMenuTests
     }
 
     [Fact]
+    public void NavMenu_registers_print_service_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/print", contents, System.StringComparison.Ordinal);
+        Assert.Contains("Print service", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NavMenu_uses_a_single_MudNavMenu_so_sql_page_lives_in_the_shared_shell()
     {
         var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
@@ -68,6 +78,7 @@ public sealed class NavMenuTests
         var operatorAnnotations = contents.IndexOf("/operator/annotations", System.StringComparison.Ordinal);
         var operatorPublishing = contents.IndexOf("/operator/publishing", System.StringComparison.Ordinal);
         var operatorAnalytics = contents.IndexOf("/operator/analytics", System.StringComparison.Ordinal);
+        var operatorPrint = contents.IndexOf("/operator/print", System.StringComparison.Ordinal);
         var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
 
         Assert.True(operatorSpec > 0);
@@ -75,9 +86,11 @@ public sealed class NavMenuTests
         Assert.True(operatorAnnotations > 0);
         Assert.True(operatorPublishing > 0);
         Assert.True(operatorAnalytics > 0);
+        Assert.True(operatorPrint > 0);
         Assert.True(operatorSql < menuClose);
         Assert.True(operatorAnnotations < menuClose);
         Assert.True(operatorPublishing < menuClose);
         Assert.True(operatorAnalytics < menuClose);
+        Assert.True(operatorPrint < menuClose);
     }
 }

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -11,6 +11,7 @@ using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.Operations;
+using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +33,8 @@ public sealed class AdminPageRenderTests : TestContext
         Services.AddScoped<IAdminTelemetry, NullAdminTelemetry>();
         Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
         Services.AddScoped<UsageAnalyticsState>();
+        Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
+        Services.AddScoped<PrintServiceState>();
         Services.AddTestRealtime();
     }
 
@@ -195,6 +198,21 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Parcels");
             cut.Markup.MarkupMatchesContaining("CSV");
             cut.Markup.MarkupMatchesContaining("PDF");
+        });
+    }
+
+    [Fact]
+    public void PrintService_RendersTemplatesPreviewAndQueue()
+    {
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.PrintService>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Print service");
+            cut.Markup.MarkupMatchesContaining("Letter portrait");
+            cut.Markup.MarkupMatchesContaining("Preview");
+            cut.Markup.MarkupMatchesContaining("Queue export");
+            cut.Markup.MarkupMatchesContaining("Planning commission packet");
         });
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -11,6 +11,7 @@ using Honua.Admin.Models.Admin;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.AspNetCore.Components;
@@ -39,6 +40,8 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<PublishingWorkspaceState>();
         Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
         Services.AddScoped<UsageAnalyticsState>();
+        Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
+        Services.AddScoped<PrintServiceState>();
         Services.AddTestRealtime();
     }
 
@@ -113,6 +116,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Operator.UsageAnalytics),
             "Queries per second",
             new[] { "[aria-label='Usage analytics toolbar']", "[aria-label='Popular layers']" },
+        ];
+        yield return
+        [
+            "Print service",
+            typeof(Honua.Admin.Pages.Operator.PrintService),
+            "Letter portrait",
+            new[] { "[aria-label='Print service toolbar']", "[aria-label='Print preview']", "[aria-label='Print job queue']" },
         ];
     }
 

--- a/tests/Honua.Admin.Tests/PrintServiceStateTests.cs
+++ b/tests/Honua.Admin.Tests/PrintServiceStateTests.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.PrintService;
+using Honua.Admin.Services.PrintService;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class PrintServiceStateTests
+{
+    [Fact]
+    public async Task LoadAsync_populates_templates_preview_layers_and_queue()
+    {
+        var state = new PrintServiceState(new StubPrintServiceClient());
+
+        await state.LoadAsync();
+
+        Assert.Equal(PrintServiceStatus.Ready, state.Status);
+        Assert.NotEmpty(state.Templates);
+        Assert.NotEmpty(state.Layers);
+        Assert.NotEmpty(state.VisibleLayers);
+        Assert.NotEmpty(state.Jobs);
+        Assert.NotNull(state.Preview);
+        Assert.Contains("/rest/services/default/MapServer/export", state.Preview.ExportUrl, StringComparison.Ordinal);
+        Assert.Contains("layout=letter-portrait", state.Preview.ExportUrl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Preview_reflects_template_layer_and_atlas_options()
+    {
+        var state = new PrintServiceState(new StubPrintServiceClient());
+        await state.LoadAsync();
+
+        state.SetTemplate("a3-atlas");
+        state.SetBatchAtlas(true);
+        foreach (var layer in state.Layers)
+        {
+            state.SetLayerVisibility(layer.LayerId, visible: false);
+        }
+
+        await state.RefreshPreviewAsync();
+
+        Assert.Equal("A3 atlas", state.Preview?.TemplateName);
+        Assert.Contains("No visible layers selected.", state.Preview?.Warnings ?? Array.Empty<string>());
+        Assert.Empty(state.Preview?.Layers ?? Array.Empty<PrintPreviewLayer>());
+
+        state.SetLayerVisibility("default:parcels", visible: true);
+        await state.RefreshPreviewAsync();
+
+        Assert.True(state.Preview?.PageCount > 1);
+        var previewLayer = Assert.Single(state.Preview?.Layers ?? Array.Empty<PrintPreviewLayer>());
+        Assert.Equal("default / Parcels", previewLayer.DisplayName);
+    }
+
+    [Fact]
+    public async Task QueueExportAsync_adds_a_job_using_current_format_and_template()
+    {
+        var state = new PrintServiceState(new StubPrintServiceClient());
+        await state.LoadAsync();
+
+        state.SetTemplate("tabloid-landscape");
+        state.SetOutputFormat("png");
+        state.SetTitle("Field inspection export");
+        await state.QueueExportAsync();
+
+        var job = state.Jobs[0];
+        Assert.Equal("Field inspection export", job.Title);
+        Assert.Equal("Tabloid landscape", job.TemplateName);
+        Assert.Equal(PrintOutputFormats.Png, job.Format);
+        Assert.EndsWith(".png", job.FileName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueueExportAsync_stops_when_snapshot_bootstrap_fails()
+    {
+        var client = new FailingSnapshotClient();
+        var state = new PrintServiceState(client);
+
+        await state.QueueExportAsync();
+
+        Assert.Equal(PrintServiceStatus.Error, state.Status);
+        Assert.Equal("snapshot failed", state.LastError);
+        Assert.False(client.QueueExportCalled);
+    }
+
+    [Fact]
+    public async Task ExportPreviewManifest_includes_print_request_context()
+    {
+        var state = new PrintServiceState(new StubPrintServiceClient());
+        await state.LoadAsync();
+
+        var payload = state.ExportPreviewManifest();
+
+        Assert.Equal("text/plain", payload.MimeType);
+        Assert.EndsWith("-preview.txt", payload.FileName, StringComparison.Ordinal);
+        Assert.Contains("Honua print preview", payload.Content, StringComparison.Ordinal);
+        Assert.Contains("Scale: 1:24,000", payload.Content, StringComparison.Ordinal);
+        Assert.Contains("default / Parcels", payload.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RefreshPreviewAsync_ignores_stale_preview_responses()
+    {
+        var stalePreview = new TaskCompletionSource<PrintPreviewDocument>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new SequencedPrintServiceClient(
+            Snapshot(DefaultLayers()),
+            PreviewStep(request => Preview(request)),
+            PreviewStep(_ => stalePreview.Task),
+            PreviewStep(request => Preview(request)));
+        var state = new PrintServiceState(client);
+
+        await state.LoadAsync();
+        state.SetTitle("Old title");
+        var staleRefresh = state.RefreshPreviewAsync();
+        state.SetTitle("New title");
+        await state.RefreshPreviewAsync();
+
+        stalePreview.SetResult(Preview(new PrintJobRequest { Title = "Old title", TemplateId = "letter-portrait" }));
+        await staleRefresh;
+
+        Assert.Equal("New title", state.Preview?.Title);
+    }
+
+    [Fact]
+    public async Task RefreshPreviewAsync_ignores_stale_preview_failures()
+    {
+        var stalePreview = new TaskCompletionSource<PrintPreviewDocument>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new SequencedPrintServiceClient(
+            Snapshot(DefaultLayers()),
+            PreviewStep(request => Preview(request)),
+            PreviewStep(_ => stalePreview.Task),
+            PreviewStep(request => Preview(request)));
+        var state = new PrintServiceState(client);
+
+        await state.LoadAsync();
+        var staleRefresh = state.RefreshPreviewAsync();
+        state.SetTitle("Recovered title");
+        await state.RefreshPreviewAsync();
+
+        stalePreview.SetException(new InvalidOperationException("stale preview failed"));
+        await staleRefresh;
+
+        Assert.Equal(PrintServiceStatus.Ready, state.Status);
+        Assert.Null(state.LastError);
+        Assert.Equal("Recovered title", state.Preview?.Title);
+    }
+
+    [Fact]
+    public async Task LoadAsync_reconciles_visible_layers_when_snapshot_catalog_changes()
+    {
+        var client = new SequencedPrintServiceClient(
+            Snapshot(DefaultLayers()),
+            PreviewStep(request => Preview(request)),
+            Snapshot(DefaultLayers().Skip(1).ToArray()),
+            PreviewStep(request => Preview(request)));
+        var state = new PrintServiceState(client);
+
+        await state.LoadAsync();
+        Assert.True(state.IsLayerVisible("default:parcels"));
+
+        await state.LoadAsync();
+
+        Assert.False(state.IsLayerVisible("default:parcels"));
+        Assert.DoesNotContain("default:parcels", client.LastPreviewRequest?.VisibleLayerIds ?? Array.Empty<string>());
+    }
+
+    [Fact]
+    public async Task LoadAsync_reselects_template_when_snapshot_catalog_changes()
+    {
+        var client = new SequencedPrintServiceClient(
+            Snapshot(DefaultLayers(), [Template("letter-portrait", "Letter portrait")]),
+            PreviewStep(request => Preview(request)),
+            Snapshot(DefaultLayers(), [Template("tabloid-landscape", "Tabloid landscape")]),
+            PreviewStep(request => Preview(request)));
+        var state = new PrintServiceState(client);
+
+        await state.LoadAsync();
+        Assert.Equal("letter-portrait", state.TemplateId);
+
+        await state.LoadAsync();
+
+        Assert.Equal("tabloid-landscape", state.TemplateId);
+        Assert.Equal("tabloid-landscape", client.LastPreviewRequest?.TemplateId);
+    }
+
+    private static IReadOnlyList<PrintMapLayer> DefaultLayers()
+        =>
+        [
+            new PrintMapLayer
+            {
+                LayerId = "default:parcels",
+                ServiceName = "default",
+                LayerName = "Parcels",
+                Protocol = "FeatureServer",
+                VisibleByDefault = true,
+            },
+            new PrintMapLayer
+            {
+                LayerId = "planning:zoning",
+                ServiceName = "planning",
+                LayerName = "Zoning districts",
+                Protocol = "MapServer",
+                VisibleByDefault = true,
+            },
+        ];
+
+    private static PrintServiceSnapshot Snapshot(
+        IReadOnlyList<PrintMapLayer> layers,
+        IReadOnlyList<PrintLayoutTemplate>? templates = null)
+        => new()
+        {
+            GeneratedAt = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            Templates = templates ?? [Template("letter-portrait", "Letter portrait")],
+            Layers = layers,
+        };
+
+    private static PrintLayoutTemplate Template(string templateId, string name)
+        => new()
+        {
+            TemplateId = templateId,
+            Name = name,
+            PageSize = "Letter",
+            Orientation = "Portrait",
+            WidthInches = 8.5,
+            HeightInches = 11,
+            IncludeLegendByDefault = true,
+            IncludeScaleBarByDefault = true,
+            IncludeNorthArrowByDefault = true,
+        };
+
+    private static PrintPreviewDocument Preview(PrintJobRequest request)
+        => new()
+        {
+            GeneratedAt = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            TemplateId = request.TemplateId,
+            TemplateName = "Letter portrait",
+            Format = request.Format,
+            Title = string.IsNullOrWhiteSpace(request.Title) ? "Untitled map export" : request.Title,
+            ScaleDenominator = request.ScaleDenominator,
+            ExportUrl = "/rest/services/default/MapServer/export?format=pdf&layout=letter-portrait",
+        };
+
+    private static Func<PrintJobRequest, Task<PrintPreviewDocument>> PreviewStep(Func<PrintJobRequest, PrintPreviewDocument> build)
+        => request => Task.FromResult(build(request));
+
+    private static Func<PrintJobRequest, Task<PrintPreviewDocument>> PreviewStep(Func<PrintJobRequest, Task<PrintPreviewDocument>> build)
+        => build;
+
+    private sealed class SequencedPrintServiceClient : IPrintServiceClient
+    {
+        private readonly Queue<PrintServiceSnapshot> _snapshots = new();
+        private readonly Queue<Func<PrintJobRequest, Task<PrintPreviewDocument>>> _previews = new();
+
+        public SequencedPrintServiceClient(params object[] steps)
+        {
+            foreach (var step in steps)
+            {
+                switch (step)
+                {
+                    case PrintServiceSnapshot snapshot:
+                        _snapshots.Enqueue(snapshot);
+                        break;
+                    case Func<PrintJobRequest, Task<PrintPreviewDocument>> preview:
+                        _previews.Enqueue(preview);
+                        break;
+                }
+            }
+        }
+
+        public PrintJobRequest? LastPreviewRequest { get; private set; }
+
+        public Task<PrintServiceSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => Task.FromResult(_snapshots.Dequeue());
+
+        public Task<PrintPreviewDocument> PreviewAsync(PrintJobRequest request, CancellationToken cancellationToken)
+        {
+            LastPreviewRequest = request;
+            return _previews.Dequeue()(request);
+        }
+
+        public Task<PrintJobSummary> QueueExportAsync(PrintJobRequest request, CancellationToken cancellationToken)
+            => Task.FromResult(new PrintJobSummary
+            {
+                JobId = "print-test",
+                Title = request.Title,
+                TemplateName = "Letter portrait",
+                Format = request.Format,
+                CreatedAt = DateTimeOffset.Parse("2026-04-25T12:00:00Z"),
+            });
+    }
+
+    private sealed class FailingSnapshotClient : IPrintServiceClient
+    {
+        public bool QueueExportCalled { get; private set; }
+
+        public Task<PrintServiceSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => throw new InvalidOperationException("snapshot failed");
+
+        public Task<PrintPreviewDocument> PreviewAsync(PrintJobRequest request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("preview should not run");
+
+        public Task<PrintJobSummary> QueueExportAsync(PrintJobRequest request, CancellationToken cancellationToken)
+        {
+            QueueExportCalled = true;
+            return Task.FromResult(new PrintJobSummary());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an experimental print service workspace at `/operator/print` with layout template selection, PDF/PNG output options, visible layer controls, preview, and queue management
- add print service models, state, and deterministic stub client to mirror the future server render API contract
- wire navigation, assets, render smoke tests, quality gates, and state coverage

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"

Closes #3