### PR TITLE
feat: add app builder publishing readiness

### DIFF
--- a/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
+++ b/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
@@ -86,6 +86,7 @@ public sealed record AppDraft
     public string TemplateId { get; init; } = "operations-dashboard";
     public string ThemeName { get; init; } = "Civic light";
     public int AutoRefreshSeconds { get; init; } = 60;
+    public bool IsPublished { get; init; }
     public IReadOnlyList<AppWidgetInstance> Widgets { get; init; } = Array.Empty<AppWidgetInstance>();
 }
 

--- a/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
+++ b/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
@@ -12,6 +12,13 @@ public enum AppBuilderStatus
     Error
 }
 
+public enum AppPublishChannelKind
+{
+    StandaloneUrl,
+    IframeEmbed,
+    CustomDomain
+}
+
 public enum AppWidgetKind
 {
     Map,
@@ -29,6 +36,8 @@ public sealed record AppBuilderSnapshot
 {
     public IReadOnlyList<AppTemplate> Templates { get; init; } = Array.Empty<AppTemplate>();
     public IReadOnlyList<AppWidgetDefinition> WidgetLibrary { get; init; } = Array.Empty<AppWidgetDefinition>();
+    public IReadOnlyList<AppPublishChannel> PublishChannels { get; init; } = Array.Empty<AppPublishChannel>();
+    public AppQuotaState Quota { get; init; } = new();
     public AppDraft Draft { get; init; } = new();
 }
 
@@ -49,6 +58,25 @@ public sealed record AppWidgetDefinition
     public string Description { get; init; } = string.Empty;
     public bool SupportsDataBinding { get; init; }
     public string DefaultBinding { get; init; } = string.Empty;
+}
+
+public sealed record AppPublishChannel
+{
+    public string ChannelId { get; init; } = string.Empty;
+    public AppPublishChannelKind Kind { get; init; }
+    public string Label { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public bool Enabled { get; init; }
+    public string RequiredEdition { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+}
+
+public sealed record AppQuotaState
+{
+    public string Edition { get; init; } = "Pro";
+    public int PublishedApps { get; init; }
+    public int? AppLimit { get; init; } = 5;
+    public bool CanPublishMore => AppLimit is null || PublishedApps < AppLimit.Value;
 }
 
 public sealed record AppDraft

--- a/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
+++ b/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
@@ -115,4 +115,5 @@ public sealed record AppPublishResult
     public string EmbedUrl { get; init; } = string.Empty;
     public DateTimeOffset PublishedAt { get; init; }
     public string Message { get; init; } = string.Empty;
+    public bool ConsumedQuotaSlot { get; init; }
 }

--- a/src/Honua.Admin/Pages/Operator/AppBuilder.razor
+++ b/src/Honua.Admin/Pages/Operator/AppBuilder.razor
@@ -148,6 +148,45 @@
                              Margin="Margin.Dense"
                              aria-label="Auto refresh seconds" />
 
+            <MudText Typo="Typo.h6" Class="mt-4">Publishing readiness</MudText>
+            <div class="app-builder-publishing-readiness" aria-label="App builder publishing readiness">
+                <div class="app-builder-quota-row" data-testid="app-builder-quota">
+                    <MudIcon Icon="@Icons.Material.Filled.VerifiedUser" Size="Size.Small" />
+                    <div>
+                        <strong>@($"{State.Quota.Edition} app quota")</strong>
+                        <span>@QuotaMessage</span>
+                    </div>
+                </div>
+                @foreach (var channel in State.PublishChannels)
+                {
+                    <div class="app-builder-publish-channel" data-testid="@($"app-builder-channel-{channel.ChannelId}")">
+                        <MudIcon Icon="@ChannelIcon(channel.Kind)"
+                                 Color="@ChannelColor(channel)"
+                                 Size="Size.Small" />
+                        <div>
+                            <strong>@channel.Label</strong>
+                            <span>@channel.Target</span>
+                            <small>@channel.Message</small>
+                        </div>
+                        <MudChip T="string" Size="Size.Small" Color="@ChannelColor(channel)" Variant="Variant.Outlined">
+                            @(channel.Enabled ? "Enabled" : channel.RequiredEdition)
+                        </MudChip>
+                    </div>
+                }
+                @foreach (var check in State.PublishReadinessChecks)
+                {
+                    <div class="app-builder-validation-row" data-testid="@($"app-builder-publish-check-{check.Key}")">
+                        <MudIcon Icon="@(check.Passed ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Error)"
+                                 Color="@(check.Passed ? Color.Success : Color.Warning)"
+                                 Size="Size.Small" />
+                        <div>
+                            <strong>@check.Label</strong>
+                            <span>@check.Message</span>
+                        </div>
+                    </div>
+                }
+            </div>
+
             <MudText Typo="Typo.h6" Class="mt-4">Validation</MudText>
             <div class="app-builder-validation" aria-label="App builder validation checks">
                 @foreach (var check in State.ValidationChecks)
@@ -199,6 +238,10 @@
 
     private void StateChanged() => InvokeAsync(StateHasChanged);
 
+    private string QuotaMessage => State.Quota.AppLimit is null
+        ? $"{State.Quota.PublishedApps} published apps, unlimited {State.Quota.Edition} allowance."
+        : $"{State.Quota.PublishedApps} of {State.Quota.AppLimit.Value} published apps used.";
+
     private string TemplateClass(AppTemplate template)
         => string.Equals(template.TemplateId, State.Draft.TemplateId, StringComparison.OrdinalIgnoreCase)
             ? "app-builder-template selected"
@@ -230,6 +273,17 @@
         AppWidgetKind.RichText => Icons.Material.Filled.Article,
         _ => Icons.Material.Filled.Widgets
     };
