### PR TITLE
feat: add open data hub workspace slice

### DIFF
--- a/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
+++ b/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+
+namespace Honua.Admin.Models.OpenDataHub;
+
+public enum OpenDataHubStatus
+{
+    Idle,
+    Loading,
+    Publishing,
+    Published,
+    Error
+}
+
+public enum OpenDataDatasetStatus
+{
+    Draft,
+    InReview,
+    Scheduled,
+    Published,
+    Blocked
+}
+
+public enum OpenDataDownloadFormat
+{
+    GeoJson,
+    GeoParquet,
+    Shapefile,
+    Csv,
+    Kml
+}
+
+public sealed record OpenDataHubSnapshot
+{
+    public IReadOnlyList<OpenDataDataset> Datasets { get; init; } = Array.Empty<OpenDataDataset>();
+    public IReadOnlyList<OpenDataHubMetric> Metrics { get; init; } = Array.Empty<OpenDataHubMetric>();
+}
+
+public sealed record OpenDataDataset
+{
+    public string DatasetId { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string Category { get; init; } = string.Empty;
+    public string Geography { get; init; } = string.Empty;
+    public string License { get; init; } = string.Empty;
+    public string Contact { get; init; } = string.Empty;
+    public string UpdateFrequency { get; init; } = string.Empty;
+    public OpenDataDatasetStatus Status { get; init; }
+    public DateTimeOffset LastUpdated { get; init; }
+    public DateTimeOffset? ScheduledPublishAt { get; init; }
+    public bool PublicCatalogEnabled { get; init; }
+    public bool ApiEnabled { get; init; }
+    public bool EmbedEnabled { get; init; }
+    public string StacCollectionId { get; init; } = string.Empty;
+    public string SampleResponse { get; init; } = string.Empty;
+    public IReadOnlyList<string> Keywords { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<OpenDataDownloadOption> Downloads { get; init; } = Array.Empty<OpenDataDownloadOption>();
+    public IReadOnlyList<OpenDataApiEndpoint> ApiEndpoints { get; init; } = Array.Empty<OpenDataApiEndpoint>();
+    public OpenDataEmbedConfig EmbedConfig { get; init; } = new();
+}
+
+public sealed record OpenDataDownloadOption
+{
+    public OpenDataDownloadFormat Format { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public long SizeBytes { get; init; }
+    public DateTimeOffset GeneratedAt { get; init; }
+}
+
+public sealed record OpenDataApiEndpoint
+{
+    public string Name { get; init; } = string.Empty;
+    public string Method { get; init; } = "GET";
+    public string Path { get; init; } = string.Empty;
+    public string Example { get; init; } = string.Empty;
+    public bool RequiresApiKey { get; init; }
+    public int RateLimitPerMinute { get; init; }
+}
+
+public sealed record OpenDataEmbedConfig
+{
+    public string EmbedUrl { get; init; } = string.Empty;
+    public string Basemap { get; init; } = string.Empty;
+    public string InitialExtent { get; init; } = string.Empty;
+    public string BrandingMode { get; init; } = string.Empty;
+    public bool Responsive { get; init; }
+    public bool WcagReady { get; init; }
+}
+
+public sealed record OpenDataHubMetric
+{
+    public string Label { get; init; } = string.Empty;
+    public string Value { get; init; } = string.Empty;
+    public string Detail { get; init; } = string.Empty;
+}
+
+public sealed record OpenDataValidationCheck
+{
+    public string Key { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public bool Passed { get; init; }
+    public string Message { get; init; } = string.Empty;
+}
+
+public sealed record OpenDataPublishResult
+{
+    public string DatasetId { get; init; } = string.Empty;
+    public string CatalogUrl { get; init; } = string.Empty;
+    public string ApiDocsUrl { get; init; } = string.Empty;
+    public DateTimeOffset PublishedAt { get; init; }
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
+++ b/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
@@ -1,0 +1,334 @@
+@page "/operator/open-data"
+@using System.Globalization
+@using Honua.Admin.Models.OpenDataHub
+@using Honua.Admin.Services.OpenDataHub
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+@inject OpenDataHubState State
+@inject IAdminTelemetry Telemetry
+@implements IDisposable
+
+<PageTitle>Open data hub</PageTitle>
+
+<div class="open-data-root" data-testid="open-data-hub-root">
+    <div class="open-data-toolbar" aria-label="Open data hub toolbar">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="open-data-toolbar-row">
+            <MudText Typo="Typo.h5">
+                <MudIcon Icon="@Icons.Material.Filled.Public" Class="mr-2" />
+                Open data hub
+            </MudText>
+            <MudChip T="string" Size="Size.Small" Color="@StatusColor(State.Status)" Variant="Variant.Outlined" data-testid="open-data-status">
+                @State.Status
+            </MudChip>
+            <MudSpacer />
+            <MudButton StartIcon="@Icons.Material.Filled.Refresh"
+                       Variant="Variant.Outlined"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="RefreshAsync"
+                       data-testid="open-data-refresh">
+                Refresh
+            </MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Publish"
+                       Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Size="Size.Small"
+                       Disabled="@(IsBusy || State.SelectedDataset is null || State.HasBlockingValidation)"
+                       OnClick="PublishAsync"
+                       data-testid="open-data-publish">
+                Publish
+            </MudButton>
+        </MudStack>
+        @if (!string.IsNullOrWhiteSpace(State.LastError))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" Class="mt-2" data-testid="open-data-error">
+                @State.LastError
+            </MudAlert>
+        }
+    </div>
+
+    <section class="open-data-metrics" aria-label="Open data hub metrics">
+        @foreach (var metric in State.Metrics)
+        {
+            <article class="open-data-metric" data-testid="@($"open-data-metric-{metric.Label}")">
+                <span>@metric.Label</span>
+                <strong>@metric.Value</strong>
+                <small>@metric.Detail</small>
+            </article>
+        }
+    </section>
+
+    <div class="open-data-grid">
+        <section class="open-data-pane" aria-label="Open data catalog filters">
+            <MudText Typo="Typo.h6">Catalog intake</MudText>
+            <MudTextField T="string"
+                          Label="Search"
+                          Value="@State.SearchText"
+                          ValueChanged="State.SetSearchText"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Disabled="@IsBusy"
+                          aria-label="Open data search" />
+            <MudSelect T="string"
+                       Label="Category"
+                       Value="@State.CategoryFilter"
+                       ValueChanged="State.SetCategoryFilter"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       Disabled="@IsBusy"
+                       aria-label="Open data category filter">
+                @foreach (var category in State.CategoryOptions)
+                {
+                    <MudSelectItem T="string" Value="@category">@category</MudSelectItem>
+                }
+            </MudSelect>
+            <MudSelect T="string"
+                       Label="Geography"
+                       Value="@State.GeographyFilter"
+                       ValueChanged="State.SetGeographyFilter"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       Disabled="@IsBusy"
+                       aria-label="Open data geography filter">
+                @foreach (var geography in State.GeographyOptions)
+                {
+                    <MudSelectItem T="string" Value="@geography">@geography</MudSelectItem>
+                }
+            </MudSelect>
+            <MudButton StartIcon="@Icons.Material.Filled.FilterAltOff"
+                       Variant="Variant.Text"
+                       Size="Size.Small"
+                       Disabled="@IsBusy"
+                       OnClick="State.ClearFilters"
+                       data-testid="open-data-clear-filters">
+                Clear filters
+            </MudButton>
+
+            <div class="open-data-dataset-list" aria-label="Open data dataset catalog">
+                @if (State.FilteredDatasets.Count == 0)
+                {
+                    <div class="open-data-empty" data-testid="open-data-empty">
+                        No datasets match the current filters.
+                    </div>
+                }
+                else
+                {
+                    @foreach (var dataset in State.FilteredDatasets)
+                    {
+                        var item = dataset;
+                        <button type="button"
+                                class="@DatasetClass(item)"
+                                disabled="@IsBusy"
+                                @onclick="@(() => State.SelectDataset(item.DatasetId))"
+                                data-testid="@($"open-data-dataset-{item.DatasetId}")">
+                            <span>@item.Title</span>
+                            <small>@item.Category - @item.Geography</small>
+                            <em>@item.Status</em>
+                        </button>
+                    }
+                }
+            </div>
+        </section>
+
+        @if (State.SelectedDataset is { } selected)
+        {
+            <section class="open-data-pane open-data-detail" aria-label="Open data dataset details">
+                <MudStack Row AlignItems="AlignItems.Start" Class="open-data-detail-heading">
+                    <div>
+                        <MudText Typo="Typo.h6">@selected.Title</MudText>
+                        <MudText Typo="Typo.body2">@selected.Description</MudText>
+                    </div>
+                    <MudSpacer />
+                    <MudChip T="string" Size="Size.Small" Color="@DatasetStatusColor(selected.Status)" Variant="Variant.Outlined">
+                        @selected.Status
+                    </MudChip>
+                </MudStack>
+
+                <div class="open-data-metadata-grid" aria-label="Open data catalog metadata">
+                    <div>
+                        <span>License</span>
+                        <strong>@selected.License</strong>
+                    </div>
+                    <div>
+                        <span>Update frequency</span>
+                        <strong>@selected.UpdateFrequency</strong>
+                    </div>
+                    <div>
+                        <span>Contact</span>
+                        <strong>@selected.Contact</strong>
+                    </div>
+                    <div>
+                        <span>STAC collection</span>
+                        <strong>@selected.StacCollectionId</strong>
+                    </div>
+                    <div>
+                        <span>Last updated</span>
+                        <strong>@selected.LastUpdated.ToLocalTime().ToString("MMM d, yyyy h:mm tt", CultureInfo.CurrentCulture)</strong>
+                    </div>
+                    <div>
+                        <span>Scheduled publish</span>
+                        <strong>@(selected.ScheduledPublishAt?.ToLocalTime().ToString("MMM d, yyyy h:mm tt", CultureInfo.CurrentCulture) ?? "Manual")</strong>
+                    </div>
+                </div>
+
+                <div class="open-data-keywords" aria-label="Open data keywords">
+                    @foreach (var keyword in selected.Keywords)
+                    {
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@keyword</MudChip>
+                    }
+                </div>
+
+                <MudText Typo="Typo.h6" Class="mt-4">Preview response</MudText>
+                <pre class="open-data-code" aria-label="Open data sample API response"><code>@selected.SampleResponse</code></pre>
+            </section>
+
+            <section class="open-data-pane" aria-label="Open data delivery readiness">
+                <MudText Typo="Typo.h6">Distribution</MudText>
+
+                <div class="open-data-delivery-group" aria-label="Open data downloads">
+                    <MudText Typo="Typo.subtitle2">Downloads</MudText>
+                    @foreach (var download in selected.Downloads)
+                    {
+                        <div class="open-data-delivery-row" data-testid="@($"open-data-download-{download.Format}")">
+                            <MudIcon Icon="@Icons.Material.Filled.Download" Size="Size.Small" />
+                            <div>
+                                <strong>@FormatDownload(download.Format)</strong>
+                                <span>@download.Url</span>
+                            </div>
+                            <small>@FormatBytes(download.SizeBytes)</small>
+                        </div>
+                    }
+                </div>
+
+                <div class="open-data-delivery-group" aria-label="Open data API endpoints">
+                    <MudText Typo="Typo.subtitle2">Civic tech API</MudText>
+                    @foreach (var endpoint in selected.ApiEndpoints)
+                    {
+                        <article class="open-data-api-row" data-testid="@($"open-data-api-{endpoint.Name}")">
+                            <div>
+                                <strong>@endpoint.Name</strong>
+                                <span>@endpoint.Method @endpoint.Path</span>
+                            </div>
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                                @(endpoint.RequiresApiKey ? "API key" : "No auth")
+                            </MudChip>
+                            <pre class="open-data-code"><code>@endpoint.Example</code></pre>
+                        </article>
+                    }
+                </div>
+
+                <div class="open-data-delivery-group" aria-label="Open data embed configuration">
+                    <MudText Typo="Typo.subtitle2">Embeddable map</MudText>
+                    <div class="open-data-embed-preview">
+                        <div>
+                            <MudIcon Icon="@Icons.Material.Filled.Map" />
+                            <strong>@selected.EmbedConfig.Basemap</strong>
+                            <span>@selected.EmbedConfig.InitialExtent</span>
+                        </div>
+                        <small>@selected.EmbedConfig.BrandingMode</small>
+                    </div>
+                    <div class="open-data-embed-flags">
+                        <MudChip T="string" Size="Size.Small" Color="@(selected.EmbedConfig.Responsive ? Color.Success : Color.Warning)" Variant="Variant.Outlined">
+                            Responsive
+                        </MudChip>
+                        <MudChip T="string" Size="Size.Small" Color="@(selected.EmbedConfig.WcagReady ? Color.Success : Color.Warning)" Variant="Variant.Outlined">
+                            WCAG
+                        </MudChip>
+                    </div>
+                </div>
+
+                <div class="open-data-validation" aria-label="Open data validation checks">
+                    <MudText Typo="Typo.subtitle2">Readiness checks</MudText>
+                    @foreach (var check in State.ValidationChecks)
+                    {
+                        <div class="open-data-validation-row" data-testid="@($"open-data-check-{check.Key}")">
+                            <MudIcon Icon="@(check.Passed ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Error)"
+                                     Color="@(check.Passed ? Color.Success : Color.Warning)"
+                                     Size="Size.Small" />
+                            <div>
+                                <strong>@check.Label</strong>
+                                <span>@check.Message</span>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                @if (State.LastPublish is not null)
+                {
+                    <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined" Class="mt-3" data-testid="open-data-publish-result">
+                        @State.LastPublish.Message
+                        <br />
+                        <MudLink Href="@State.LastPublish.CatalogUrl">@State.LastPublish.CatalogUrl</MudLink>
+                        <br />
+                        <MudLink Href="@State.LastPublish.ApiDocsUrl">@State.LastPublish.ApiDocsUrl</MudLink>
+                    </MudAlert>
+                }
+            </section>
+        }
+    </div>
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += StateChanged;
+        Telemetry.PageNavigated("/operator/open-data", principalId: null);
+        await State.LoadAsync(CancellationToken.None);
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= StateChanged;
+    }
+
+    private bool IsBusy => State.Status is OpenDataHubStatus.Loading or OpenDataHubStatus.Publishing;
+
+    private Task RefreshAsync() => State.LoadAsync(CancellationToken.None);
+
+    private Task PublishAsync() => State.PublishSelectedAsync(CancellationToken.None);
+
+    private void StateChanged() => InvokeAsync(StateHasChanged);
+
+    private string DatasetClass(OpenDataDataset dataset)
+        => string.Equals(dataset.DatasetId, State.SelectedDataset?.DatasetId, StringComparison.OrdinalIgnoreCase)
+            ? "open-data-dataset selected"
+            : "open-data-dataset";
+
+    private static string FormatDownload(OpenDataDownloadFormat format) => format switch
+    {
+        OpenDataDownloadFormat.GeoJson => "GeoJSON",
+        OpenDataDownloadFormat.GeoParquet => "GeoParquet",
+        OpenDataDownloadFormat.Shapefile => "Shapefile",
+        OpenDataDownloadFormat.Csv => "CSV",
+        OpenDataDownloadFormat.Kml => "KML",
+        _ => format.ToString()
+    };
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes >= 1_000_000)
+        {
+            return $"{bytes / 1_000_000d:0.0} MB";
+        }
+
+        return $"{bytes / 1_000d:0.0} KB";
+    }
+
+    private static Color StatusColor(OpenDataHubStatus status) => status switch
+    {
+        OpenDataHubStatus.Error => Color.Error,
+        OpenDataHubStatus.Loading => Color.Info,
+        OpenDataHubStatus.Publishing => Color.Warning,
+        OpenDataHubStatus.Published => Color.Success,
+        _ => Color.Default
+    };
+
+    private static Color DatasetStatusColor(OpenDataDatasetStatus status) => status switch
+    {
+        OpenDataDatasetStatus.Published => Color.Success,
+        OpenDataDatasetStatus.Scheduled => Color.Info,
+        OpenDataDatasetStatus.InReview => Color.Warning,
+        OpenDataDatasetStatus.Blocked => Color.Error,
+        _ => Color.Default
+    };
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -9,6 +9,7 @@ using Honua.Admin.Services.DataConnections.Providers;
 using Honua.Admin.Services.Identity;
 using Honua.Admin.Services.LicenseWorkspace;
 using Honua.Admin.Services.Operations;
+using Honua.Admin.Services.OpenDataHub;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.SpatialSql;
@@ -65,6 +66,11 @@ builder.Services.AddScoped<PrintServiceState>();
 // assembly workflow while server-side publish APIs are defined separately.
 builder.Services.AddScoped<IAppBuilderClient, StubAppBuilderClient>();
 builder.Services.AddScoped<AppBuilderState>();
+
+// Open data hub workspace (issue #6) exposes the admin-side catalog,
+// download, API, and embed readiness workflow while server APIs are defined.
+builder.Services.AddScoped<IOpenDataHubClient, StubOpenDataHubClient>();
+builder.Services.AddScoped<OpenDataHubState>();
 
 // Admin client + auth wiring (ticket #28 — restored from PR #17 onto the post-#27 shell).
 builder.Services.AddSingleton<AdminAuthStateProvider>();

--- a/src/Honua.Admin/Services/OpenDataHub/IOpenDataHubClient.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/IOpenDataHubClient.cs
@@ -1,0 +1,10 @@
+using Honua.Admin.Models.OpenDataHub;
+
+namespace Honua.Admin.Services.OpenDataHub;
+
+public interface IOpenDataHubClient
+{
+    Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken);
+
+    Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken);
+}

