### PR TITLE
feat: add admin control center overview

### DIFF
--- a/src/Honua.Admin/Pages/Operator/ControlCenter.razor
+++ b/src/Honua.Admin/Pages/Operator/ControlCenter.razor
@@ -1,0 +1,283 @@
+@page "/operator/control-center"
+@using Honua.Admin.Services.Operations
+@inherits Honua.Admin.Shared.AdminPageBase
+@implements IDisposable
+@inject OperationsConsoleState State
+@inject IAdminRealtimeEvents RealtimeEvents
+
+<PageTitle>Admin control center - Honua Server Admin</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="mt-4" data-testid="control-center-root">
+    <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-4">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.h4">
+                <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Class="mr-2" />
+                Admin control center
+            </MudText>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@StatusColor(State.Status)" data-testid="control-center-status">
+                @State.Status
+            </MudChip>
+        </MudStack>
+        <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="RefreshAsync" Disabled="@IsBusy">
+            Refresh
+        </MudButton>
+    </MudStack>
+
+    <ErrorBanner Message="@ErrorMessage" />
+    @if (!string.IsNullOrWhiteSpace(State.LastError))
+    {
+        <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Filled" Class="mb-4" data-testid="control-center-warning">
+            @State.LastError
+        </MudAlert>
+    }
+
+    @if (IsBusy && State.DeployPreflight is null)
+    {
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="320px" Animation="Animation.Wave" />
+    }
+    else
+    {
+        <MudGrid Class="mb-4" aria-label="Control center surfaces">
+            <MudItem xs="12" md="3">
+                <MudCard Elevation="1">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Publishing</MudText>
+                        <MudText Typo="Typo.h6">@State.DriftLabel</MudText>
+                        <MudText Typo="Typo.body2">@PublishingSummary</MudText>
+                        <MudText Typo="Typo.caption">@PendingApprovalSummary</MudText>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudButton Href="/operator/publishing" Variant="Variant.Text" Size="Size.Small" StartIcon="@Icons.Material.Filled.Publish">
+                            Publishing
+                        </MudButton>
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudCard Elevation="1">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Operations</MudText>
+                        <MudText Typo="Typo.h6">@State.ReleaseHealthLabel</MudText>
+                        <MudText Typo="Typo.body2">@(State.DeployPreflight?.Message ?? SectionError("Deploy preflight") ?? "No preflight loaded")</MudText>
+                        <MudText Typo="Typo.caption">@($"{State.DeployPreflight?.Environment ?? "unknown"} / {State.DeployPreflight?.InstanceName ?? "unknown"}")</MudText>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudButton Href="/operator/operations" Variant="Variant.Text" Size="Size.Small" StartIcon="@Icons.Material.Filled.Settings">
+                            Operations
+                        </MudButton>
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudCard Elevation="1">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Release evidence</MudText>
+                        <MudText Typo="Typo.h6">@State.ReleaseEvidenceLabel</MudText>
+                        <MudText Typo="Typo.body2">@LatestGitOpsEvidence()</MudText>
+                        <MudText Typo="Typo.caption">@MigrationEvidence()</MudText>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudButton Href="/deploy" Variant="Variant.Text" Size="Size.Small" StartIcon="@Icons.Material.Filled.RocketLaunch">
+                            Deploy
+                        </MudButton>
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudCard Elevation="1">
+                    <MudCardContent>
+                        <MudText Typo="Typo.overline">Troubleshooting</MudText>
+                        <MudText Typo="Typo.h6">@State.TroubleshootingLabel</MudText>
+                        <MudText Typo="Typo.body2">@(State.TelemetryStatus?.OtlpEndpoint ?? SectionError("Telemetry") ?? "No OTLP endpoint")</MudText>
+                        <MudText Typo="Typo.caption">@(State.RecentErrors?.InstanceId ?? "unknown instance")</MudText>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudButton Href="/observability" Variant="Variant.Text" Size="Size.Small" StartIcon="@Icons.Material.Filled.MonitorHeart">
+                            Observability
+                        </MudButton>
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
+        </MudGrid>
+
+        @if (State.SectionErrors.Count > 0)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" Class="mb-4" data-testid="control-center-section-errors">
+                @string.Join("; ", State.SectionErrors.Select(error => $"{error.Key}: {error.Value}"))
+            </MudAlert>
+        }
+
+        <MudGrid>
+            <MudItem xs="12" lg="5">
+                <MudPaper Elevation="1" Class="pa-4" aria-label="Governance queue">
+                    <MudStack Row AlignItems="AlignItems.Center" Class="mb-2">
+                        <MudText Typo="Typo.h6">Governance queue</MudText>
+                        <MudSpacer />
+                        <MudButton Href="/operator/publishing" Variant="Variant.Text" Size="Size.Small">Review intent</MudButton>
+                    </MudStack>
+                    @if (State.PendingApprovals.Count > 0)
+                    {
+                        <MudTable Items="State.PendingApprovals" Dense="true" Hover="true" aria-label="Pending manifest approvals">
+                            <HeaderContent>
+                                <MudTh>Requested by</MudTh>
+                                <MudTh>Reason</MudTh>
+                                <MudTh>Resources</MudTh>
+                                <MudTh>Hash</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd>@context.RequestedBy</MudTd>
+                                <MudTd>@(context.RequestedReason ?? "No reason supplied")</MudTd>
+                                <MudTd>@context.ResourceCount</MudTd>
+                                <MudTd>@ShortHash(context.ManifestHash)</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
+                    else if (!string.IsNullOrWhiteSpace(SectionError("Manifest approvals")))
+                    {
+                        <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Text">
+                            @SectionError("Manifest approvals")
+                        </MudAlert>
+                    }
+                    else
+                    {
+                        <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Text">
+                            No pending manifest approvals.
+                        </MudAlert>
+                    }
+
+                    <MudDivider Class="my-4" />
+                    <MudText Typo="Typo.subtitle2">Drift evidence</MudText>
+                    @if (State.ManifestDrift?.Resources.Count > 0)
+                    {
+                        @foreach (var resource in State.ManifestDrift.Resources.Take(4))
+                        {
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning" Class="mr-1 mt-1">
+                                @($"{resource.Identifier.DisplayName}: {resource.DriftType}")
+                            </MudChip>
+                        }
+                    }
+                    else if (!string.IsNullOrWhiteSpace(SectionError("Manifest drift")))
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Warning">@SectionError("Manifest drift")</MudText>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Success">Manifest baseline in sync.</MudText>
+                    }
+                </MudPaper>
+            </MudItem>
+
+            <MudItem xs="12" lg="4">
+                <MudPaper Elevation="1" Class="pa-4">
+                    <MudStack Row AlignItems="AlignItems.Center" Class="mb-2">
+                        <MudText Typo="Typo.h6">Release evidence</MudText>
+                        <MudSpacer />
+                        <MudButton Href="/operator/operations" Variant="Variant.Text" Size="Size.Small">Operations</MudButton>
+                    </MudStack>
+                    <MudSimpleTable Dense="true" Hover="true" aria-label="Release evidence control center">
+                        <tbody>
+                            <tr><td>Preflight</td><td>@(State.DeployPreflight?.Status ?? SectionError("Deploy preflight") ?? "unknown")</td></tr>
+                            <tr><td>Version</td><td>@(State.DeployPreflight?.ServerVersion ?? "unknown")</td></tr>
+                            <tr><td>Migration</td><td>@MigrationEvidence()</td></tr>
+                            <tr><td>Latest manifest</td><td>@(State.LatestManifestVersion?.ManifestHash ?? SectionError("Manifest versions") ?? "none")</td></tr>
+                            <tr><td>Latest GitOps change</td><td>@LatestGitOpsEvidence()</td></tr>
+                        </tbody>
+                    </MudSimpleTable>
+                </MudPaper>
+            </MudItem>
+
+            <MudItem xs="12" lg="3">
+                <MudPaper Elevation="1" Class="pa-4" aria-label="Troubleshooting handoff">
+                    <MudText Typo="Typo.h6" Class="mb-2">Troubleshooting handoff</MudText>
+                    <MudList T="string" Dense="true">
+                        <MudListItem Href="/observability" Icon="@Icons.Material.Filled.Insights">
+                            Logs, traces, metrics, and recent errors
+                        </MudListItem>
+                        <MudListItem Href="/operator/operations" Icon="@Icons.Material.Filled.Settings">
+                            Rollout health, drift, and release evidence
+                        </MudListItem>
+                        <MudListItem Href="/deploy" Icon="@Icons.Material.Filled.RocketLaunch">
+                            Promotion, rollback, and operation status
+                        </MudListItem>
+                        <MudListItem Href="/server-info" Icon="@Icons.Material.Filled.Info">
+                            Version, configuration, and OpenAPI
+                        </MudListItem>
+                    </MudList>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    }
+</MudContainer>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += StateChanged;
+        RealtimeEvents.RecentErrorReceived += OnRecentErrorReceived;
+        RealtimeEvents.MigrationStatusChanged += OnMigrationStatusChanged;
+        Telemetry.PageNavigated("/operator/control-center", principalId: null);
+        await RefreshAsync();
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= StateChanged;
+        RealtimeEvents.RecentErrorReceived -= OnRecentErrorReceived;
+        RealtimeEvents.MigrationStatusChanged -= OnMigrationStatusChanged;
+    }
+
+    private bool IsBusy => IsLoading || State.Status == OperationsConsoleStatus.Loading;
+
+    private string PublishingSummary => State.ManifestDrift is null
+        ? SectionError("Manifest drift") ?? "Desired-vs-actual state is not loaded"
+        : State.ManifestDrift.HasDrift
+            ? State.ManifestDrift.BaselineVersionId ?? "No baseline version loaded"
+            : "Desired and observed state match";
+
+    private string PendingApprovalSummary => SectionError("Manifest approvals")
+        ?? $"{State.PendingApprovals.Count} pending approval(s)";
+
+    private Task RefreshAsync() => ExecuteAsync(() => State.RefreshAsync(CancellationToken.None));
+
+    private void StateChanged() => InvokeAsync(StateHasChanged);
+
+    private void OnRecentErrorReceived(RecentErrorEntry entry)
+        => State.ApplyRecentError(entry);
+
+    private void OnMigrationStatusChanged(MigrationObservabilityResponse status)
+        => State.ApplyMigrationStatus(status);
+
+    private string? SectionError(string section)
+        => State.SectionErrors.TryGetValue(section, out var message) ? message : null;
+
+    private string LatestGitOpsEvidence()
+    {
+        var latest = State.LatestGitOpsChange;
+        if (latest is null)
+        {
+            return SectionError("GitOps changes") ?? "No GitOps change loaded";
+        }
+
+        return $"{ShortHash(latest.CommitSha)} - {latest.Status}";
+    }
+
+    private string MigrationEvidence()
+        => State.MigrationStatus is null
+            ? SectionError("Migrations") ?? "No migration status loaded"
+            : $"{State.MigrationStatus.Status} - {(State.MigrationStatus.UpgradeRequired ? "upgrade required" : "no upgrade")}";
+
+    private static string ShortHash(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? "none"
+            : value.Length <= 12
+                ? value
+                : value[..12];
+
+    private static Color StatusColor(OperationsConsoleStatus status) => status switch
+    {
+        OperationsConsoleStatus.Error => Color.Error,
+        OperationsConsoleStatus.Loading => Color.Info,
+        OperationsConsoleStatus.Partial => Color.Warning,
+        _ => Color.Default
+    };
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -4,6 +4,9 @@
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Dashboard">
         Dashboard
     </MudNavLink>
+    <MudNavLink Href="/operator/control-center" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AdminPanelSettings">
+        Control center
+    </MudNavLink>
 
     <MudNavLink Href="/operator/spec" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Edit">
         Spec workspace

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -22,6 +22,16 @@ public sealed class NavMenuTests
     }
 
     [Fact]