+
+    private static string ChannelIcon(AppPublishChannelKind kind) => kind switch
+    {
+        AppPublishChannelKind.StandaloneUrl => Icons.Material.Filled.Link,
+        AppPublishChannelKind.IframeEmbed => Icons.Material.Filled.Code,
+        AppPublishChannelKind.CustomDomain => Icons.Material.Filled.Language,
+        _ => Icons.Material.Filled.Publish
+    };
+
+    private static Color ChannelColor(AppPublishChannel channel)
+        => channel.Enabled ? Color.Success : Color.Warning;
 
     private static Color StatusColor(AppBuilderStatus status) => status switch
     {

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -85,6 +85,15 @@ public sealed class AppBuilderState
             var customDomain = PublishChannels.FirstOrDefault(channel => channel.Kind == AppPublishChannelKind.CustomDomain);
             var quotaLimit = Quota.AppLimit?.ToString() ?? "unlimited";
             var isEnterprise = string.Equals(Quota.Edition, "Enterprise", StringComparison.OrdinalIgnoreCase);
+            var quotaPassed = Draft.IsPublished || Quota.CanPublishMore;
+            var quotaMessage = quotaPassed
+                ? $"{Quota.PublishedApps} of {quotaLimit} {Quota.Edition} app slots used."
+                : $"{Quota.Edition} app limit reached.";
+
+            if (Draft.IsPublished && !Quota.CanPublishMore)
+            {
+                quotaMessage = $"{Quota.Edition} app limit reached; updates to this published app do not use a new slot.";
+            }
 
             return
             [
@@ -92,8 +101,8 @@ public sealed class AppBuilderState
                 {
                     Key = "quota",
                     Label = "Published app quota",
-                    Passed = Quota.CanPublishMore,
-                    Message = Quota.CanPublishMore ? $"{Quota.PublishedApps} of {quotaLimit} {Quota.Edition} app slots used." : $"{Quota.Edition} app limit reached."
+                    Passed = quotaPassed,
+                    Message = quotaMessage
                 },
                 new AppValidationCheck
                 {
@@ -120,7 +129,7 @@ public sealed class AppBuilderState
         }
     }
 
-    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed) || !Quota.CanPublishMore;
+    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed) || (!Draft.IsPublished && !Quota.CanPublishMore);
 
     public event Action? OnChanged;
 