--- a/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
@@ -143,6 +143,7 @@ public sealed class OpenDataHubState
         var loadVersion = Interlocked.Increment(ref _loadRequestVersion);
         Status = OpenDataHubStatus.Loading;
         LastError = null;
+        LastPublish = null;
         Notify();
 
         try

--- a/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
@@ -1,0 +1,374 @@
+using Honua.Admin.Models.OpenDataHub;
+
+namespace Honua.Admin.Services.OpenDataHub;
+
+public sealed class OpenDataHubState
+{
+    private readonly IOpenDataHubClient _client;
+    private int _loadRequestVersion;
+
+    public OpenDataHubState(IOpenDataHubClient client)
+    {
+        _client = client;
+    }
+
+    public OpenDataHubStatus Status { get; private set; } = OpenDataHubStatus.Idle;
+
+    public string? LastError { get; private set; }
+
+    public IReadOnlyList<OpenDataDataset> Datasets { get; private set; } = Array.Empty<OpenDataDataset>();
+
+    public IReadOnlyList<OpenDataHubMetric> Metrics { get; private set; } = Array.Empty<OpenDataHubMetric>();
+
+    public string SearchText { get; private set; } = string.Empty;
+
+    public string CategoryFilter { get; private set; } = "All";
+
+    public string GeographyFilter { get; private set; } = "All";
+
+    public string? SelectedDatasetId { get; private set; }
+
+    public OpenDataPublishResult? LastPublish { get; private set; }
+
+    public OpenDataDataset? SelectedDataset
+    {
+        get
+        {
+            var filtered = FilteredDatasets;
+            return filtered.FirstOrDefault(dataset => string.Equals(dataset.DatasetId, SelectedDatasetId, StringComparison.OrdinalIgnoreCase)) ??
+                filtered.FirstOrDefault();
+        }
+    }
+
+    public IReadOnlyList<OpenDataDataset> FilteredDatasets =>
+        Datasets
+            .Where(MatchesSearch)
+            .Where(MatchesCategory)
+            .Where(MatchesGeography)
+            .OrderByDescending(dataset => dataset.Status == OpenDataDatasetStatus.Published)
+            .ThenBy(dataset => dataset.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    public IReadOnlyList<string> CategoryOptions =>
+        ["All", .. Datasets.Select(dataset => dataset.Category).Where(value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase)];
+
+    public IReadOnlyList<string> GeographyOptions =>
+        ["All", .. Datasets.Select(dataset => dataset.Geography).Where(value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase)];
+
+    public IReadOnlyList<OpenDataValidationCheck> ValidationChecks
+    {
+        get
+        {
+            var dataset = SelectedDataset;
+            if (dataset is null)
+            {
+                return
+                [
+                    new OpenDataValidationCheck
+                    {
+                        Key = "dataset",
+                        Label = "Dataset",
+                        Passed = false,
+                        Message = "Select a dataset before publishing."
+                    }
+                ];
+            }
+
+            var hasMetadata = HasText(dataset.Title) &&
+                HasText(dataset.Description) &&
+                HasText(dataset.Category) &&
+                HasText(dataset.Geography) &&
+                HasText(dataset.License) &&
+                HasText(dataset.Contact) &&
+                HasText(dataset.UpdateFrequency);
+            var hasDownloads = RequiredDownloadFormats.All(format => dataset.Downloads.Any(download => download.Format == format));
+            var hasApis = dataset.ApiEnabled &&
+                dataset.ApiEndpoints.Any(endpoint => !endpoint.RequiresApiKey) &&
+                HasText(dataset.StacCollectionId) &&
+                HasText(dataset.SampleResponse);
+            var hasEmbed = !dataset.EmbedEnabled ||
+                dataset.EmbedConfig.Responsive &&
+                dataset.EmbedConfig.WcagReady &&
+                HasText(dataset.EmbedConfig.EmbedUrl) &&
+                HasText(dataset.EmbedConfig.InitialExtent);
+            var canPublish = dataset.Status != OpenDataDatasetStatus.Blocked && dataset.PublicCatalogEnabled;
+
+            return
+            [
+                new OpenDataValidationCheck
+                {
+                    Key = "metadata",
+                    Label = "Catalog metadata",
+                    Passed = hasMetadata,
+                    Message = hasMetadata ? $"{dataset.License} license, {dataset.UpdateFrequency.ToLowerInvariant()} updates." : "Title, description, category, geography, license, contact, and update frequency are required."
+                },
+                new OpenDataValidationCheck
+                {
+                    Key = "downloads",
+                    Label = "Download formats",
+                    Passed = hasDownloads,
+                    Message = hasDownloads ? "GeoJSON, GeoParquet, Shapefile, CSV, and KML exports are available." : "All required download formats must be generated."
+                },
+                new OpenDataValidationCheck
+                {
+                    Key = "api",
+                    Label = "Civic tech API",
+                    Passed = hasApis,
+                    Message = hasApis ? $"{dataset.ApiEndpoints.Count} endpoint(s), including no-auth public access." : "Enable public API endpoints, STAC metadata, and a sample response."
+                },
+                new OpenDataValidationCheck
+                {
+                    Key = "embed",
+                    Label = "Embed readiness",
+                    Passed = hasEmbed,
+                    Message = hasEmbed ? "Responsive embed configuration is ready." : "Embed viewers need responsive and WCAG-ready configuration."
+                },
+                new OpenDataValidationCheck
+                {
+                    Key = "workflow",
+                    Label = "Publishing workflow",
+                    Passed = canPublish,
+                    Message = canPublish ? $"{dataset.Status} is clear for catalog publishing." : "Dataset must be catalog-enabled and unblocked."
+                }
+            ];
+        }
+    }
+
+    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed);
+
+    public event Action? OnChanged;
+
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var loadVersion = Interlocked.Increment(ref _loadRequestVersion);
+        Status = OpenDataHubStatus.Loading;
+        LastError = null;
+        Notify();
+
+        try
+        {
+            var snapshot = await _client.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+            if (!IsCurrentLoad(loadVersion))
+            {
+                return;
+            }
+
+            Datasets = snapshot.Datasets;
+            Metrics = snapshot.Metrics;
+            SelectedDatasetId = Datasets.Any(dataset => string.Equals(dataset.DatasetId, SelectedDatasetId, StringComparison.OrdinalIgnoreCase))
+                ? SelectedDatasetId
+                : Datasets.FirstOrDefault()?.DatasetId;
+            LastPublish = null;
+            Status = OpenDataHubStatus.Idle;
+        }
+        catch (OperationCanceledException)
+        {
+            if (IsCurrentLoad(loadVersion))
+            {
+                Status = OpenDataHubStatus.Idle;
+                Notify();
+            }
+
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (!IsCurrentLoad(loadVersion))
+            {
+                return;
+            }
+
+            Status = OpenDataHubStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    public void SelectDataset(string datasetId)
+    {
+        if (IsLocked || !Datasets.Any(dataset => string.Equals(dataset.DatasetId, datasetId, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        SelectedDatasetId = datasetId;
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetSearchText(string? searchText)
+    {
+        if (IsLocked)
+        {
+            return;
+        }
+
+        SearchText = searchText?.Trim() ?? string.Empty;
+        AlignSelectionWithFilters();
+        Notify();
+    }
+
+    public void SetCategoryFilter(string? category)
+    {
+        if (IsLocked)
+        {
+            return;
+        }
+
+        CategoryFilter = NormalizeOption(category, CategoryOptions);
+        AlignSelectionWithFilters();
+        Notify();
+    }
+
+    public void SetGeographyFilter(string? geography)
+    {
+        if (IsLocked)
+        {
+            return;
+        }
+
+        GeographyFilter = NormalizeOption(geography, GeographyOptions);
+        AlignSelectionWithFilters();
+        Notify();
+    }
+
+    public void ClearFilters()
+    {
+        if (IsLocked)
+        {
+            return;
+        }
+
+        SearchText = string.Empty;
+        CategoryFilter = "All";
+        GeographyFilter = "All";
+        AlignSelectionWithFilters();
+        Notify();
+    }
+
+    public async Task PublishSelectedAsync(CancellationToken cancellationToken = default)
+    {
+        if (Status is OpenDataHubStatus.Loading or OpenDataHubStatus.Publishing)
+        {
+            return;
+        }
+
+        var dataset = SelectedDataset;
+        if (dataset is null || HasBlockingValidation)
+        {
+            Status = OpenDataHubStatus.Error;
+            LastError = "Resolve validation checks before publishing.";
+            LastPublish = null;
+            Notify();
+            return;
+        }
+
+        Status = OpenDataHubStatus.Publishing;
+        LastError = null;
+        LastPublish = null;
+        Notify();
+
+        try
+        {
+            LastPublish = await _client.PublishAsync(dataset.DatasetId, cancellationToken).ConfigureAwait(false);
+            Datasets = Datasets
+                .Select(item => string.Equals(item.DatasetId, dataset.DatasetId, StringComparison.OrdinalIgnoreCase)
+                    ? item with { Status = OpenDataDatasetStatus.Published, PublicCatalogEnabled = true }
+                    : item)
+                .ToArray();
+            SelectedDatasetId = dataset.DatasetId;
+            Status = OpenDataHubStatus.Published;
+        }
+        catch (OperationCanceledException)
+        {
+            Status = OpenDataHubStatus.Idle;
+            Notify();
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Status = OpenDataHubStatus.Error;
+            LastError = ex.Message;
+        }
+
+        Notify();
+    }
+
+    private static readonly OpenDataDownloadFormat[] RequiredDownloadFormats =
+    [
+        OpenDataDownloadFormat.GeoJson,
+        OpenDataDownloadFormat.GeoParquet,
+        OpenDataDownloadFormat.Shapefile,
+        OpenDataDownloadFormat.Csv,
+        OpenDataDownloadFormat.Kml
+    ];
+
+    private bool MatchesSearch(OpenDataDataset dataset)
+    {
+        if (string.IsNullOrWhiteSpace(SearchText))
+        {
+            return true;
+        }
+
+        return Contains(dataset.Title, SearchText) ||
+            Contains(dataset.Description, SearchText) ||
+            Contains(dataset.Category, SearchText) ||
+            Contains(dataset.Geography, SearchText) ||
+            dataset.Keywords.Any(keyword => Contains(keyword, SearchText));
+    }
+
+    private bool MatchesCategory(OpenDataDataset dataset)
+        => IsAll(CategoryFilter) || string.Equals(dataset.Category, CategoryFilter, StringComparison.OrdinalIgnoreCase);
+
+    private bool MatchesGeography(OpenDataDataset dataset)
+        => IsAll(GeographyFilter) || string.Equals(dataset.Geography, GeographyFilter, StringComparison.OrdinalIgnoreCase);
+
+    private void AlignSelectionWithFilters()
+    {
+        var filtered = FilteredDatasets;
+        if (filtered.Any(dataset => string.Equals(dataset.DatasetId, SelectedDatasetId, StringComparison.OrdinalIgnoreCase)))
+        {
+            ResetTransientPublishState();
+            return;
+        }
+
+        SelectedDatasetId = filtered.FirstOrDefault()?.DatasetId;
+        ResetTransientPublishState();
+    }
+
+    private void ResetTransientPublishState()
+    {
+        LastPublish = null;
+        LastError = null;
+        if (Status is OpenDataHubStatus.Error or OpenDataHubStatus.Published)
+        {
+            Status = OpenDataHubStatus.Idle;
+        }
+    }
+
+    private static string NormalizeOption(string? option, IReadOnlyList<string> allowedOptions)
+    {
+        if (string.IsNullOrWhiteSpace(option))
+        {
+            return "All";
+        }
+
+        return allowedOptions.FirstOrDefault(value => string.Equals(value, option.Trim(), StringComparison.OrdinalIgnoreCase)) ?? "All";
+    }
+
+    private static bool Contains(string value, string searchText)
+        => value.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasText(string value)
+        => !string.IsNullOrWhiteSpace(value);
+
+    private static bool IsAll(string value)
+        => string.Equals(value, "All", StringComparison.OrdinalIgnoreCase);
+
+    private bool IsCurrentLoad(int loadVersion) => loadVersion == Volatile.Read(ref _loadRequestVersion);
+
+    private bool IsLocked => Status is OpenDataHubStatus.Loading or OpenDataHubStatus.Publishing;
+
+    private void Notify() => OnChanged?.Invoke();
+}

--- a/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
@@ -1,0 +1,244 @@
+using System.Text;
+using Honua.Admin.Models.OpenDataHub;
+
+namespace Honua.Admin.Services.OpenDataHub;
+
+public sealed class StubOpenDataHubClient : IOpenDataHubClient
+{
+    public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new OpenDataHubSnapshot
+        {
+            Metrics =
+            [
+                new OpenDataHubMetric
+                {
+                    Label = "Published datasets",
+                    Value = "18",
+                    Detail = "12 refreshed this week"
+                },
+                new OpenDataHubMetric
+                {
+                    Label = "Downloads",
+                    Value = "24.8k",
+                    Detail = "GeoJSON and CSV lead demand"
+                },
+                new OpenDataHubMetric
+                {
+                    Label = "API calls",
+                    Value = "1.3M",
+                    Detail = "Rate limits active on all keys"
+                },
+                new OpenDataHubMetric
+                {
+                    Label = "Feedback queue",
+                    Value = "7",
+                    Detail = "3 quality reports need triage"
+                }
+            ],
+            Datasets =
+            [
+                Dataset(
+                    "harbor-assets",
+                    "Harbor assets",
+                    "Authoritative public inventory of docks, terminals, bollards, lights, and safety equipment.",
+                    "Infrastructure",
+                    "Honolulu Harbor",
+                    OpenDataDatasetStatus.Published,
+                    true,
+                    true,
+                    true,
+                    ["harbor", "assets", "operations"],
+                    "CC BY 4.0",
+                    "gis@honua.local",
+                    "Daily",
+                    "collections/harbor-assets",
+                    "[-157.91,21.28,-157.84,21.34]",
+                    "Light civic",
+                    "{ \"type\": \"FeatureCollection\", \"features\": [{ \"id\": \"dock-14\", \"properties\": { \"asset_type\": \"Dock\" } }] }"),
+                Dataset(
+                    "coastal-resilience-zones",
+                    "Coastal resilience zones",
+                    "Planning overlays for inundation exposure, resilience projects, and community adaptation areas.",
+                    "Planning",
+                    "Oahu",
+                    OpenDataDatasetStatus.InReview,
+                    true,
+                    true,
+                    false,
+                    ["resilience", "planning", "coast"],
+                    "ODC-BY",
+                    "planning@honua.local",
+                    "Monthly",
+                    "collections/coastal-resilience-zones",
+                    "[-158.28,21.25,-157.64,21.72]",
+                    "Topo",
+                    "{ \"type\": \"FeatureCollection\", \"features\": [{ \"id\": \"zone-7\", \"properties\": { \"priority\": \"High\" } }] }"),
+                Dataset(
+                    "permit-activity",
+                    "Permit activity",
+                    "Daily building permit feed with status, valuation band, neighborhood, and inspection counts.",
+                    "Permits",
+                    "Citywide",
+                    OpenDataDatasetStatus.Scheduled,
+                    true,
+                    false,
+                    true,
+                    ["permits", "inspections", "buildings"],
+                    "Public domain",
+                    "permits@honua.local",
+                    "Daily",
+                    "collections/permit-activity",
+                    "[-158.12,21.26,-157.64,21.55]",
+                    "Streets",
+                    "{ \"records\": [{ \"permit_id\": \"B2026-1042\", \"status\": \"Issued\" }] }",
+                    DateTimeOffset.Parse("2026-04-29T18:00:00Z")),
+                Dataset(
+                    "reef-monitoring",
+                    "Reef monitoring observations",
+                    "Research observations with survey locations, temperature, turbidity, and species presence.",
+                    "Environment",
+                    "South Shore",
+                    OpenDataDatasetStatus.Blocked,
+                    false,
+                    true,
+                    false,
+                    ["reef", "water quality", "biology"],
+                    "CC BY-NC 4.0",
+                    "environment@honua.local",
+                    "Weekly",
+                    "collections/reef-monitoring",
+                    "[-158.05,21.24,-157.72,21.31]",
+                    "Satellite",
+                    "{ \"observations\": [{ \"station\": \"SS-04\", \"turbidity\": 2.4 }] }")
+            ]
+        });
+
+    public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+        => Task.FromResult(new OpenDataPublishResult
+        {
+            DatasetId = datasetId,
+            CatalogUrl = $"https://data.honua.local/datasets/{Slug(datasetId)}",
+            ApiDocsUrl = $"https://data.honua.local/api/docs/{Slug(datasetId)}",
+            PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+            Message = $"{datasetId} is published to the open data catalog."
+        });
+
+    private static OpenDataDataset Dataset(
+        string datasetId,
+        string title,
+        string description,
+        string category,
+        string geography,
+        OpenDataDatasetStatus status,
+        bool publicCatalogEnabled,
+        bool apiEnabled,
+        bool embedEnabled,
+        IReadOnlyList<string> keywords,
+        string license,
+        string contact,
+        string updateFrequency,
+        string stacCollectionId,
+        string extent,
+        string basemap,
+        string sampleResponse,
+        DateTimeOffset? scheduledPublishAt = null)
+    {
+        var basePath = $"/open-data/{Slug(datasetId)}";
+        return new OpenDataDataset
+        {
+            DatasetId = datasetId,
+            Title = title,
+            Description = description,
+            Category = category,
+            Geography = geography,
+            License = license,
+            Contact = contact,
+            UpdateFrequency = updateFrequency,
+            Status = status,
+            LastUpdated = DateTimeOffset.Parse("2026-04-27T18:30:00Z"),
+            ScheduledPublishAt = scheduledPublishAt,
+            PublicCatalogEnabled = publicCatalogEnabled,
+            ApiEnabled = apiEnabled,
+            EmbedEnabled = embedEnabled,
+            StacCollectionId = stacCollectionId,
+            SampleResponse = sampleResponse,
+            Keywords = keywords,
+            Downloads =
+            [
+                Download(OpenDataDownloadFormat.GeoJson, $"{basePath}.geojson", 8_120_000),
+                Download(OpenDataDownloadFormat.GeoParquet, $"{basePath}.parquet", 3_840_000),
+                Download(OpenDataDownloadFormat.Shapefile, $"{basePath}.zip", 11_240_000),
+                Download(OpenDataDownloadFormat.Csv, $"{basePath}.csv", 2_220_000),
+                Download(OpenDataDownloadFormat.Kml, $"{basePath}.kml", 4_160_000)
+            ],
+            ApiEndpoints =
+            [
+                new OpenDataApiEndpoint
+                {
+                    Name = "Features",
+                    Path = $"/api/open-data/{Slug(datasetId)}/features",
+                    Example = $"curl https://data.honua.local/api/open-data/{Slug(datasetId)}/features?limit=100",
+                    RequiresApiKey = false,
+                    RateLimitPerMinute = 120
+                },
+                new OpenDataApiEndpoint
+                {
+                    Name = "STAC collection",
+                    Path = $"/api/stac/{stacCollectionId}",
+                    Example = $"fetch('/api/stac/{stacCollectionId}')",
+                    RequiresApiKey = false,
+                    RateLimitPerMinute = 240
+                },
+                new OpenDataApiEndpoint
+                {
+                    Name = "Bulk export",
+                    Path = $"/api/open-data/{Slug(datasetId)}/exports/latest",
+                    Example = $"python -m honua_download https://data.honua.local/api/open-data/{Slug(datasetId)}/exports/latest",
+                    RequiresApiKey = true,
+                    RateLimitPerMinute = 30
+                }
+            ],
+            EmbedConfig = new OpenDataEmbedConfig
+            {
+                EmbedUrl = $"https://data.honua.local/embed/{Slug(datasetId)}",
+                Basemap = basemap,
+                InitialExtent = extent,
+                BrandingMode = "White label",
+                Responsive = true,
+                WcagReady = embedEnabled
+            }
+        };
+    }
+
+    private static OpenDataDownloadOption Download(OpenDataDownloadFormat format, string url, long sizeBytes)
+        => new()
+        {
+            Format = format,
+            Url = url,
+            SizeBytes = sizeBytes,
+            GeneratedAt = DateTimeOffset.Parse("2026-04-27T18:30:00Z")
+        };
+
+    private static string Slug(string value)
+    {
+        var builder = new StringBuilder();
+        foreach (var character in value.Trim())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(char.ToLowerInvariant(character));
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+
+        while (builder.Length > 0 && builder[^1] == '-')
+        {
+            builder.Length--;
+        }
+
+        return builder.Length == 0 ? "untitled-dataset" : builder.ToString();
+    }
+}

--- a/src/Honua.Admin/Shared/NavMenu.razor
+++ b/src/Honua.Admin/Shared/NavMenu.razor
@@ -35,6 +35,9 @@
     <MudNavLink Href="/operator/app-builder" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.DashboardCustomize">
         App builder
     </MudNavLink>
+    <MudNavLink Href="/operator/open-data" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Public">
+        Open data hub
+    </MudNavLink>
     <MudNavLink Href="/operator/print" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Print">
         Print service
     </MudNavLink>

--- a/src/Honua.Admin/wwwroot/css/open-data-hub.css
+++ b/src/Honua.Admin/wwwroot/css/open-data-hub.css
@@ -1,0 +1,269 @@
+.open-data-root {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-height: calc(100vh - 96px);
+    padding: 16px;
+    background: #f5f7f8;
+}
+
+.open-data-toolbar,
+.open-data-pane,
+.open-data-metric {
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 8px;
+    background: #ffffff;
+}
+
+.open-data-toolbar,
+.open-data-pane {
+    padding: 14px;
+}
+
+.open-data-toolbar-row,
+.open-data-detail-heading {
+    flex-wrap: wrap;
+}
+
+.open-data-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(160px, 1fr));
+    gap: 12px;
+}
+
+.open-data-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px;
+    border-left: 4px solid #1b7895;
+}
+
+.open-data-metric:nth-child(2) {
+    border-left-color: #6f5b95;
+}
+
+.open-data-metric:nth-child(3) {
+    border-left-color: #2f7d55;
+}
+
+.open-data-metric:nth-child(4) {
+    border-left-color: #a4642d;
+}
+
+.open-data-metric span,
+.open-data-metric small,
+.open-data-dataset small,
+.open-data-dataset em,
+.open-data-metadata-grid span,
+.open-data-delivery-row span,
+.open-data-api-row span,
+.open-data-validation-row span,
+.open-data-embed-preview span,
+.open-data-embed-preview small {
+    color: var(--mud-palette-text-secondary, #607d8b);
+}
+
+.open-data-metric strong {
+    font-size: 1.55rem;
+    line-height: 1.2;
+}
+
+.open-data-grid {
+    display: grid;
+    grid-template-columns: minmax(280px, 0.85fr) minmax(420px, 1.35fr) minmax(340px, 1fr);
+    gap: 12px;
+    align-items: start;
+}
+
+.open-data-dataset-list,
+.open-data-delivery-group,
+.open-data-validation {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.open-data-dataset {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    gap: 3px;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+    background: #ffffff;
+    cursor: pointer;
+    text-align: left;
+}
+
+.open-data-dataset:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+}
+
+.open-data-dataset.selected {
+    border-color: #1b7895;
+    background: #eef8fa;
+}
+
+.open-data-dataset span,
+.open-data-dataset small,
+.open-data-dataset em {
+    overflow-wrap: anywhere;
+}
+
+.open-data-dataset em {
+    font-style: normal;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+}
+
+.open-data-empty {
+    border: 1px dashed var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 14px;
+    color: var(--mud-palette-text-secondary, #607d8b);
+}
+
+.open-data-detail {
+    min-height: 620px;
+}
+
+.open-data-metadata-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.open-data-metadata-grid div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 3px;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+    background: #fbfcfd;
+}
+
+.open-data-metadata-grid strong,
+.open-data-delivery-row strong,
+.open-data-delivery-row span,
+.open-data-api-row strong,
+.open-data-api-row span,
+.open-data-validation-row strong,
+.open-data-validation-row span,
+.open-data-embed-preview strong,
+.open-data-embed-preview span {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.open-data-keywords,
+.open-data-embed-flags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.open-data-code {
+    overflow: auto;
+    max-width: 100%;
+    margin: 8px 0 0;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+    background: #101820;
+    color: #f5f7f8;
+    font-size: 0.82rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.open-data-delivery-row,
+.open-data-validation-row,
+.open-data-api-row,
+.open-data-embed-preview {
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+    background: #ffffff;
+}
+
+.open-data-delivery-row,
+.open-data-validation-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.open-data-delivery-row div,
+.open-data-validation-row div,
+.open-data-api-row div,
+.open-data-embed-preview div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.open-data-delivery-row small {
+    margin-left: auto;
+    color: var(--mud-palette-text-secondary, #607d8b);
+    white-space: nowrap;
+}
+
+.open-data-api-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+}
+
+.open-data-api-row .open-data-code {
+    grid-column: 1 / -1;
+}
+
+.open-data-embed-preview {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    background: #f8fbf8;
+}
+
+@media (max-width: 1180px) {
+    .open-data-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 860px) {
+    .open-data-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .open-data-root {
+        padding: 10px;
+    }
+
+    .open-data-metrics,
+    .open-data-metadata-grid,
+    .open-data-api-row {
+        grid-template-columns: 1fr;
+    }
+
+    .open-data-delivery-row {
+        align-items: flex-start;
+    }
+
+    .open-data-delivery-row small {
+        margin-left: 0;
+    }
+}

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -16,6 +16,7 @@
     <link href="css/publishing-workspace.css" rel="stylesheet" />
     <link href="css/usage-analytics.css" rel="stylesheet" />
     <link href="css/app-builder.css" rel="stylesheet" />
+    <link href="css/open-data-hub.css" rel="stylesheet" />
     <link href="css/print-service.css" rel="stylesheet" />
 </head>
 

--- a/tests/Honua.Admin.Tests/NavMenuTests.cs
+++ b/tests/Honua.Admin.Tests/NavMenuTests.cs
@@ -92,6 +92,16 @@ public sealed class NavMenuTests
     }
 
     [Fact]
+    public void NavMenu_registers_open_data_hub_under_operator_route()
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
+        var contents = File.ReadAllText(path);
+
+        Assert.Contains("/operator/open-data", contents, System.StringComparison.Ordinal);
+        Assert.Contains("Open data hub", contents, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NavMenu_uses_a_single_MudNavMenu_so_sql_page_lives_in_the_shared_shell()
     {
         var path = Path.Combine(System.AppContext.BaseDirectory, NavMenuPath);
@@ -111,6 +121,7 @@ public sealed class NavMenuTests
         var operatorPublishing = contents.IndexOf("/operator/publishing", System.StringComparison.Ordinal);
         var operatorAnalytics = contents.IndexOf("/operator/analytics", System.StringComparison.Ordinal);
         var operatorAppBuilder = contents.IndexOf("/operator/app-builder", System.StringComparison.Ordinal);
+        var operatorOpenData = contents.IndexOf("/operator/open-data", System.StringComparison.Ordinal);
         var operatorPrint = contents.IndexOf("/operator/print", System.StringComparison.Ordinal);
         var menuClose = contents.IndexOf("</MudNavMenu>", System.StringComparison.Ordinal);
 
@@ -122,6 +133,7 @@ public sealed class NavMenuTests
         Assert.True(operatorPublishing > 0);
         Assert.True(operatorAnalytics > 0);
         Assert.True(operatorAppBuilder > 0);
+        Assert.True(operatorOpenData > 0);
         Assert.True(operatorPrint > 0);
         Assert.True(operatorControlCenter < menuClose);
         Assert.True(operatorAdminReadiness < menuClose);
@@ -130,6 +142,7 @@ public sealed class NavMenuTests
         Assert.True(operatorPublishing < menuClose);
         Assert.True(operatorAnalytics < menuClose);
         Assert.True(operatorAppBuilder < menuClose);
+        Assert.True(operatorOpenData < menuClose);
         Assert.True(operatorPrint < menuClose);
     }
 }

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -161,6 +161,21 @@ public sealed class OpenDataHubStateTests
     }
 
     [Fact]
+    public async Task LoadAsync_clears_stale_publish_result_when_refresh_fails()
+    {
+        var state = new OpenDataHubState(new FailingRefreshAfterPublishOpenDataHubClient());
+        await state.LoadAsync();
+        await state.PublishSelectedAsync();
+        Assert.NotNull(state.LastPublish);
+
+        await state.LoadAsync();
+
+        Assert.Equal(OpenDataHubStatus.Error, state.Status);
+        Assert.Equal("refresh failed", state.LastError);
+        Assert.Null(state.LastPublish);
+    }
+
+    [Fact]
     public async Task PublishSelectedAsync_notifies_when_publish_is_canceled()
     {
         var state = new OpenDataHubState(new CancelingPublishOpenDataHubClient());
@@ -233,6 +248,26 @@ public sealed class OpenDataHubStateTests
 
         public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
             => throw new OperationCanceledException(cancellationToken);
+    }
+
+    private sealed class FailingRefreshAfterPublishOpenDataHubClient : IOpenDataHubClient
+    {
+        private readonly StubOpenDataHubClient _inner = new();
+        private int _loadCount;
+
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            _loadCount++;
+            if (_loadCount == 1)
+            {
+                return _inner.GetSnapshotAsync(cancellationToken);
+            }
+
+            throw new InvalidOperationException("refresh failed");
+        }
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+            => _inner.PublishAsync(datasetId, cancellationToken);
     }
 
     private sealed class BlockingPublishOpenDataHubClient : IOpenDataHubClient

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -1,0 +1,335 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Models.OpenDataHub;
+using Honua.Admin.Services.OpenDataHub;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class OpenDataHubStateTests
+{
+    [Fact]
+    public async Task LoadAsync_populates_metrics_datasets_and_validation()
+    {
+        var state = new OpenDataHubState(new StubOpenDataHubClient());
+
+        await state.LoadAsync();
+
+        Assert.Equal(OpenDataHubStatus.Idle, state.Status);
+        Assert.Contains(state.Metrics, metric => metric.Label == "Published datasets");
+        Assert.Contains(state.Datasets, dataset => dataset.DatasetId == "harbor-assets");
+        Assert.Equal("harbor-assets", state.SelectedDataset?.DatasetId);
+        Assert.False(state.HasBlockingValidation);
+    }
+
+    [Fact]
+    public async Task Filters_update_catalog_results_and_selection()
+    {
+        var state = new OpenDataHubState(new StubOpenDataHubClient());
+        await state.LoadAsync();
+
+        state.SetSearchText("permit");
+        state.SetCategoryFilter("Permits");
+        state.SetGeographyFilter("Citywide");
+
+        var dataset = Assert.Single(state.FilteredDatasets);
+        Assert.Equal("permit-activity", dataset.DatasetId);
+        Assert.Equal("permit-activity", state.SelectedDataset?.DatasetId);
+
+        state.ClearFilters();
+
+        Assert.Equal(4, state.FilteredDatasets.Count);
+        Assert.Equal("harbor-assets", state.FilteredDatasets[0].DatasetId);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ignores_stale_snapshot_responses()
+    {
+        var client = new SequencedLoadOpenDataHubClient();
+        var state = new OpenDataHubState(client);
+
+        var staleLoad = state.LoadAsync();
+        var freshLoad = state.LoadAsync();
+        client.CompleteLoad(1, Snapshot("fresh-dataset", "Fresh dataset"));
+        await freshLoad;
+
+        Assert.Equal("fresh-dataset", state.SelectedDataset?.DatasetId);
+
+        client.CompleteLoad(0, Snapshot("stale-dataset", "Stale dataset"));
+        await staleLoad;
+
+        Assert.Equal("fresh-dataset", state.SelectedDataset?.DatasetId);
+        Assert.Equal(OpenDataHubStatus.Idle, state.Status);
+    }
+
+    [Fact]
+    public async Task PublishSelectedAsync_returns_catalog_and_docs_urls_when_valid()
+    {
+        var state = new OpenDataHubState(new StubOpenDataHubClient());
+        await state.LoadAsync();
+
+        await state.PublishSelectedAsync();
+
+        Assert.Equal(OpenDataHubStatus.Published, state.Status);
+        Assert.NotNull(state.LastPublish);
+        Assert.Equal("https://data.honua.local/datasets/harbor-assets", state.LastPublish.CatalogUrl);
+        Assert.Equal("https://data.honua.local/api/docs/harbor-assets", state.LastPublish.ApiDocsUrl);
+        Assert.Null(state.LastError);
+    }
+
+    [Fact]
+    public async Task PublishSelectedAsync_blocks_when_dataset_fails_readiness()
+    {
+        var state = new OpenDataHubState(new StubOpenDataHubClient());
+        await state.LoadAsync();
+        state.SelectDataset("reef-monitoring");
+
+        await state.PublishSelectedAsync();
+
+        Assert.Equal(OpenDataHubStatus.Error, state.Status);
+        Assert.Equal("Resolve validation checks before publishing.", state.LastError);
+        Assert.Null(state.LastPublish);
+        Assert.True(state.HasBlockingValidation);
+    }
+
+    [Fact]
+    public async Task Mutators_ignore_changes_while_publish_is_in_flight()
+    {
+        var client = new BlockingPublishOpenDataHubClient();
+        var state = new OpenDataHubState(client);
+        await state.LoadAsync();
+        var originalSelection = state.SelectedDatasetId;
+
+        var publishTask = state.PublishSelectedAsync();
+        await client.PublishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        state.SetSearchText("permit");
+        state.SetCategoryFilter("Permits");
+        state.SetGeographyFilter("Citywide");
+        state.SelectDataset("permit-activity");
+        state.ClearFilters();
+
+        Assert.Equal(OpenDataHubStatus.Publishing, state.Status);
+        Assert.Equal(originalSelection, state.SelectedDatasetId);
+        Assert.Equal(string.Empty, state.SearchText);
+        Assert.Equal("All", state.CategoryFilter);
+        Assert.Equal("All", state.GeographyFilter);
+
+        client.Complete();
+        await publishTask;
+
+        Assert.Equal(OpenDataHubStatus.Published, state.Status);
+        Assert.Equal(originalSelection, client.PublishedDatasetId);
+    }
+
+    [Fact]
+    public async Task PublishSelectedAsync_ignores_reentrant_publish_calls()
+    {
+        var client = new BlockingPublishOpenDataHubClient();
+        var state = new OpenDataHubState(client);
+        await state.LoadAsync();
+
+        var firstPublish = state.PublishSelectedAsync();
+        await client.PublishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await state.PublishSelectedAsync();
+
+        Assert.Equal(1, client.PublishCalls);
+
+        client.Complete();
+        await firstPublish;
+
+        Assert.Equal(OpenDataHubStatus.Published, state.Status);
+    }
+
+    [Fact]
+    public async Task PublishSelectedAsync_clears_stale_publish_result_when_retry_fails()
+    {
+        var state = new OpenDataHubState(new FailingRetryOpenDataHubClient());
+        await state.LoadAsync();
+        await state.PublishSelectedAsync();
+        Assert.NotNull(state.LastPublish);
+
+        await state.PublishSelectedAsync();
+
+        Assert.Equal(OpenDataHubStatus.Error, state.Status);
+        Assert.Equal("publish failed", state.LastError);
+        Assert.Null(state.LastPublish);
+    }
+
+    [Fact]
+    public async Task PublishSelectedAsync_notifies_when_publish_is_canceled()
+    {
+        var state = new OpenDataHubState(new CancelingPublishOpenDataHubClient());
+        await state.LoadAsync();
+        var observedStatuses = new List<OpenDataHubStatus>();
+        state.OnChanged += () => observedStatuses.Add(state.Status);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => state.PublishSelectedAsync());
+
+        Assert.Equal(OpenDataHubStatus.Idle, state.Status);
+        Assert.Contains(OpenDataHubStatus.Publishing, observedStatuses);
+        Assert.Equal(OpenDataHubStatus.Idle, observedStatuses[^1]);
+    }
+
+    [Fact]
+    public async Task StubPublishAsync_sanitizes_catalog_url_slug()
+    {
+        var client = new StubOpenDataHubClient();
+
+        var result = await client.PublishAsync("Ops/2026?Launch #1", CancellationToken.None);
+
+        Assert.Equal("https://data.honua.local/datasets/ops-2026-launch-1", result.CatalogUrl);
+        Assert.Equal("https://data.honua.local/api/docs/ops-2026-launch-1", result.ApiDocsUrl);
+    }
+
+    private sealed class SequencedLoadOpenDataHubClient : IOpenDataHubClient
+    {
+        private readonly List<TaskCompletionSource<OpenDataHubSnapshot>> _loads = [];
+
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            var load = new TaskCompletionSource<OpenDataHubSnapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _loads.Add(load);
+            return load.Task;
+        }
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public void CompleteLoad(int index, OpenDataHubSnapshot snapshot)
+            => _loads[index].SetResult(snapshot);
+    }
+
+    private sealed class FailingRetryOpenDataHubClient : IOpenDataHubClient
+    {
+        private readonly StubOpenDataHubClient _inner = new();
+        private int _publishCount;
+
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => _inner.GetSnapshotAsync(cancellationToken);
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+        {
+            _publishCount++;
+            if (_publishCount == 1)
+            {
+                return _inner.PublishAsync(datasetId, cancellationToken);
+            }
+
+            throw new InvalidOperationException("publish failed");
+        }
+    }
+
+    private sealed class CancelingPublishOpenDataHubClient : IOpenDataHubClient
+    {
+        private readonly StubOpenDataHubClient _inner = new();
+
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => _inner.GetSnapshotAsync(cancellationToken);
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+            => throw new OperationCanceledException(cancellationToken);
+    }
+
+    private sealed class BlockingPublishOpenDataHubClient : IOpenDataHubClient
+    {
+        private readonly StubOpenDataHubClient _inner = new();
+        private readonly TaskCompletionSource<OpenDataPublishResult> _publishResult =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> PublishStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string? PublishedDatasetId { get; private set; }
+
+        public int PublishCalls { get; private set; }
+
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => _inner.GetSnapshotAsync(cancellationToken);
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+        {
+            PublishCalls++;
+            PublishedDatasetId = datasetId;
+            PublishStarted.TrySetResult(true);
+            return _publishResult.Task;
+        }
+
+        public void Complete()
+            => _publishResult.SetResult(new OpenDataPublishResult
+            {
+                DatasetId = PublishedDatasetId ?? "unknown",
+                CatalogUrl = "https://data.honua.local/datasets/published",
+                ApiDocsUrl = "https://data.honua.local/api/docs/published",
+                PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+                Message = "Published",
+            });
+    }
+
+    private static OpenDataHubSnapshot Snapshot(string datasetId, string title)
+        => new()
+        {
+            Datasets =
+            [
+                new OpenDataDataset
+                {
+                    DatasetId = datasetId,
+                    Title = title,
+                    Description = "Public dataset",
+                    Category = "Infrastructure",
+                    Geography = "Harbor",
+                    License = "CC BY 4.0",
+                    Contact = "gis@honua.local",
+                    UpdateFrequency = "Daily",
+                    Status = OpenDataDatasetStatus.Published,
+                    LastUpdated = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+                    PublicCatalogEnabled = true,
+                    ApiEnabled = true,
+                    EmbedEnabled = true,
+                    StacCollectionId = $"collections/{datasetId}",
+                    SampleResponse = "{}",
+                    Keywords = ["public"],
+                    Downloads =
+                    [
+                        Download(OpenDataDownloadFormat.GeoJson),
+                        Download(OpenDataDownloadFormat.GeoParquet),
+                        Download(OpenDataDownloadFormat.Shapefile),
+                        Download(OpenDataDownloadFormat.Csv),
+                        Download(OpenDataDownloadFormat.Kml),
+                    ],
+                    ApiEndpoints =
+                    [
+                        new OpenDataApiEndpoint
+                        {
+                            Name = "Features",
+                            Path = "/api/open-data/features",
+                            RequiresApiKey = false,
+                            RateLimitPerMinute = 120,
+                        },
+                    ],
+                    EmbedConfig = new OpenDataEmbedConfig
+                    {
+                        EmbedUrl = "https://data.honua.local/embed/dataset",
+                        Basemap = "Light",
+                        InitialExtent = "[-158,21,-157,22]",
+                        BrandingMode = "White label",
+                        Responsive = true,
+                        WcagReady = true,
+                    },
+                },
+            ],
+        };
+
+    private static OpenDataDownloadOption Download(OpenDataDownloadFormat format)
+        => new()
+        {
+            Format = format,
+            Url = $"/downloads/{format}",
+            SizeBytes = 100,
+            GeneratedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+        };
+}

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -14,6 +14,7 @@ using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.AppBuilder;
 using Honua.Admin.Services.Operations;
