### PR TITLE
feat: add app builder workspace slice

### DIFF
--- a/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
+++ b/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.AppBuilder;
+
+public enum AppBuilderStatus
+{
+    Idle,
+    Loading,
+    Publishing,
+    Published,
+    Error
+}
+
+public enum AppWidgetKind
+{
+    Map,
+    Chart,
+    Indicator,
+    List,
+    Filter,
+    Legend,
+    Search,
+    Gauge,
+    RichText
+}
+
+public sealed record AppBuilderSnapshot
+{
+    public IReadOnlyList<AppTemplate> Templates { get; init; } = Array.Empty<AppTemplate>();
+    public IReadOnlyList<AppWidgetDefinition> WidgetLibrary { get; init; } = Array.Empty<AppWidgetDefinition>();
+    public AppDraft Draft { get; init; } = new();
+}
+
+public sealed record AppTemplate
+{
+    public string TemplateId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string PublishMode { get; init; } = string.Empty;
+    public IReadOnlyList<AppWidgetKind> StarterWidgets { get; init; } = Array.Empty<AppWidgetKind>();
+    public IReadOnlyList<string> Breakpoints { get; init; } = Array.Empty<string>();
+}
+
+public sealed record AppWidgetDefinition
+{
+    public AppWidgetKind Kind { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public bool SupportsDataBinding { get; init; }
+    public string DefaultBinding { get; init; } = string.Empty;
+}
+
+public sealed record AppDraft
+{
+    public string DraftId { get; init; } = Guid.NewGuid().ToString("n");
+    public string Name { get; init; } = "Operations dashboard";
+    public string TemplateId { get; init; } = "operations-dashboard";
+    public string ThemeName { get; init; } = "Civic light";
+    public int AutoRefreshSeconds { get; init; } = 60;
+    public IReadOnlyList<AppWidgetInstance> Widgets { get; init; } = Array.Empty<AppWidgetInstance>();
+}
+
+public sealed record AppWidgetInstance
+{
+    public string WidgetId { get; init; } = Guid.NewGuid().ToString("n");
+    public AppWidgetKind Kind { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string DataBinding { get; init; } = string.Empty;
+    public int Column { get; init; }
+    public int Row { get; init; }
+    public int Width { get; init; } = 4;
+    public int Height { get; init; } = 2;
+}
+
+public sealed record AppValidationCheck
+{
+    public string Key { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public bool Passed { get; init; }
+    public string Message { get; init; } = string.Empty;
+}
+
+public sealed record AppPublishResult
+{
+    public string PublishedUrl { get; init; } = string.Empty;
+    public string EmbedUrl { get; init; } = string.Empty;
+    public DateTimeOffset PublishedAt { get; init; }
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/Honua.Admin/Pages/Operator/AppBuilder.razor
+++ b/src/Honua.Admin/Pages/Operator/AppBuilder.razor
@@ -1,0 +1,242 @@
+@page "/operator/app-builder"
+@using Microsoft.AspNetCore.Authorization
+@using Honua.Admin.Models.AppBuilder
+@using Honua.Admin.Services.AppBuilder
+@attribute [Authorize]
+@inject AppBuilderState State
+@inject IAdminTelemetry Telemetry
+@implements IDisposable
+
+<PageTitle>App builder</PageTitle>
+
+<div class="app-builder-root" data-testid="app-builder-root">
+    <div class="app-builder-toolbar" aria-label="App builder toolbar">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="app-builder-toolbar-row">
+            <MudText Typo="Typo.h5">App builder</MudText>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@StatusColor(State.Status)" data-testid="app-builder-status">
+                @State.Status
+            </MudChip>
+            <MudSpacer />
+            <MudButton StartIcon="@Icons.Material.Filled.Refresh"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="RefreshAsync"
+                       data-testid="app-builder-refresh">
+                Refresh
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Publish"
+                       Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Size="Size.Small"
+                       Disabled="@(IsBusy || State.HasBlockingValidation)"
+                       OnClick="PublishAsync"
+                       data-testid="app-builder-publish">
+                Publish
+            </MudButton>
+        </MudStack>
+        @if (!string.IsNullOrWhiteSpace(State.LastError))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" Class="mt-2" data-testid="app-builder-error">
+                @State.LastError
+            </MudAlert>
+        }
+    </div>
+
+    <div class="app-builder-grid">
+        <section class="app-builder-pane" aria-label="App templates">
+            <MudText Typo="Typo.h6">Templates</MudText>
+            <div class="app-builder-template-list">
+                @foreach (var template in State.Templates)
+                {
+                    var item = template;
+                    <button type="button"
+                            class="@TemplateClass(item)"
+                            disabled="@IsBusy"
+                            @onclick="@(() => State.SelectTemplate(item.TemplateId))"
+                            data-testid="@($"app-template-{item.TemplateId}")">
+                        <span>@item.Name</span>
+                        <small>@item.PublishMode</small>
+                    </button>
+                }
+            </div>
+
+            <MudText Typo="Typo.h6" Class="mt-4">Widget library</MudText>
+            <div class="app-builder-widget-library" aria-label="Widget library">
+                @foreach (var widget in State.WidgetLibrary)
+                {
+                    var definition = widget;
+                    <div class="app-builder-widget-definition" data-testid="@($"widget-definition-{definition.Kind}")">
+                        <div>
+                            <strong>@definition.Name</strong>
+                            <span>@definition.Description</span>
+                        </div>
+                        <MudIconButton Icon="@Icons.Material.Filled.Add"
+                                       aria-label="@($"Add {definition.Name}")"
+                                       Size="Size.Small"
+                                       Disabled="@IsBusy"
+                                       OnClick="@(() => State.AddWidget(definition.Kind))" />
+                    </div>
+                }
+            </div>
+        </section>
+
+        <section class="app-builder-pane app-builder-canvas-pane" aria-label="Dashboard layout preview">
+            <MudStack Row AlignItems="AlignItems.Center" Class="mb-2">
+                <MudText Typo="Typo.h6">@State.Draft.Name</MudText>
+                <MudSpacer />
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                    @State.SelectedTemplate?.Name
+                </MudChip>
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                    @($"{State.Draft.AutoRefreshSeconds}s refresh")
+                </MudChip>
+            </MudStack>
+            <div class="app-builder-canvas" aria-label="App layout canvas">
+                @foreach (var widget in State.Draft.Widgets)
+                {
+                    var item = widget;
+                    <article class="@WidgetClass(item)"
+                             style="@WidgetStyle(item)"
+                             data-testid="@($"app-widget-{item.Kind}-{item.WidgetId}")">
+                        <div class="app-builder-widget-header">
+                            <MudIcon Icon="@WidgetIcon(item.Kind)" Size="Size.Small" />
+                            <strong>@item.Title</strong>
+                            <MudSpacer />
+                            <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                           aria-label="@($"Remove {item.Title}")"
+                                           Size="Size.Small"
+                                           Disabled="@IsBusy"
+                                           OnClick="@(() => State.RemoveWidget(item.WidgetId))" />
+                        </div>
+                        <div class="app-builder-widget-body">
+                            <span>@item.DataBinding</span>
+                            <small>@($"{item.Width} x {item.Height}")</small>
+                        </div>
+                    </article>
+                }
+            </div>
+        </section>
+
+        <section class="app-builder-pane" aria-label="App builder configuration">
+            <MudText Typo="Typo.h6">Configuration</MudText>
+            <MudTextField T="string"
+                          Label="App name"
+                          Value="@State.Draft.Name"
+                          ValueChanged="State.SetName"
+                          Disabled="@IsBusy"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          aria-label="App name" />
+            <MudTextField T="string"
+                          Label="Theme"
+                          Value="@State.Draft.ThemeName"
+                          ValueChanged="State.SetTheme"
+                          Disabled="@IsBusy"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          aria-label="App theme" />
+            <MudNumericField T="int"
+                             Label="Auto refresh seconds"
+                             Value="@State.Draft.AutoRefreshSeconds"
+                             ValueChanged="State.SetAutoRefreshSeconds"
+                             Disabled="@IsBusy"
+                             Min="15"
+                             Max="3600"
+                             Step="15"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             aria-label="Auto refresh seconds" />
+
+            <MudText Typo="Typo.h6" Class="mt-4">Validation</MudText>
+            <div class="app-builder-validation" aria-label="App builder validation checks">
+                @foreach (var check in State.ValidationChecks)
+                {
+                    <div class="app-builder-validation-row" data-testid="@($"app-builder-check-{check.Key}")">
+                        <MudIcon Icon="@(check.Passed ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Error)"
+                                 Color="@(check.Passed ? Color.Success : Color.Warning)"
+                                 Size="Size.Small" />
+                        <div>
+                            <strong>@check.Label</strong>
+                            <span>@check.Message</span>
+                        </div>
+                    </div>
+                }
+            </div>
+
+            @if (State.LastPublish is not null)
+            {
+                <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined" Class="mt-4" data-testid="app-builder-publish-result">
+                    @State.LastPublish.Message
+                    <br />
+                    <MudLink Href="@State.LastPublish.PublishedUrl">@State.LastPublish.PublishedUrl</MudLink>
+                    <br />
+                    <MudLink Href="@State.LastPublish.EmbedUrl">@State.LastPublish.EmbedUrl</MudLink>
+                </MudAlert>
+            }
+        </section>
+    </div>
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += StateChanged;
+        Telemetry.PageNavigated("/operator/app-builder", principalId: null);
+        await State.LoadAsync(CancellationToken.None);
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= StateChanged;
+    }
+
+    private bool IsBusy => State.Status is AppBuilderStatus.Loading or AppBuilderStatus.Publishing;
+
+    private Task RefreshAsync() => State.LoadAsync(CancellationToken.None);
+
+    private Task PublishAsync() => State.PublishAsync(CancellationToken.None);
+
+    private void StateChanged() => InvokeAsync(StateHasChanged);
+
+    private string TemplateClass(AppTemplate template)
+        => string.Equals(template.TemplateId, State.Draft.TemplateId, StringComparison.OrdinalIgnoreCase)
+            ? "app-builder-template selected"
+            : "app-builder-template";
+
+    private static string WidgetClass(AppWidgetInstance widget)
+        => $"app-builder-widget app-builder-widget-{widget.Kind.ToString().ToLowerInvariant()}";
+
+    private static string WidgetStyle(AppWidgetInstance widget)
+    {
+        var column = Math.Clamp(widget.Column, 1, 9);
+        var width = Math.Clamp(widget.Width, 1, 10 - column);
+        var row = Math.Max(1, widget.Row);
+        var height = Math.Clamp(widget.Height, 1, 6);
+
+        return $"grid-column: {column} / span {width}; grid-row: {row} / span {height};";
+    }
+
+    private static string WidgetIcon(AppWidgetKind kind) => kind switch
+    {
+        AppWidgetKind.Map => Icons.Material.Filled.Map,
+        AppWidgetKind.Chart => Icons.Material.Filled.BarChart,
+        AppWidgetKind.Indicator => Icons.Material.Filled.Speed,
+        AppWidgetKind.List => Icons.Material.Filled.FormatListBulleted,
+        AppWidgetKind.Filter => Icons.Material.Filled.FilterAlt,
+        AppWidgetKind.Legend => Icons.Material.Filled.Label,
+        AppWidgetKind.Search => Icons.Material.Filled.Search,
+        AppWidgetKind.Gauge => Icons.Material.Filled.Speed,
+        AppWidgetKind.RichText => Icons.Material.Filled.Article,
+        _ => Icons.Material.Filled.Widgets
+    };
+
+    private static Color StatusColor(AppBuilderStatus status) => status switch
+    {
+        AppBuilderStatus.Error => Color.Error,
+        AppBuilderStatus.Loading => Color.Info,
+        AppBuilderStatus.Publishing => Color.Warning,
+        AppBuilderStatus.Published => Color.Success,
+        _ => Color.Default
+    };
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -3,6 +3,7 @@ using Honua.Admin.Auth;
 using Honua.Admin.Configuration;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.AppBuilder;
 using Honua.Admin.Services.DataConnections;
 using Honua.Admin.Services.DataConnections.Providers;
 using Honua.Admin.Services.Identity;
@@ -59,6 +60,11 @@ builder.Services.AddScoped<UsageAnalyticsState>();
 // and queue workflow while server-side render endpoints are wired separately.
 builder.Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
 builder.Services.AddScoped<PrintServiceState>();
+
+// App builder workspace (issue #5) exposes the admin-side low-code dashboard
+// assembly workflow while server-side publish APIs are defined separately.
+builder.Services.AddScoped<IAppBuilderClient, StubAppBuilderClient>();
+builder.Services.AddScoped<AppBuilderState>();
 
 // Admin client + auth wiring (ticket #28 — restored from PR #17 onto the post-#27 shell).
 builder.Services.AddSingleton<AdminAuthStateProvider>();

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -1,0 +1,316 @@
+using Honua.Admin.Models.AppBuilder;
+
+namespace Honua.Admin.Services.AppBuilder;
+
+public sealed class AppBuilderState
+{
+    private const int CanvasColumns = 9;
+
+    private readonly IAppBuilderClient _client;
+    private int _loadRequestVersion;
+
+    public AppBuilderState(IAppBuilderClient client)
+    {
+        _client = client;
+    }
+
+    public AppBuilderStatus Status { get; private set; } = AppBuilderStatus.Idle;
+
+    public string? LastError { get; private set; }
+
+    public IReadOnlyList<AppTemplate> Templates { get; private set; } = Array.Empty<AppTemplate>();
+
+    public IReadOnlyList<AppWidgetDefinition> WidgetLibrary { get; private set; } = Array.Empty<AppWidgetDefinition>();
+
+    public AppDraft Draft { get; private set; } = new();
+
+    public AppPublishResult? LastPublish { get; private set; }
+
+    public AppTemplate? SelectedTemplate =>
+        Templates.FirstOrDefault(template => string.Equals(template.TemplateId, Draft.TemplateId, StringComparison.OrdinalIgnoreCase));
+
+    public IReadOnlyList<AppValidationCheck> ValidationChecks
+    {
+        get
+        {
+            var hasName = !string.IsNullOrWhiteSpace(Draft.Name);
+            var hasWidgets = Draft.Widgets.Count > 0;
+            var dataBoundWidgets = Draft.Widgets.Where(widget => WidgetRequiresBinding(widget.Kind)).ToArray();
+            var allBindings = dataBoundWidgets.All(widget => !string.IsNullOrWhiteSpace(widget.DataBinding));
+
+            return
+            [
+                new AppValidationCheck
+                {
+                    Key = "name",
+                    Label = "App name",
+                    Passed = hasName,
+                    Message = hasName ? Draft.Name : "Name is required before publish."
+                },
+                new AppValidationCheck
+                {
+                    Key = "widgets",
+                    Label = "Widget layout",
+                    Passed = hasWidgets,
+                    Message = hasWidgets ? $"{Draft.Widgets.Count} widget(s) on canvas." : "Add at least one widget."
+                },
+                new AppValidationCheck
+                {
+                    Key = "bindings",
+                    Label = "Data bindings",
+                    Passed = allBindings,
+                    Message = allBindings ? $"{dataBoundWidgets.Length} data-bound widget(s) configured." : "Data-bound widgets need bindings."
+                },
+                new AppValidationCheck
+                {
+                    Key = "responsive",
+                    Label = "Responsive breakpoints",
+                    Passed = SelectedTemplate?.Breakpoints.Count > 0,
+                    Message = SelectedTemplate is null ? "Select a template." : string.Join(", ", SelectedTemplate.Breakpoints)
+                }
+            ];
+        }
+    }
+
+    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed);
+
+    public event Action? OnChanged;
+
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var loadVersion = Interlocked.Increment(ref _loadRequestVersion);
+        Status = AppBuilderStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var snapshot = await _client.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+            if (!IsCurrentLoad(loadVersion))
+            {
+                return;
+            }
+
+            Templates = snapshot.Templates;
+            WidgetLibrary = snapshot.WidgetLibrary;
+            Draft = snapshot.Draft;
+            LastPublish = null;
+            Status = AppBuilderStatus.Idle;
+        }
+        catch (OperationCanceledException)
+        {
+            if (IsCurrentLoad(loadVersion))
+            {
+                Status = AppBuilderStatus.Idle;
+                Notify();
+            }
+
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (!IsCurrentLoad(loadVersion))
+            {
+                return;
+            }
+
+            Status = AppBuilderStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    public void SelectTemplate(string templateId)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        if (!Templates.Any(template => string.Equals(template.TemplateId, templateId, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        Draft = Draft with { TemplateId = templateId };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetName(string? name)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { Name = name?.Trim() ?? string.Empty };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetTheme(string? themeName)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { ThemeName = string.IsNullOrWhiteSpace(themeName) ? "Civic light" : themeName.Trim() };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetAutoRefreshSeconds(int seconds)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { AutoRefreshSeconds = Math.Clamp(seconds, 15, 3600) };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void AddWidget(AppWidgetKind kind)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        var definition = WidgetLibrary.FirstOrDefault(widget => widget.Kind == kind);
+        if (definition is null || string.IsNullOrWhiteSpace(definition.Name))
+        {
+            return;
+        }
+
+        var width = kind == AppWidgetKind.Map ? 6 : 3;
+        var height = kind == AppWidgetKind.Map ? 4 : 2;
+        var (column, row) = FindOpenSlot(width, height);
+        var instance = new AppWidgetInstance
+        {
+            Kind = kind,
+            Title = definition.Name,
+            DataBinding = definition.DefaultBinding,
+            Column = column,
+            Row = row,
+            Width = width,
+            Height = height
+        };
+
+        Draft = Draft with { Widgets = [.. Draft.Widgets, instance] };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void RemoveWidget(string widgetId)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with
+        {
+            Widgets = Draft.Widgets
+                .Where(widget => !string.Equals(widget.WidgetId, widgetId, StringComparison.Ordinal))
+                .ToArray()
+        };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public async Task PublishAsync(CancellationToken cancellationToken = default)
+    {
+        if (Status is AppBuilderStatus.Loading or AppBuilderStatus.Publishing)
+        {
+            return;
+        }
+
+        if (HasBlockingValidation)
+        {
+            Status = AppBuilderStatus.Error;
+            LastError = "Resolve validation checks before publishing.";
+            LastPublish = null;
+            Notify();
+            return;
+        }
+
+        Status = AppBuilderStatus.Publishing;
+        LastError = null;
+        LastPublish = null;
+        Notify();
+
+        try
+        {
+            LastPublish = await _client.PublishAsync(Draft, cancellationToken).ConfigureAwait(false);
+            Status = AppBuilderStatus.Published;
+        }
+        catch (OperationCanceledException)
+        {
+            Status = AppBuilderStatus.Idle;
+            Notify();
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Status = AppBuilderStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    private bool WidgetRequiresBinding(AppWidgetKind kind)
+        => WidgetLibrary.FirstOrDefault(widget => widget.Kind == kind)?.SupportsDataBinding == true;
+
+    private bool IsCurrentLoad(int loadVersion) => loadVersion == Volatile.Read(ref _loadRequestVersion);
+
+    private bool IsDraftLocked => Status is AppBuilderStatus.Loading or AppBuilderStatus.Publishing;
+
+    private (int Column, int Row) FindOpenSlot(int width, int height)
+    {
+        var clampedWidth = Math.Clamp(width, 1, CanvasColumns);
+        var clampedHeight = Math.Max(1, height);
+        for (var row = 1; row < 200; row++)
+        {
+            for (var column = 1; column <= CanvasColumns - clampedWidth + 1; column++)
+            {
+                if (!Draft.Widgets.Any(widget => Overlaps(column, row, clampedWidth, clampedHeight, widget)))
+                {
+                    return (column, row);
+                }
+            }
+        }
+
+        return (1, Draft.Widgets.Count * clampedHeight + 1);
+    }
+
+    private static bool Overlaps(int column, int row, int width, int height, AppWidgetInstance existing)
+    {
+        var existingColumn = Math.Clamp(existing.Column, 1, CanvasColumns);
+        var existingWidth = Math.Clamp(existing.Width, 1, CanvasColumns - existingColumn + 1);
+        var existingRow = Math.Max(1, existing.Row);
+        var existingHeight = Math.Max(1, existing.Height);
+
+        return column < existingColumn + existingWidth &&
+            column + width > existingColumn &&
+            row < existingRow + existingHeight &&
+            row + height > existingRow;
+    }
+
+    private void ResetTransientPublishState()
+    {
+        LastPublish = null;
+        LastError = null;
+        if (Status is AppBuilderStatus.Error or AppBuilderStatus.Published)
+        {
+            Status = AppBuilderStatus.Idle;
+        }
+    }
+
+    private void Notify() => OnChanged?.Invoke();
+}

--- a/src/Honua.Admin/Services/AppBuilder/IAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/IAppBuilderClient.cs
@@ -1,0 +1,10 @@
+using Honua.Admin.Models.AppBuilder;
+
+namespace Honua.Admin.Services.AppBuilder;
+
+public interface IAppBuilderClient
+{
+    Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken);
+
+    Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken);
+}

--- a/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
@@ -1,0 +1,137 @@
+using System.Text;
+using Honua.Admin.Models.AppBuilder;
+
+namespace Honua.Admin.Services.AppBuilder;
+
+public sealed class StubAppBuilderClient : IAppBuilderClient
+{
+    public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var snapshot = new AppBuilderSnapshot
+        {
+            Templates =
+            [
+                new AppTemplate
+                {
+                    TemplateId = "operations-dashboard",
+                    Name = "Operations dashboard",
+                    Description = "Multi-widget monitoring surface with map, indicators, chart, and list.",
+                    PublishMode = "Standalone URL and iframe",
+                    StarterWidgets = [AppWidgetKind.Map, AppWidgetKind.Indicator, AppWidgetKind.Chart, AppWidgetKind.List],
+                    Breakpoints = ["Desktop", "Tablet", "Mobile"]
+                },
+                new AppTemplate
+                {
+                    TemplateId = "public-viewer",
+                    Name = "Public viewer",
+                    Description = "Read-only map viewer with search, legend, identify, and print handoff.",
+                    PublishMode = "Public URL and iframe",
+                    StarterWidgets = [AppWidgetKind.Map, AppWidgetKind.Search, AppWidgetKind.Legend],
+                    Breakpoints = ["Desktop", "Mobile"]
+                },
+                new AppTemplate
+                {
+                    TemplateId = "story-map",
+                    Name = "Story map",
+                    Description = "Scrolling narrative shell with rich text and embedded map sections.",
+                    PublishMode = "Standalone URL",
+                    StarterWidgets = [AppWidgetKind.RichText, AppWidgetKind.Map],
+                    Breakpoints = ["Desktop", "Mobile"]
+                }
+            ],
+            WidgetLibrary =
+            [
+                Widget(AppWidgetKind.Map, "Map", "MapLibre map with layer controls.", true, "Parcels feature service"),
+                Widget(AppWidgetKind.Chart, "Chart", "Bar, line, pie, and scatter chart shell.", true, "Permit activity by month"),
+                Widget(AppWidgetKind.Indicator, "Indicator", "Single-value metric with trend state.", true, "Open permits count"),
+                Widget(AppWidgetKind.List, "List", "Sortable feature list bound to a service layer.", true, "Recent inspections"),
+                Widget(AppWidgetKind.Filter, "Filter", "Shared filter control for linked widgets.", true, "District selector"),
+                Widget(AppWidgetKind.Legend, "Legend", "Layer legend for visible map content.", false, "Visible layers"),
+                Widget(AppWidgetKind.Search, "Search", "Geocoding and feature search entry point.", true, "Address locator"),
+                Widget(AppWidgetKind.Gauge, "Gauge", "Numeric range visualization.", true, "SLA compliance"),
+                Widget(AppWidgetKind.RichText, "Rich text", "Header, narrative, and branded text block.", false, "Section copy")
+            ],
+            Draft = new AppDraft
+            {
+                DraftId = "draft-operations-dashboard",
+                Name = "Harbor operations dashboard",
+                TemplateId = "operations-dashboard",
+                ThemeName = "Civic light",
+                AutoRefreshSeconds = 60,
+                Widgets =
+                [
+                    Instance(AppWidgetKind.Map, "Operational map", "Harbor assets", 1, 1, 6, 4),
+                    Instance(AppWidgetKind.Indicator, "Open incidents", "Incidents count", 7, 1, 3, 2),
+                    Instance(AppWidgetKind.Chart, "Incidents by type", "Incident types", 7, 3, 3, 2),
+                    Instance(AppWidgetKind.List, "Recent work orders", "Work orders", 1, 5, 9, 2)
+                ]
+            }
+        };
+
+        return Task.FromResult(snapshot);
+    }
+
+    public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
+        => Task.FromResult(new AppPublishResult
+        {
+            PublishedUrl = $"https://apps.honua.local/{Slug(draft.Name)}",
+            EmbedUrl = $"https://apps.honua.local/embed/{Slug(draft.Name)}",
+            PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+            Message = $"{draft.Name} is ready for preview."
+        });
+
+    private static AppWidgetDefinition Widget(
+        AppWidgetKind kind,
+        string name,
+        string description,
+        bool supportsDataBinding,
+        string defaultBinding) => new()
+        {
+            Kind = kind,
+            Name = name,
+            Description = description,
+            SupportsDataBinding = supportsDataBinding,
+            DefaultBinding = defaultBinding
+        };
+
+    private static AppWidgetInstance Instance(
+        AppWidgetKind kind,
+        string title,
+        string binding,
+        int column,
+        int row,
+        int width,
+        int height) => new()
+        {
+            Kind = kind,
+            Title = title,
+            DataBinding = binding,
+            Column = column,
+            Row = row,
+            Width = width,
+            Height = height
+        };
+
+    private static string Slug(string value)
+    {
+        var builder = new StringBuilder();
+        foreach (var character in value.Trim())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(char.ToLowerInvariant(character));
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+
+        while (builder.Length > 0 && builder[^1] == '-')
+        {
+            builder.Length--;
+        }
+
+        return builder.Length == 0 ? "untitled-app" : builder.ToString();
+    }
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -32,6 +32,9 @@
     <MudNavLink Href="/operator/analytics" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Insights">
         Usage analytics
     </MudNavLink>
+    <MudNavLink Href="/operator/app-builder" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.DashboardCustomize">
+        App builder
+    </MudNavLink>
     <MudNavLink Href="/operator/print" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Print">
         Print service
     </MudNavLink>

--- a/src/Honua.Admin/wwwroot/css/app-builder.css
+++ b/src/Honua.Admin/wwwroot/css/app-builder.css
@@ -1,0 +1,175 @@
+.app-builder-root {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    min-height: calc(100vh - 96px);
+    background: #f6f8fa;
+}
+
+.app-builder-toolbar,
+.app-builder-pane {
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    background: #ffffff;
+    border-radius: 8px;
+    padding: 14px;
+}
+
+.app-builder-toolbar-row {
+    flex-wrap: wrap;
+}
+
+.app-builder-grid {
+    display: grid;
+    grid-template-columns: minmax(260px, 0.85fr) minmax(420px, 1.7fr) minmax(300px, 0.95fr);
+    gap: 12px;
+    align-items: start;
+}
+
+.app-builder-template-list,
+.app-builder-widget-library,
+.app-builder-validation {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.app-builder-template {
+    width: 100%;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 10px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.app-builder-template:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+}
+
+.app-builder-template.selected {
+    border-color: var(--mud-palette-primary, #594ae2);
+    background: rgba(89, 74, 226, 0.08);
+}
+
+.app-builder-template span,
+.app-builder-template small {
+    display: block;
+}
+
+.app-builder-template small,
+.app-builder-widget-definition span,
+.app-builder-widget-body small {
+    color: var(--mud-palette-text-secondary, #607d8b);
+}
+
+.app-builder-widget-definition,
+.app-builder-validation-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+}
+
+.app-builder-widget-definition div,
+.app-builder-validation-row div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.app-builder-canvas-pane {
+    min-height: 620px;
+}
+
+.app-builder-canvas {
+    display: grid;
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+    grid-auto-rows: 64px;
+    gap: 8px;
+    padding: 10px;
+    border: 1px dashed var(--mud-palette-divider, #d7dbe0);
+    border-radius: 8px;
+    background: #f9fbfc;
+}
+
+.app-builder-widget {
+    grid-column: span 3;
+    min-height: 116px;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 8px;
+    background: #ffffff;
+    border-left: 4px solid #546a7b;
+    padding: 10px;
+    overflow: hidden;
+}
+
+.app-builder-widget-map {
+    border-left-color: #1976d2;
+}
+
+.app-builder-widget-chart {
+    border-left-color: #6a4c93;
+}
+
+.app-builder-widget-indicator,
+.app-builder-widget-gauge {
+    border-left-color: #0b7a75;
+}
+
+.app-builder-widget-list,
+.app-builder-widget-filter {
+    border-left-color: #aa6f39;
+}
+
+.app-builder-widget-search,
+.app-builder-widget-legend,
+.app-builder-widget-richtext {
+    border-left-color: #607d3b;
+}
+
+.app-builder-widget-header,
+.app-builder-widget-body {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.app-builder-widget-body {
+    justify-content: space-between;
+    margin-top: 14px;
+}
+
+.app-builder-widget-header strong,
+.app-builder-widget-body span,
+.app-builder-widget-body small {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 1100px) {
+    .app-builder-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .app-builder-root {
+        padding: 10px;
+    }
+
+    .app-builder-canvas {
+        grid-template-columns: 1fr;
+    }
+
+    .app-builder-widget,
+    .app-builder-widget-map {
+        grid-column: 1 / -1 !important;
+        grid-row: auto !important;
+    }
+}

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -15,6 +15,7 @@
     <link href="css/annotation-workspace.css" rel="stylesheet" />
     <link href="css/publishing-workspace.css" rel="stylesheet" />
     <link href="css/usage-analytics.css" rel="stylesheet" />
+    <link href="css/app-builder.css" rel="stylesheet" />
     <link href="css/print-service.css" rel="stylesheet" />
 </head>
 

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -1,0 +1,383 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.AppBuilder;
+using Honua.Admin.Services.AppBuilder;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class AppBuilderStateTests
+{
+    [Fact]
+    public async Task LoadAsync_populates_templates_widgets_and_draft()
+    {
+        var state = new AppBuilderState(new StubAppBuilderClient());
+
+        await state.LoadAsync();
+
+        Assert.Equal(AppBuilderStatus.Idle, state.Status);
+        Assert.Contains(state.Templates, template => template.TemplateId == "operations-dashboard");
+        Assert.Contains(state.WidgetLibrary, widget => widget.Kind == AppWidgetKind.Map);
+        Assert.Equal("Harbor operations dashboard", state.Draft.Name);
+        Assert.NotEmpty(state.Draft.Widgets);
+        Assert.False(state.HasBlockingValidation);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ignores_stale_snapshot_responses()
+    {
+        var client = new SequencedLoadAppBuilderClient();
+        var state = new AppBuilderState(client);
+
+        var staleLoad = state.LoadAsync();
+        var freshLoad = state.LoadAsync();
+        client.CompleteLoad(1, Snapshot("Fresh dashboard"));
+        await freshLoad;
+
+        Assert.Equal("Fresh dashboard", state.Draft.Name);
+
+        client.CompleteLoad(0, Snapshot("Stale dashboard"));
+        await staleLoad;
+
+        Assert.Equal("Fresh dashboard", state.Draft.Name);
+        Assert.Equal(AppBuilderStatus.Idle, state.Status);
+    }
+
+    [Fact]
+    public async Task AddWidget_adds_widget_and_recomputes_binding_validation()
+    {
+        var state = new AppBuilderState(new FixedAppBuilderClient(new AppBuilderSnapshot
+        {
+            Templates =
+            [
+                new AppTemplate
+                {
+                    TemplateId = "ops",
+                    Name = "Operations",
+                    Breakpoints = ["Desktop", "Mobile"],
+                },
+            ],
+            WidgetLibrary =
+            [
+                new AppWidgetDefinition
+                {
+                    Kind = AppWidgetKind.Chart,
+                    Name = "Chart",
+                    SupportsDataBinding = true,
+                },
+            ],
+            Draft = new AppDraft
+            {
+                Name = "Operations",
+                TemplateId = "ops",
+            },
+        }));
+        await state.LoadAsync();
+
+        state.AddWidget(AppWidgetKind.Chart);
+
+        var widget = Assert.Single(state.Draft.Widgets);
+        Assert.Equal(AppWidgetKind.Chart, widget.Kind);
+        var bindings = Assert.Single(state.ValidationChecks, check => check.Key == "bindings");
+        Assert.False(bindings.Passed);
+        Assert.True(state.HasBlockingValidation);
+    }
+
+    [Fact]
+    public async Task AddWidget_places_new_widget_in_an_open_canvas_region()
+    {
+        var state = new AppBuilderState(new StubAppBuilderClient());
+        await state.LoadAsync();
+        var existing = state.Draft.Widgets;
+
+        state.AddWidget(AppWidgetKind.Search);
+
+        var added = Assert.Single(state.Draft.Widgets, widget => existing.All(item => item.WidgetId != widget.WidgetId));
+        Assert.DoesNotContain(existing, widget => Overlaps(widget, added));
+    }
+
+    [Fact]
+    public async Task PublishAsync_returns_publish_urls_when_valid()
+    {
+        var state = new AppBuilderState(new StubAppBuilderClient());
+        await state.LoadAsync();
+
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Published, state.Status);
+        Assert.NotNull(state.LastPublish);
+        Assert.Equal("https://apps.honua.local/harbor-operations-dashboard", state.LastPublish.PublishedUrl);
+        Assert.Equal("https://apps.honua.local/embed/harbor-operations-dashboard", state.LastPublish.EmbedUrl);
+        Assert.Null(state.LastError);
+    }
+
+    [Fact]
+    public async Task Draft_mutators_ignore_changes_while_publish_is_in_flight()
+    {
+        var client = new BlockingPublishAppBuilderClient();
+        var state = new AppBuilderState(client);
+        await state.LoadAsync();
+        var originalDraft = state.Draft;
+
+        var publishTask = state.PublishAsync();
+        await client.PublishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        state.SetName("Edited during publish");
+        state.SetTheme("Dark");
+        state.SetAutoRefreshSeconds(15);
+        state.SelectTemplate("public-viewer");
+        state.AddWidget(AppWidgetKind.Search);
+        state.RemoveWidget(originalDraft.Widgets[0].WidgetId);
+
+        Assert.Equal(AppBuilderStatus.Publishing, state.Status);
+        Assert.Equal(originalDraft.Name, state.Draft.Name);
+        Assert.Equal(originalDraft.ThemeName, state.Draft.ThemeName);
+        Assert.Equal(originalDraft.AutoRefreshSeconds, state.Draft.AutoRefreshSeconds);
+        Assert.Equal(originalDraft.TemplateId, state.Draft.TemplateId);
+        Assert.Equal(originalDraft.Widgets.Count, state.Draft.Widgets.Count);
+
+        client.Complete();
+        await publishTask;
+
+        Assert.Equal(AppBuilderStatus.Published, state.Status);
+        Assert.Equal(originalDraft.Name, client.PublishedDraft?.Name);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ignores_reentrant_publish_calls()
+    {
+        var client = new BlockingPublishAppBuilderClient();
+        var state = new AppBuilderState(client);
+        await state.LoadAsync();
+
+        var firstPublish = state.PublishAsync();
+        await client.PublishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await state.PublishAsync();
+
+        Assert.Equal(1, client.PublishCalls);
+
+        client.Complete();
+        await firstPublish;
+
+        Assert.Equal(AppBuilderStatus.Published, state.Status);
+    }
+
+    [Fact]
+    public async Task PublishAsync_blocks_when_name_is_missing()
+    {
+        var client = new StubAppBuilderClient();
+        var state = new AppBuilderState(client);
+        await state.LoadAsync();
+
+        state.SetName(" ");
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Error, state.Status);
+        Assert.Equal("Resolve validation checks before publishing.", state.LastError);
+        Assert.Null(state.LastPublish);
+
+        state.SetName("Recovered dashboard");
+
+        Assert.Equal(AppBuilderStatus.Idle, state.Status);
+        Assert.Null(state.LastError);
+    }
+
+    [Fact]
+    public async Task PublishAsync_clears_stale_publish_result_when_retry_fails()
+    {
+        var state = new AppBuilderState(new FailingRetryAppBuilderClient());
+        await state.LoadAsync();
+        await state.PublishAsync();
+        Assert.NotNull(state.LastPublish);
+
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Error, state.Status);
+        Assert.Equal("publish failed", state.LastError);
+        Assert.Null(state.LastPublish);
+    }
+
+    [Fact]
+    public async Task PublishAsync_notifies_when_publish_is_canceled()
+    {
+        var state = new AppBuilderState(new CancelingPublishAppBuilderClient());
+        await state.LoadAsync();
+        var observedStatuses = new List<AppBuilderStatus>();
+        state.OnChanged += () => observedStatuses.Add(state.Status);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => state.PublishAsync());
+
+        Assert.Equal(AppBuilderStatus.Idle, state.Status);
+        Assert.Contains(AppBuilderStatus.Publishing, observedStatuses);
+        Assert.Equal(AppBuilderStatus.Idle, observedStatuses[^1]);
+    }
+
+    [Fact]
+    public async Task StubPublishAsync_sanitizes_preview_url_slug()
+    {
+        var client = new StubAppBuilderClient();
+
+        var result = await client.PublishAsync(new AppDraft { Name = "Ops/2026?Launch #1" }, CancellationToken.None);
+
+        Assert.Equal("https://apps.honua.local/ops-2026-launch-1", result.PublishedUrl);
+        Assert.Equal("https://apps.honua.local/embed/ops-2026-launch-1", result.EmbedUrl);
+    }
+
+    private sealed class FixedAppBuilderClient : IAppBuilderClient
+    {
+        private readonly AppBuilderSnapshot _snapshot;
+
+        public FixedAppBuilderClient(AppBuilderSnapshot snapshot)
+        {
+            _snapshot = snapshot;
+        }
+
+        public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => Task.FromResult(_snapshot);
+
+        public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
+            => Task.FromResult(new AppPublishResult
+            {
+                PublishedUrl = "https://apps.honua.local/test",
+                EmbedUrl = "https://apps.honua.local/embed/test",
+                PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+                Message = "Published",
+            });
+    }
+
+    private sealed class SequencedLoadAppBuilderClient : IAppBuilderClient
+    {
+        private readonly List<TaskCompletionSource<AppBuilderSnapshot>> _loads = [];
+
+        public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            var load = new TaskCompletionSource<AppBuilderSnapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _loads.Add(load);
+            return load.Task;
+        }
+
+        public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public void CompleteLoad(int index, AppBuilderSnapshot snapshot)
+            => _loads[index].SetResult(snapshot);
+    }
+
+    private sealed class FailingRetryAppBuilderClient : IAppBuilderClient
+    {
+        private readonly StubAppBuilderClient _inner = new();
+        private int _publishCount;
+
+        public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => _inner.GetSnapshotAsync(cancellationToken);
+
+        public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
+        {
+            _publishCount++;
+            if (_publishCount == 1)
+            {
+                return _inner.PublishAsync(draft, cancellationToken);
+            }
+
+            throw new InvalidOperationException("publish failed");
+        }
+    }
+
+    private sealed class CancelingPublishAppBuilderClient : IAppBuilderClient
+    {
+        private readonly StubAppBuilderClient _inner = new();
+
+        public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => _inner.GetSnapshotAsync(cancellationToken);
+
+        public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
+            => throw new OperationCanceledException(cancellationToken);
+    }
+
+    private sealed class BlockingPublishAppBuilderClient : IAppBuilderClient
+    {
+        private readonly StubAppBuilderClient _inner = new();
+        private readonly TaskCompletionSource<AppPublishResult> _publishResult =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> PublishStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public AppDraft? PublishedDraft { get; private set; }
+
+        public int PublishCalls { get; private set; }
+
+        public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => _inner.GetSnapshotAsync(cancellationToken);
+
+        public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
+        {
+            PublishCalls++;
+            PublishedDraft = draft;
+            PublishStarted.TrySetResult(true);
+            return _publishResult.Task;
+        }
+
+        public void Complete()
+            => _publishResult.SetResult(new AppPublishResult
+            {
+                PublishedUrl = "https://apps.honua.local/published",
+                EmbedUrl = "https://apps.honua.local/embed/published",
+                PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+                Message = "Published",
+            });
+    }
+
+    private static AppBuilderSnapshot Snapshot(string draftName)
+        => new()
+        {
+            Templates =
+            [
+                new AppTemplate
+                {
+                    TemplateId = "operations-dashboard",
+                    Name = "Operations dashboard",
+                    Breakpoints = ["Desktop"],
+                },
+            ],
+            WidgetLibrary =
+            [
+                new AppWidgetDefinition
+                {
+                    Kind = AppWidgetKind.Map,
+                    Name = "Map",
+                    SupportsDataBinding = true,
+                    DefaultBinding = "Assets",
+                },
+            ],
+            Draft = new AppDraft
+            {
+                Name = draftName,
+                TemplateId = "operations-dashboard",
+                Widgets =
+                [
+                    new AppWidgetInstance
+                    {
+                        Kind = AppWidgetKind.Map,
+                        Title = "Map",
+                        DataBinding = "Assets",
+                        Column = 1,
+                        Row = 1,
+                        Width = 6,
+                        Height = 4,
+                    },
+                ],
+            },
+        };
+
+    private static bool Overlaps(AppWidgetInstance first, AppWidgetInstance second)
+    {
+        return first.Column < second.Column + second.Width &&
+            first.Column + first.Width > second.Column &&
+            first.Row < second.Row + second.Height &&
+            first.Row + first.Height > second.Row;
+    }
+}

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -82,6 +82,16 @@ public sealed class NavMenuTests
     }
 
     [Fact]
+    public void NavMenu_registers_app_builder_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/app-builder", contents, System.StringComparison.Ordinal);
+        Assert.Contains("App builder", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NavMenu_uses_a_single_MudNavMenu_so_sql_page_lives_in_the_shared_shell()
     {
         var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
@@ -100,6 +110,7 @@ public sealed class NavMenuTests
         var operatorAnnotations = contents.IndexOf("/operator/annotations", System.StringComparison.Ordinal);
         var operatorPublishing = contents.IndexOf("/operator/publishing", System.StringComparison.Ordinal);
         var operatorAnalytics = contents.IndexOf("/operator/analytics", System.StringComparison.Ordinal);
+        var operatorAppBuilder = contents.IndexOf("/operator/app-builder", System.StringComparison.Ordinal);
         var operatorPrint = contents.IndexOf("/operator/print", System.StringComparison.Ordinal);
         var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
 
@@ -110,6 +121,7 @@ public sealed class NavMenuTests
         Assert.True(operatorAnnotations > 0);
         Assert.True(operatorPublishing > 0);
         Assert.True(operatorAnalytics > 0);
+        Assert.True(operatorAppBuilder > 0);
         Assert.True(operatorPrint > 0);
         Assert.True(operatorControlCenter < menuClose);
         Assert.True(operatorAdminReadiness < menuClose);
@@ -117,6 +129,7 @@ public sealed class NavMenuTests
         Assert.True(operatorAnnotations < menuClose);
         Assert.True(operatorPublishing < menuClose);
         Assert.True(operatorAnalytics < menuClose);
+        Assert.True(operatorAppBuilder < menuClose);
         Assert.True(operatorPrint < menuClose);
     }
 }

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -12,6 +12,7 @@ using Honua.Admin.Models.SpecWorkspace;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.AppBuilder;
 using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
@@ -38,6 +39,8 @@ public sealed class AdminPageRenderTests : TestContext
         Services.AddScoped<UsageAnalyticsState>();
         Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
         Services.AddScoped<PrintServiceState>();
+        Services.AddScoped<IAppBuilderClient, StubAppBuilderClient>();
+        Services.AddScoped<AppBuilderState>();
         Services.AddScoped<OperationsConsoleState>();
         Services.AddScoped<CatalogCache>();
         Services.AddScoped<IBrowserStorageService, MemoryBrowserStorageService>();
@@ -309,6 +312,22 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Preview");
             cut.Markup.MarkupMatchesContaining("Queue export");
             cut.Markup.MarkupMatchesContaining("Planning commission packet");
+        });
+    }
+
+    [Fact]
+    public void AppBuilder_RendersTemplatesWidgetsCanvasAndValidation()
+    {
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.AppBuilder>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("App builder");
+            cut.Markup.MarkupMatchesContaining("Operations dashboard");
+            cut.Markup.MarkupMatchesContaining("Widget library");
+            cut.Markup.MarkupMatchesContaining("Harbor operations dashboard");
+            cut.Markup.MarkupMatchesContaining("Open incidents");
+            cut.Markup.MarkupMatchesContaining("App builder validation checks");
         });
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -11,6 +11,7 @@ using Honua.Admin.Models.Admin;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
+using Honua.Admin.Services.AppBuilder;
 using Honua.Admin.Services.Operations;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