@@ -302,6 +311,7 @@ public sealed class AppBuilderState
                 Quota = Quota with { PublishedApps = Quota.PublishedApps + 1 };
             }
 
+            Draft = Draft with { IsPublished = true };
             Status = AppBuilderStatus.Published;
         }
         catch (OperationCanceledException)

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -22,6 +22,10 @@ public sealed class AppBuilderState
 
     public IReadOnlyList<AppWidgetDefinition> WidgetLibrary { get; private set; } = Array.Empty<AppWidgetDefinition>();
 
+    public IReadOnlyList<AppPublishChannel> PublishChannels { get; private set; } = Array.Empty<AppPublishChannel>();
+
+    public AppQuotaState Quota { get; private set; } = new();
+
     public AppDraft Draft { get; private set; } = new();
 
     public AppPublishResult? LastPublish { get; private set; }
@@ -72,7 +76,50 @@ public sealed class AppBuilderState
         }
     }
 
-    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed);
+    public IReadOnlyList<AppValidationCheck> PublishReadinessChecks
+    {
+        get
+        {
+            var standalone = PublishChannels.FirstOrDefault(channel => channel.Kind == AppPublishChannelKind.StandaloneUrl);
+            var embed = PublishChannels.FirstOrDefault(channel => channel.Kind == AppPublishChannelKind.IframeEmbed);
+            var customDomain = PublishChannels.FirstOrDefault(channel => channel.Kind == AppPublishChannelKind.CustomDomain);
+            var quotaLimit = Quota.AppLimit?.ToString() ?? "unlimited";
+
+            return
+            [
+                new AppValidationCheck
+                {
+                    Key = "quota",
+                    Label = "Published app quota",
+                    Passed = Quota.CanPublishMore,
+                    Message = Quota.CanPublishMore ? $"{Quota.PublishedApps} of {quotaLimit} {Quota.Edition} app slots used." : $"{Quota.Edition} app limit reached."
+                },
+                new AppValidationCheck
+                {
+                    Key = "standalone",
+                    Label = "Standalone URL",
+                    Passed = standalone?.Enabled == true,
+                    Message = standalone?.Message ?? "Standalone URL publishing channel is not configured."
+                },
+                new AppValidationCheck
+                {
+                    Key = "embed",
+                    Label = "Iframe embed",
+                    Passed = embed?.Enabled == true,
+                    Message = embed?.Message ?? "Embed publishing channel is not configured."
+                },
+                new AppValidationCheck
+                {
+                    Key = "custom-domain",
+                    Label = "Custom domain",
+                    Passed = customDomain is null || customDomain.Enabled || !string.Equals(Quota.Edition, "Enterprise", StringComparison.OrdinalIgnoreCase),
+                    Message = customDomain?.Message ?? "Custom domains can be configured from Enterprise branding."
+                }
+            ];
+        }
+    }
+
+    public bool HasBlockingValidation => ValidationChecks.Any(check => !check.Passed) || !Quota.CanPublishMore;
 
     public event Action? OnChanged;
 
@@ -93,6 +140,8 @@ public sealed class AppBuilderState
 
             Templates = snapshot.Templates;
             WidgetLibrary = snapshot.WidgetLibrary;
