### PR TITLE
feat: surface spec workspace readiness

### DIFF
--- a/src/Honua.Admin/Components/SpecWorkspace/DslSectionEditor.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/DslSectionEditor.razor
@@ -9,6 +9,7 @@
     <div class="spec-editor-shell">
         <pre class="spec-editor-underlay" aria-hidden="true">@((MarkupString)BuildHighlightedMarkup())</pre>
         <textarea class="spec-editor-input"
+                  aria-label="@($"{SectionId} spec section editor")"
                   value="@State.GetSectionText(SectionId)"
                   @ref="_editorRef"
                   @oninput="HandleInputAsync"

--- a/src/Honua.Admin/Components/SpecWorkspace/SpecWorkspaceBody.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/SpecWorkspaceBody.razor
@@ -6,31 +6,60 @@
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
-<div class="spec-workspace-root" data-testid="spec-workspace-root"
-     style="@($"grid-template-columns: {State.Layout.Nl}fr 6px {State.Layout.Dsl}fr 6px {State.Layout.Preview}fr;")">
+<div class="spec-workspace-shell" data-testid="spec-workspace-shell">
+    <MudPaper Class="spec-readiness-bar pa-3" Elevation="0" aria-label="Spec workspace S1 readiness">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="2" Class="spec-readiness-content">
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                <MudText Typo="Typo.subtitle1">Spec workspace S1</MudText>
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary" data-testid="spec-readiness-grammar">
+                    @($"grammar {GrammarVersion}")
+                </MudChip>
+            </MudStack>
+            <MudSpacer />
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" data-testid="spec-readiness-sections">
+                @($"{GrammarSectionCount} sections")
+            </MudChip>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" data-testid="spec-readiness-operators">
+                @($"{GrammarOperatorCount} operators")
+            </MudChip>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@DraftCoverageColor" data-testid="spec-readiness-draft">
+                @($"{DraftSectionCount}/5 drafted")
+            </MudChip>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Success" data-testid="spec-readiness-plan-apply">
+                plan/apply
+            </MudChip>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Success" data-testid="spec-readiness-preview">
+                map/table/app preview
+            </MudChip>
+        </MudStack>
+    </MudPaper>
 
-    <div class="spec-workspace-cell spec-workspace-nl">
-        <ConversationPane />
-    </div>
+    <div class="spec-workspace-root" data-testid="spec-workspace-root"
+         style="@($"grid-template-columns: {State.Layout.Nl}fr 6px {State.Layout.Dsl}fr 6px {State.Layout.Preview}fr;")">
 
-    <div class="spec-workspace-splitter"
-         data-splitter-left="nl"
-         data-splitter-right="dsl"
-         @onpointerdown="(e => BeginDragAsync(e, SpecSplitter.NlDsl))"
-         data-testid="splitter-nl-dsl"></div>
+        <div class="spec-workspace-cell spec-workspace-nl">
+            <ConversationPane />
+        </div>
 
-    <div class="spec-workspace-cell spec-workspace-dsl">
-        <DslPane />
-    </div>
+        <div class="spec-workspace-splitter"
+             data-splitter-left="nl"
+             data-splitter-right="dsl"
+             @onpointerdown="(e => BeginDragAsync(e, SpecSplitter.NlDsl))"
+             data-testid="splitter-nl-dsl"></div>
 
-    <div class="spec-workspace-splitter"
-         data-splitter-left="dsl"
-         data-splitter-right="preview"
-         @onpointerdown="(e => BeginDragAsync(e, SpecSplitter.DslPreview))"
-         data-testid="splitter-dsl-preview"></div>
+        <div class="spec-workspace-cell spec-workspace-dsl">
+            <DslPane />
+        </div>
 
-    <div class="spec-workspace-cell spec-workspace-preview">
-        <PreviewPane />
+        <div class="spec-workspace-splitter"
+             data-splitter-left="dsl"
+             data-splitter-right="preview"
+             @onpointerdown="(e => BeginDragAsync(e, SpecSplitter.DslPreview))"
+             data-testid="splitter-dsl-preview"></div>
+
+        <div class="spec-workspace-cell spec-workspace-preview">
+            <PreviewPane />
+        </div>
     </div>
 </div>
 