@@ -45,6 +46,8 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<UsageAnalyticsState>();
         Services.AddScoped<IPrintServiceClient, StubPrintServiceClient>();
         Services.AddScoped<PrintServiceState>();
+        Services.AddScoped<IAppBuilderClient, StubAppBuilderClient>();
+        Services.AddScoped<AppBuilderState>();
         Services.AddScoped<CatalogCache>();
         Services.AddScoped<IBrowserStorageService, BrowserStorageService>();
         Services.AddScoped<ISpecWorkspaceTelemetry, NullSpecWorkspaceTelemetry>();
@@ -152,6 +155,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Operator.PrintService),
             "Letter portrait",
             new[] { "[aria-label='Print service toolbar']", "[aria-label='Print preview']", "[aria-label='Print job queue']" },
+        ];
+        yield return
+        [
+            "App builder",
+            typeof(Honua.Admin.Pages.Operator.AppBuilder),
+            "Harbor operations dashboard",
+            new[] { "[aria-label='App builder toolbar']", "[aria-label='Widget library']", "[aria-label='App layout canvas']", "[aria-label='App builder validation checks']" },
         ];
     }
 


### PR DESCRIPTION
## Summary
- add an app builder admin workspace for selecting templates, assembling widgets, editing draft settings, validating readiness, and publishing preview URLs
- add app builder state models, a stub client, DI, shared nav entry, and workspace stylesheet
- cover the new state, route render, shared nav, quality-gate baseline, and non-overlapping widget placement

Related to honua-io/honua-portal#5 (partial admin UI slice)

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~AppBuilderStateTests|FullyQualifiedName~AdminPageRenderTests|FullyQualifiedName~AdminQualityGateTests|FullyQualifiedName~NavMenuTests" --logger "console;verbosity=minimal"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"