+            PublishChannels = snapshot.PublishChannels;
+            Quota = snapshot.Quota;
             Draft = snapshot.Draft;
             LastPublish = null;
             Status = AppBuilderStatus.Idle;

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -297,7 +297,11 @@ public sealed class AppBuilderState
         try
         {
             LastPublish = await _client.PublishAsync(Draft, cancellationToken).ConfigureAwait(false);
-            Quota = Quota with { PublishedApps = Quota.PublishedApps + 1 };
+            if (LastPublish.ConsumedQuotaSlot)
+            {
+                Quota = Quota with { PublishedApps = Quota.PublishedApps + 1 };
+            }
+
             Status = AppBuilderStatus.Published;
         }
         catch (OperationCanceledException)

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -297,6 +297,7 @@ public sealed class AppBuilderState
         try
         {
             LastPublish = await _client.PublishAsync(Draft, cancellationToken).ConfigureAwait(false);
+            Quota = Quota with { PublishedApps = Quota.PublishedApps + 1 };
             Status = AppBuilderStatus.Published;
         }
         catch (OperationCanceledException)

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -84,6 +84,7 @@ public sealed class AppBuilderState
             var embed = PublishChannels.FirstOrDefault(channel => channel.Kind == AppPublishChannelKind.IframeEmbed);
             var customDomain = PublishChannels.FirstOrDefault(channel => channel.Kind == AppPublishChannelKind.CustomDomain);
             var quotaLimit = Quota.AppLimit?.ToString() ?? "unlimited";
+            var isEnterprise = string.Equals(Quota.Edition, "Enterprise", StringComparison.OrdinalIgnoreCase);
 
             return
             [
@@ -112,8 +113,8 @@ public sealed class AppBuilderState
                 {
                     Key = "custom-domain",
                     Label = "Custom domain",
-                    Passed = customDomain is null || customDomain.Enabled || !string.Equals(Quota.Edition, "Enterprise", StringComparison.OrdinalIgnoreCase),
-                    Message = customDomain?.Message ?? "Custom domains can be configured from Enterprise branding."
+                    Passed = !isEnterprise || customDomain?.Enabled == true,
+                    Message = customDomain?.Message ?? (isEnterprise ? "Custom domain publishing channel is not configured." : "Custom domains can be configured from Enterprise branding.")
                 }
             ];
         }