@@ -43,6 +72,31 @@
 
     private DotNetObjectReference<SpecWorkspaceBody>? _selfRef;
     private bool _interopReady;
+
+    private string GrammarVersion => State.Grammar?.Version ?? "loading";
+
+    private int GrammarSectionCount => State.Grammar?.Sections.Count ?? Enum.GetValues<SpecSectionId>().Length;
+
+    private int GrammarOperatorCount => State.Grammar?.Operators.Count ?? 0;
+
+    private int DraftSectionCount =>
+        (State.Spec.Sources.Count > 0 ? 1 : 0) +
+        (State.Spec.Scope.Bbox is not null || !string.IsNullOrWhiteSpace(State.Spec.Scope.Crs) ? 1 : 0) +
+        (State.Spec.Compute.Count > 0 ? 1 : 0) +
+        (State.Spec.Map.Layers.Count > 0 ? 1 : 0) +
+        (State.Spec.Output.Kind != SpecOutputKind.None ? 1 : 0);
+
+    private Color DraftCoverageColor => DraftSectionCount switch
+    {
+        0 => Color.Default,
+        < 5 => Color.Warning,
+        _ => Color.Success
+    };
+
+    protected override void OnInitialized()
+    {
+        State.OnChanged += StateChanged;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -60,6 +114,8 @@
             }
         }
     }
+
+    private void StateChanged() => InvokeAsync(StateHasChanged);
 
     [JSInvokable]
     public Task OnSplitterDrag(string splitterId, double deltaFraction)
@@ -99,6 +155,7 @@
 
     public ValueTask DisposeAsync()
     {
+        State.OnChanged -= StateChanged;
         _selfRef?.Dispose();
         return ValueTask.CompletedTask;
     }

--- a/src/Honua.Admin/wwwroot/css/spec-workspace.css
+++ b/src/Honua.Admin/wwwroot/css/spec-workspace.css
@@ -1,8 +1,26 @@
+.spec-workspace-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    height: calc(100vh - 128px);
+    min-height: 520px;
+}
+
+.spec-readiness-bar {
+    border: 1px solid var(--mud-palette-divider, #e0e0e0);
+    background: #ffffff;
+}
+
+.spec-readiness-content {
+    min-width: 0;
+    flex-wrap: wrap;
+}
+
 .spec-workspace-root {
     display: grid;
     grid-template-rows: 100%;
-    height: calc(100vh - 128px);
-    min-height: 480px;
+    flex: 1 1 auto;
+    min-height: 420px;
     gap: 0;
 }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -8,12 +8,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using Honua.Admin.Models.Admin;
+using Honua.Admin.Models.SpecWorkspace;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
+using Honua.Admin.Services.SpecWorkspace;
 using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
@@ -37,6 +39,11 @@ public sealed class AdminPageRenderTests : TestContext
         Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
         Services.AddScoped<PrintServiceState>();
         Services.AddScoped<OperationsConsoleState>();
+        Services.AddScoped<CatalogCache>();
+        Services.AddScoped<IBrowserStorageService, MemoryBrowserStorageService>();
+        Services.AddScoped<ISpecWorkspaceTelemetry, NullSpecWorkspaceTelemetry>();
+        Services.AddScoped<ISpecWorkspaceClient, StubSpecWorkspaceClient>();
+        Services.AddScoped<SpecWorkspaceState>();
         Services.AddTestRealtime();
     }
 
@@ -251,6 +258,30 @@ public sealed class AdminPageRenderTests : TestContext
     }
 
     [Fact]