+    public void NavMenu_registers_control_center_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/control-center", contents, System.StringComparison.Ordinal);
+        Assert.Contains("Control center", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NavMenu_registers_annotation_workspace_under_operator_route()
     {
         var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
@@ -73,6 +83,7 @@ public sealed class NavMenuTests
         var open = System.Text.RegularExpressions.Regex.Matches(contents, "<MudNavMenu").Count;
         Assert.Equal(1, open);
 
+        var operatorControlCenter = contents.IndexOf("/operator/control-center", System.StringComparison.Ordinal);
         var operatorSpec = contents.IndexOf("/operator/spec", System.StringComparison.Ordinal);
         var operatorSql = contents.IndexOf("/operator/sql", System.StringComparison.Ordinal);
         var operatorAnnotations = contents.IndexOf("/operator/annotations", System.StringComparison.Ordinal);
@@ -81,12 +92,14 @@ public sealed class NavMenuTests
         var operatorPrint = contents.IndexOf("/operator/print", System.StringComparison.Ordinal);
         var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
 
+        Assert.True(operatorControlCenter > 0);
         Assert.True(operatorSpec > 0);
         Assert.True(operatorSql > 0);
         Assert.True(operatorAnnotations > 0);
         Assert.True(operatorPublishing > 0);
         Assert.True(operatorAnalytics > 0);
         Assert.True(operatorPrint > 0);
+        Assert.True(operatorControlCenter < menuClose);
         Assert.True(operatorSql < menuClose);
         Assert.True(operatorAnnotations < menuClose);
         Assert.True(operatorPublishing < menuClose);

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -35,6 +35,7 @@ public sealed class AdminPageRenderTests : TestContext
         Services.AddScoped<UsageAnalyticsState>();
         Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
         Services.AddScoped<PrintServiceState>();
+        Services.AddScoped<OperationsConsoleState>();
         Services.AddTestRealtime();
     }
 
@@ -155,7 +156,6 @@ public sealed class AdminPageRenderTests : TestContext
     public void OperationsConsole_RendersReleaseDriftAndTroubleshootingState()
     {
         Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
-        Services.AddScoped<OperationsConsoleState>();
 
         var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.OperationsConsole>();
 
@@ -174,7 +174,6 @@ public sealed class AdminPageRenderTests : TestContext
     public void OperationsConsole_RendersRecentErrorsFailureInsteadOfEmptyState()
     {
         Services.AddScoped<IHonuaAdminClient>(_ => new RecentErrorsUnavailableClient());
-        Services.AddScoped<OperationsConsoleState>();
 
         var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.OperationsConsole>();
 
@@ -182,6 +181,24 @@ public sealed class AdminPageRenderTests : TestContext
         {
             cut.Markup.MarkupMatchesContaining("Recent errors unavailable");
             Assert.False(cut.Markup.Contains("No recent errors loaded.", StringComparison.OrdinalIgnoreCase), cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void ControlCenter_RendersGovernanceEvidenceAndTroubleshootingHandoff()
+    {
+        Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
+
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.ControlCenter>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Admin control center");
+            cut.Markup.MarkupMatchesContaining("Governance queue");
+            cut.Markup.MarkupMatchesContaining("Release evidence");
+            cut.Markup.MarkupMatchesContaining("Troubleshooting handoff");
+            cut.Markup.MarkupMatchesContaining("Promote staging manifest");
+            cut.Markup.MarkupMatchesContaining("0123456789ab - pending_approval");
         });
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -11,6 +11,7 @@ using Honua.Admin.Models.Admin;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.UsageAnalytics;
@@ -37,6 +38,7 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<IAdminTelemetry, NullAdminTelemetry>();
         Services.AddScoped<IHonuaAdminClient>(_ => new StubHonuaAdminClient());
         Services.AddScoped<AnnotationWorkspaceState>();
+        Services.AddScoped<OperationsConsoleState>();
         Services.AddScoped<PublishingWorkspaceState>();
         Services.AddScoped<IUsageAnalyticsClient, StubUsageAnalyticsClient>();
         Services.AddScoped<UsageAnalyticsState>();
@@ -53,6 +55,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Index),
             "Honua Server Administration",
             new[] { "[aria-label='Feature overview']", "a[href='/connections']" },
+        ];
+        yield return
+        [
+            "Control center",
+            typeof(Honua.Admin.Pages.Operator.ControlCenter),
+            "Governance queue",
+            new[] { "[aria-label='Control center surfaces']", "[aria-label='Governance queue']", "[aria-label='Release evidence control center']" },
         ];
         yield return
         [


### PR DESCRIPTION
## Summary
- add a /operator/control-center page that ties publishing, operations, deploy evidence, governance approvals, drift, and observability into one operator overview
- add the control center to the shared admin nav
- cover the route with render, quality-gate, and nav tests

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~AdminPageRenderTests|FullyQualifiedName~AdminQualityGateTests|FullyQualifiedName~NavMenuTests" --logger "console;verbosity=minimal"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"

Closes #13