--- a/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
@@ -5,6 +5,8 @@ namespace Honua.Admin.Services.AppBuilder;
 
 public sealed class StubAppBuilderClient : IAppBuilderClient
 {
+    private readonly HashSet<string> _publishedDraftIds = new(StringComparer.Ordinal);
+
     public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
     {
         var snapshot = new AppBuilderSnapshot
@@ -105,13 +107,17 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
     }
 
     public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
-        => Task.FromResult(new AppPublishResult
+    {
+        var consumedQuotaSlot = _publishedDraftIds.Add(draft.DraftId);
+        return Task.FromResult(new AppPublishResult
         {
             PublishedUrl = $"https://apps.honua.local/{Slug(draft.Name)}",
             EmbedUrl = $"https://apps.honua.local/embed/{Slug(draft.Name)}",
             PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
-            Message = $"{draft.Name} is ready for preview."
+            Message = $"{draft.Name} is ready for preview.",
+            ConsumedQuotaSlot = consumedQuotaSlot
         });
+    }
 
     private static AppWidgetDefinition Widget(
         AppWidgetKind kind,

--- a/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
@@ -51,6 +51,39 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
                 Widget(AppWidgetKind.Gauge, "Gauge", "Numeric range visualization.", true, "SLA compliance"),
                 Widget(AppWidgetKind.RichText, "Rich text", "Header, narrative, and branded text block.", false, "Section copy")
             ],
+            PublishChannels =
+            [
+                Channel(
+                    "standalone-url",
+                    AppPublishChannelKind.StandaloneUrl,
+                    "Standalone URL",
+                    "https://apps.honua.local/{slug}",
+                    true,
+                    "Pro",
+                    "Ready for public or internal app launch."),
+                Channel(
+                    "iframe-embed",
+                    AppPublishChannelKind.IframeEmbed,
+                    "Iframe embed",
+                    "https://apps.honua.local/embed/{slug}",
+                    true,
+                    "Pro",
+                    "Embeddable viewer output is available for CMS pages."),
+                Channel(
+                    "custom-domain",
+                    AppPublishChannelKind.CustomDomain,
+                    "Custom domain",
+                    "https://apps.example.gov/{slug}",
+                    false,
+                    "Enterprise",
+                    "Enterprise branding unlocks custom domain publishing.")
+            ],
+            Quota = new AppQuotaState
+            {
+                Edition = "Pro",
+                PublishedApps = 3,
+                AppLimit = 5
+            },
             Draft = new AppDraft
             {
                 DraftId = "draft-operations-dashboard",
@@ -92,6 +125,24 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
             Description = description,
             SupportsDataBinding = supportsDataBinding,
             DefaultBinding = defaultBinding
+        };
+
+    private static AppPublishChannel Channel(
+        string channelId,
+        AppPublishChannelKind kind,
+        string label,
+        string target,
+        bool enabled,
+        string requiredEdition,
+        string message) => new()
+        {
+            ChannelId = channelId,
+            Kind = kind,
+            Label = label,
+            Target = target,
+            Enabled = enabled,
+            RequiredEdition = requiredEdition,
+            Message = message
         };
 
     private static AppWidgetInstance Instance(

--- a/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
@@ -108,7 +108,7 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
 
     public Task<AppPublishResult> PublishAsync(AppDraft draft, CancellationToken cancellationToken)
     {
-        var consumedQuotaSlot = _publishedDraftIds.Add(draft.DraftId);
+        var consumedQuotaSlot = !draft.IsPublished && _publishedDraftIds.Add(draft.DraftId);
         return Task.FromResult(new AppPublishResult
         {
             PublishedUrl = $"https://apps.honua.local/{Slug(draft.Name)}",

--- a/src/Honua.Admin/wwwroot/css/app-builder.css
+++ b/src/Honua.Admin/wwwroot/css/app-builder.css
@@ -28,7 +28,8 @@
 
 .app-builder-template-list,
 .app-builder-widget-library,
-.app-builder-validation {
+.app-builder-validation,
+.app-builder-publishing-readiness {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -61,11 +62,16 @@
 
 .app-builder-template small,
 .app-builder-widget-definition span,
+.app-builder-publish-channel span,
+.app-builder-publish-channel small,
+.app-builder-quota-row span,
 .app-builder-widget-body small {
     color: var(--mud-palette-text-secondary, #607d8b);
 }
 
 .app-builder-widget-definition,
+.app-builder-quota-row,
+.app-builder-publish-channel,
 .app-builder-validation-row {
     display: flex;
     align-items: center;
@@ -77,10 +83,25 @@
 }
 
 .app-builder-widget-definition div,
+.app-builder-quota-row div,
+.app-builder-publish-channel div,
 .app-builder-validation-row div {
     display: flex;
     flex-direction: column;
     min-width: 0;
+}
+
+.app-builder-publish-channel {
+    align-items: flex-start;
+}
+
+.app-builder-publish-channel strong,
+.app-builder-publish-channel span,
+.app-builder-publish-channel small,
+.app-builder-quota-row strong,
+.app-builder-quota-row span {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .app-builder-canvas-pane {

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -211,6 +211,45 @@ public sealed class AppBuilderStateTests
     }
 
     [Fact]
+    public async Task PublishReadiness_flags_missing_enterprise_custom_domain_channel()
+    {
+        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Enterprise dashboard") with
+        {
+            Quota = new AppQuotaState
+            {
+                Edition = "Enterprise",
+                AppLimit = null,
+                PublishedApps = 12,
+            },
+            PublishChannels =
+            [
+                new AppPublishChannel
+                {
+                    ChannelId = "standalone-url",
+                    Kind = AppPublishChannelKind.StandaloneUrl,
+                    Label = "Standalone URL",
+                    Enabled = true,
+                    Message = "Ready",
+                },
+                new AppPublishChannel
+                {
+                    ChannelId = "iframe-embed",
+                    Kind = AppPublishChannelKind.IframeEmbed,
+                    Label = "Iframe embed",
+                    Enabled = true,
+                    Message = "Ready",
+                },
+            ],
+        }));
+        await state.LoadAsync();
+
+        var customDomain = Assert.Single(state.PublishReadinessChecks, check => check.Key == "custom-domain");
+
+        Assert.False(customDomain.Passed);
+        Assert.Equal("Custom domain publishing channel is not configured.", customDomain.Message);
+    }
+
+    [Fact]
     public async Task PublishAsync_clears_stale_publish_result_when_retry_fails()
     {
         var state = new AppBuilderState(new FailingRetryAppBuilderClient());

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -211,6 +211,28 @@ public sealed class AppBuilderStateTests
     }
 
     [Fact]
+    public async Task PublishAsync_consumes_quota_slot_after_success()
+    {
+        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Final slot dashboard") with
+        {
+            Quota = new AppQuotaState
+            {
+                Edition = "Pro",
+                PublishedApps = 3,
+                AppLimit = 4,
+            },
+        }));
+        await state.LoadAsync();
+
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Published, state.Status);
+        Assert.Equal(4, state.Quota.PublishedApps);
+        Assert.True(state.HasBlockingValidation);
+        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && !check.Passed);
+    }
+
+    [Fact]
     public async Task PublishReadiness_flags_missing_enterprise_custom_domain_channel()
     {
         var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Enterprise dashboard") with

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -191,7 +191,8 @@ public sealed class AppBuilderStateTests
     [Fact]
     public async Task PublishAsync_blocks_when_app_quota_is_full()
     {
-        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Quota dashboard") with
+        var snapshot = Snapshot("Quota dashboard");
+        var state = new AppBuilderState(new FixedAppBuilderClient(snapshot with
         {
             Quota = new AppQuotaState
             {
@@ -199,6 +200,7 @@ public sealed class AppBuilderStateTests
                 PublishedApps = 5,
                 AppLimit = 5,
             },
+            Draft = snapshot.Draft with { IsPublished = false },
         }));
         await state.LoadAsync();
 
@@ -208,6 +210,31 @@ public sealed class AppBuilderStateTests
         Assert.Equal("Resolve validation checks before publishing.", state.LastError);
         Assert.Null(state.LastPublish);
         Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && !check.Passed);
+    }
+
+    [Fact]
+    public async Task PublishAsync_allows_republish_when_app_quota_is_full()
+    {
+        var snapshot = Snapshot("Existing quota dashboard");
+        var state = new AppBuilderState(new FixedAppBuilderClient(snapshot with
+        {
+            Quota = new AppQuotaState
+            {
+                Edition = "Pro",
+                PublishedApps = 5,
+                AppLimit = 5,
+            },
+            Draft = snapshot.Draft with { IsPublished = true },
+        }));
+        await state.LoadAsync();
+
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Published, state.Status);
+        Assert.Equal(5, state.Quota.PublishedApps);
+        Assert.True(state.Draft.IsPublished);
+        Assert.False(state.HasBlockingValidation);
+        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && check.Passed);
     }
 
     [Fact]
@@ -230,14 +257,16 @@ public sealed class AppBuilderStateTests
 
         Assert.Equal(AppBuilderStatus.Published, state.Status);
         Assert.Equal(4, state.Quota.PublishedApps);
-        Assert.True(state.HasBlockingValidation);
-        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && !check.Passed);
+        Assert.True(state.Draft.IsPublished);
+        Assert.False(state.HasBlockingValidation);
+        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && check.Passed);
     }
 
     [Fact]
     public async Task PublishAsync_preserves_quota_when_republishing_existing_app()
     {
-        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Existing dashboard") with
+        var snapshot = Snapshot("Existing dashboard");
+        var state = new AppBuilderState(new FixedAppBuilderClient(snapshot with
         {
             Quota = new AppQuotaState
             {
@@ -245,6 +274,7 @@ public sealed class AppBuilderStateTests
                 PublishedApps = 3,
                 AppLimit = 4,
             },
+            Draft = snapshot.Draft with { IsPublished = true },
         }));
         await state.LoadAsync();
 
@@ -252,6 +282,7 @@ public sealed class AppBuilderStateTests
 
         Assert.Equal(AppBuilderStatus.Published, state.Status);
         Assert.Equal(3, state.Quota.PublishedApps);
+        Assert.True(state.Draft.IsPublished);
         Assert.False(state.HasBlockingValidation);
     }
 