+    public async Task SpecWorkspace_RendersS1ReadinessEvidence()
+    {
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.SpecWorkspace>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Spec workspace S1");
+            cut.Markup.MarkupMatchesContaining("grammar v1");
+            cut.Markup.MarkupMatchesContaining("5 sections");
+            cut.Markup.MarkupMatchesContaining("plan/apply");
+            cut.Markup.MarkupMatchesContaining("map/table/app preview");
+            cut.Find("[aria-label='Spec workspace S1 readiness']");
+        });
+
+        var state = Services.GetRequiredService<SpecWorkspaceState>();
+        await cut.InvokeAsync(() => state.UpdateSectionTextAsync(SpecSectionId.Sources, "@parcels = parcels"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("1/5 drafted");
+        });
+    }
+
+    [Fact]
     public void UsageAnalytics_RendersMetricsDrilldownsAndExports()
     {
         var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.UsageAnalytics>();
@@ -350,6 +381,35 @@ public sealed class AdminPageRenderTests : TestContext
         public void PageNavigated(string pageRoute, string? principalId) { }
         public void DestructiveAction(string action, string? targetId, string? principalId) { }
         public void ClientRequestFailed(string operation, string error) { }
+    }
+
+    private sealed class NullSpecWorkspaceTelemetry : ISpecWorkspaceTelemetry
+    {
+        public void Record(string eventName, IReadOnlyDictionary<string, object?>? dimensions = null) { }
+        public void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? dimensions = null) { }
+    }
+
+    private sealed class MemoryBrowserStorageService : IBrowserStorageService
+    {
+        private readonly Dictionary<string, string> _items = new(StringComparer.Ordinal);
+
+        public ValueTask<string?> GetAsync(string key, CancellationToken cancellationToken = default)
+        {
+            _items.TryGetValue(key, out var value);
+            return ValueTask.FromResult<string?>(value);
+        }
+
+        public ValueTask SetAsync(string key, string value, CancellationToken cancellationToken = default)
+        {
+            _items[key] = value;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            _items.Remove(key);
+            return ValueTask.CompletedTask;
+        }
     }
 }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -14,6 +14,7 @@ using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
+using Honua.Admin.Services.SpecWorkspace;
 using Honua.Admin.Services.UsageAnalytics;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +45,11 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<UsageAnalyticsState>();
         Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
         Services.AddScoped<PrintServiceState>();
+        Services.AddScoped<CatalogCache>();
+        Services.AddScoped<IBrowserStorageService, BrowserStorageService>();
+        Services.AddScoped<ISpecWorkspaceTelemetry, NullSpecWorkspaceTelemetry>();
+        Services.AddScoped<ISpecWorkspaceClient, StubSpecWorkspaceClient>();
+        Services.AddScoped<SpecWorkspaceState>();
         Services.AddTestRealtime();
     }
 
@@ -69,6 +75,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Operator.AdminReadiness),
             "Administration readiness",
             new[] { "[aria-label='Administration readiness surfaces']", "[aria-label='Administration readiness checklist']", "[aria-label='Readiness connection inventory']", "[aria-label='Gated feature diagnostics']" },
+        ];
+        yield return
+        [
+            "Spec workspace",
+            typeof(Honua.Admin.Pages.Operator.SpecWorkspace),
+            "Spec workspace S1",
+            new[] { "[aria-label='Spec workspace S1 readiness']", "[data-testid='spec-workspace-root']", "[data-testid='spec-nl-pane']", "[data-testid='spec-dsl-pane']", "[data-testid='spec-preview-pane']" },
         ];
         yield return
         [
@@ -286,5 +299,11 @@ public sealed class AdminQualityGateTests : TestContext
         public void PageNavigated(string pageRoute, string? principalId) { }
         public void DestructiveAction(string action, string? targetId, string? principalId) { }
         public void ClientRequestFailed(string operation, string error) { }
+    }
+
+    private sealed class NullSpecWorkspaceTelemetry : ISpecWorkspaceTelemetry
+    {
+        public void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null) { }
+        public void RecordLatency(string eventName, long elapsedMillis, IReadOnlyDictionary<string, object?>? properties = null) { }
     }
 }


### PR DESCRIPTION
## Summary
- add an S1 readiness bar to the spec workspace with grammar, section, operator, draft coverage, plan/apply, and preview evidence
- keep the three-pane NL/DSL/preview workspace inside a responsive shell
- add accessible names for the DSL section editors and add render/quality-gate coverage for the spec workspace

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~AdminPageRenderTests|FullyQualifiedName~AdminQualityGateTests|FullyQualifiedName~NavMenuTests" --logger "console;verbosity=minimal"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"

Refs #25

Note: this intentionally does not close #25 because that epic still depends on server-side grammar, plan/apply, and grounding child work outside this repository.