+using Honua.Admin.Services.OpenDataHub;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.SpecWorkspace;
@@ -41,6 +42,8 @@ public sealed class AdminPageRenderTests : TestContext
         Services.AddScoped<PrintServiceState>();
         Services.AddScoped<IAppBuilderClient, StubAppBuilderClient>();
         Services.AddScoped<AppBuilderState>();
+        Services.AddScoped<IOpenDataHubClient, StubOpenDataHubClient>();
+        Services.AddScoped<OpenDataHubState>();
         Services.AddScoped<OperationsConsoleState>();
         Services.AddScoped<CatalogCache>();
         Services.AddScoped<IBrowserStorageService, MemoryBrowserStorageService>();
@@ -328,6 +331,22 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Harbor operations dashboard");
             cut.Markup.MarkupMatchesContaining("Open incidents");
             cut.Markup.MarkupMatchesContaining("App builder validation checks");
+        });
+    }
+
+    [Fact]
+    public void OpenDataHub_RendersCatalogDeliveryAndValidation()
+    {
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.OpenDataHub>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Open data hub");
+            cut.Markup.MarkupMatchesContaining("Published datasets");
+            cut.Markup.MarkupMatchesContaining("Harbor assets");
+            cut.Markup.MarkupMatchesContaining("GeoJSON");
+            cut.Markup.MarkupMatchesContaining("Civic tech API");
+            cut.Markup.MarkupMatchesContaining("Readiness checks");
         });
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -13,6 +13,7 @@ using Honua.Admin.Services.Admin;
 using Honua.Admin.Services.Annotations;
 using Honua.Admin.Services.AppBuilder;
 using Honua.Admin.Services.Operations;