@@ -344,10 +375,12 @@ public sealed class AppBuilderStateTests
         var first = await client.PublishAsync(draft, CancellationToken.None);
         var second = await client.PublishAsync(draft, CancellationToken.None);
         var third = await client.PublishAsync(draft with { DraftId = "draft-new" }, CancellationToken.None);
+        var existing = await client.PublishAsync(draft with { DraftId = "draft-published", IsPublished = true }, CancellationToken.None);
 
         Assert.True(first.ConsumedQuotaSlot);
         Assert.False(second.ConsumedQuotaSlot);
         Assert.True(third.ConsumedQuotaSlot);
+        Assert.False(existing.ConsumedQuotaSlot);
     }
 
     private sealed class FixedAppBuilderClient : IAppBuilderClient

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -213,7 +213,31 @@ public sealed class AppBuilderStateTests
     [Fact]
     public async Task PublishAsync_consumes_quota_slot_after_success()
     {
-        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Final slot dashboard") with
+        var state = new AppBuilderState(new FixedAppBuilderClient(
+            Snapshot("Final slot dashboard") with
+            {
+                Quota = new AppQuotaState
+                {
+                    Edition = "Pro",
+                    PublishedApps = 3,
+                    AppLimit = 4,
+                },
+            },
+            consumesQuotaSlot: true));
+        await state.LoadAsync();
+
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Published, state.Status);
+        Assert.Equal(4, state.Quota.PublishedApps);
+        Assert.True(state.HasBlockingValidation);
+        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && !check.Passed);
+    }
+
+    [Fact]
+    public async Task PublishAsync_preserves_quota_when_republishing_existing_app()
+    {
+        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Existing dashboard") with
         {
             Quota = new AppQuotaState
             {
@@ -227,9 +251,8 @@ public sealed class AppBuilderStateTests
         await state.PublishAsync();
 
         Assert.Equal(AppBuilderStatus.Published, state.Status);
-        Assert.Equal(4, state.Quota.PublishedApps);
-        Assert.True(state.HasBlockingValidation);
-        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && !check.Passed);
+        Assert.Equal(3, state.Quota.PublishedApps);
+        Assert.False(state.HasBlockingValidation);
     }
 
     [Fact]
@@ -312,13 +335,30 @@ public sealed class AppBuilderStateTests
         Assert.Equal("https://apps.honua.local/embed/ops-2026-launch-1", result.EmbedUrl);
     }
 
+    [Fact]
+    public async Task StubPublishAsync_consumes_quota_only_once_per_draft()
+    {
+        var client = new StubAppBuilderClient();
+        var draft = new AppDraft { DraftId = "draft-existing", Name = "Existing app" };
+
+        var first = await client.PublishAsync(draft, CancellationToken.None);
+        var second = await client.PublishAsync(draft, CancellationToken.None);
+        var third = await client.PublishAsync(draft with { DraftId = "draft-new" }, CancellationToken.None);
+
+        Assert.True(first.ConsumedQuotaSlot);
+        Assert.False(second.ConsumedQuotaSlot);
+        Assert.True(third.ConsumedQuotaSlot);
+    }
+
     private sealed class FixedAppBuilderClient : IAppBuilderClient
     {
         private readonly AppBuilderSnapshot _snapshot;
+        private readonly bool _consumesQuotaSlot;
 
-        public FixedAppBuilderClient(AppBuilderSnapshot snapshot)
+        public FixedAppBuilderClient(AppBuilderSnapshot snapshot, bool consumesQuotaSlot = false)
         {
             _snapshot = snapshot;
+            _consumesQuotaSlot = consumesQuotaSlot;
         }
 
         public Task<AppBuilderSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
@@ -331,6 +371,7 @@ public sealed class AppBuilderStateTests
                 EmbedUrl = "https://apps.honua.local/embed/test",
                 PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
                 Message = "Published",
+                ConsumedQuotaSlot = _consumesQuotaSlot,
             });
     }
 