+using Honua.Admin.Services.OpenDataHub;
 using Honua.Admin.Services.PrintService;
 using Honua.Admin.Services.Publishing;
 using Honua.Admin.Services.SpecWorkspace;
@@ -48,6 +49,8 @@ public sealed class AdminQualityGateTests : TestContext
         Services.AddScoped<PrintServiceState>();
         Services.AddScoped<IAppBuilderClient, StubAppBuilderClient>();
         Services.AddScoped<AppBuilderState>();
+        Services.AddScoped<IOpenDataHubClient, StubOpenDataHubClient>();
+        Services.AddScoped<OpenDataHubState>();
         Services.AddScoped<CatalogCache>();
         Services.AddScoped<IBrowserStorageService, BrowserStorageService>();
         Services.AddScoped<ISpecWorkspaceTelemetry, NullSpecWorkspaceTelemetry>();
@@ -162,6 +165,13 @@ public sealed class AdminQualityGateTests : TestContext
             typeof(Honua.Admin.Pages.Operator.AppBuilder),
             "Harbor operations dashboard",
             new[] { "[aria-label='App builder toolbar']", "[aria-label='Widget library']", "[aria-label='App layout canvas']", "[aria-label='App builder validation checks']" },
+        ];
+        yield return
+        [
+            "Open data hub",
+            typeof(Honua.Admin.Pages.Operator.OpenDataHub),
+            "Harbor assets",
+            new[] { "[aria-label='Open data hub toolbar']", "[aria-label='Open data catalog filters']", "[aria-label='Open data dataset catalog']", "[aria-label='Open data delivery readiness']", "[aria-label='Open data validation checks']" },
         ];
     }
 


### PR DESCRIPTION
Related to honua-io/honua-portal#6 (partial admin UI slice).

## Summary
- add an operator Open data hub workspace for catalog intake, dataset filtering, metadata readiness, downloads, API endpoints, and embed configuration
- add deterministic stub open-data hub models/client/state with load and publish guards
- wire navigation, CSS, and quality gates for the new operator route

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal" --filter "OpenDataHubStateTests|AdminPageRenderTests|AdminQualityGateTests|NavMenuTests"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --cached --check
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"