@@ -414,6 +455,7 @@ public sealed class AppBuilderStateTests
                 EmbedUrl = "https://apps.honua.local/embed/published",
                 PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
                 Message = "Published",
+                ConsumedQuotaSlot = true,
             });
     }
 

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -22,6 +22,9 @@ public sealed class AppBuilderStateTests
         Assert.Equal(AppBuilderStatus.Idle, state.Status);
         Assert.Contains(state.Templates, template => template.TemplateId == "operations-dashboard");
         Assert.Contains(state.WidgetLibrary, widget => widget.Kind == AppWidgetKind.Map);
+        Assert.Contains(state.PublishChannels, channel => channel.Kind == AppPublishChannelKind.StandaloneUrl);
+        Assert.Equal("Pro", state.Quota.Edition);
+        Assert.True(state.Quota.CanPublishMore);
         Assert.Equal("Harbor operations dashboard", state.Draft.Name);
         Assert.NotEmpty(state.Draft.Widgets);
         Assert.False(state.HasBlockingValidation);
@@ -183,6 +186,28 @@ public sealed class AppBuilderStateTests
 
         Assert.Equal(AppBuilderStatus.Idle, state.Status);
         Assert.Null(state.LastError);
+    }
+
+    [Fact]
+    public async Task PublishAsync_blocks_when_app_quota_is_full()
+    {
+        var state = new AppBuilderState(new FixedAppBuilderClient(Snapshot("Quota dashboard") with
+        {
+            Quota = new AppQuotaState
+            {
+                Edition = "Pro",
+                PublishedApps = 5,
+                AppLimit = 5,
+            },
+        }));
+        await state.LoadAsync();
+
+        await state.PublishAsync();
+
+        Assert.Equal(AppBuilderStatus.Error, state.Status);
+        Assert.Equal("Resolve validation checks before publishing.", state.LastError);
+        Assert.Null(state.LastPublish);
+        Assert.Contains(state.PublishReadinessChecks, check => check.Key == "quota" && !check.Passed);
     }
 
     [Fact]

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -330,6 +330,9 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Widget library");
             cut.Markup.MarkupMatchesContaining("Harbor operations dashboard");
             cut.Markup.MarkupMatchesContaining("Open incidents");
+            cut.Markup.MarkupMatchesContaining("Publishing readiness");
+            cut.Markup.MarkupMatchesContaining("Standalone URL");
+            cut.Markup.MarkupMatchesContaining("Custom domain");
             cut.Markup.MarkupMatchesContaining("App builder validation checks");
         });
     }

--- a/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminQualityGateTests.cs
@@ -164,7 +164,7 @@ public sealed class AdminQualityGateTests : TestContext
             "App builder",
             typeof(Honua.Admin.Pages.Operator.AppBuilder),
             "Harbor operations dashboard",
-            new[] { "[aria-label='App builder toolbar']", "[aria-label='Widget library']", "[aria-label='App layout canvas']", "[aria-label='App builder validation checks']" },
+            new[] { "[aria-label='App builder toolbar']", "[aria-label='Widget library']", "[aria-label='App layout canvas']", "[aria-label='App builder publishing readiness']", "[aria-label='App builder validation checks']" },
         ];
         yield return
         [


### PR DESCRIPTION
Related to honua-io/honua-portal#5 (partial admin UI slice).

## Summary
- add app-builder publish channel and quota readiness models for standalone URLs, iframe embeds, and custom domains
- surface publishing readiness in the existing operator app-builder workspace
- add state/render/quality coverage for quota gating and publish readiness selectors

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal" --filter "AppBuilderStateTests|AdminPageRenderTests|AdminQualityGateTests"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- HONUA_ADMIN_CONTAINER_E2E=true HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"