### PR TITLE
ui: add spec workspace draft change summary

### DIFF
--- a/src/Honua.Admin/Components/SpecWorkspace/PreviewPane.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/PreviewPane.razor
@@ -13,6 +13,8 @@
             <MudChip T="string" Color="@StatusColor(State.Status)" Variant="Variant.Outlined" Size="Size.Small" data-testid="preview-status">@State.Status</MudChip>
         </MudStack>
 
+        <SpecChangeSetView Changes="State.DraftChanges" />
+
         @if (_payload is { Kind: SpecOutputKind.Map } mapPayload)
         {
             <MapPreview Features="mapPayload.MapFeatures" />

--- a/src/Honua.Admin/Components/SpecWorkspace/SpecChangeSetView.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/SpecChangeSetView.razor
@@ -1,0 +1,60 @@
+@using Honua.Admin.Models.SpecWorkspace
+
+<div class="spec-change-set" data-testid="spec-change-set">
+    <MudStack Spacing="1">
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+            <MudText Typo="Typo.subtitle2">Draft changes</MudText>
+            <MudSpacer />
+            <MudChip T="string" Size="Size.Small" Color="@SummaryColor" Variant="Variant.Outlined" data-testid="spec-change-count">
+                @($"{ChangedCount} changed")
+            </MudChip>
+        </MudStack>
+        <MudStack Row Wrap="Wrap.Wrap" Spacing="1">
+            @foreach (var change in Changes)
+            {
+                <MudChip T="string"
+                         Size="Size.Small"
+                         Color="@ColorFor(change.Status)"
+                         Variant="@VariantFor(change.Status)"
+                         data-testid="@($"spec-change-{change.Section}")"
+                         data-status="@change.Status">
+                    @($"{change.Section.ToString().ToLowerInvariant()}: {LabelFor(change)}")
+                </MudChip>
+            }
+        </MudStack>
+    </MudStack>
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<SpecSectionChange> Changes { get; set; } = Array.Empty<SpecSectionChange>();
+
+    private int ChangedCount => Changes.Count(change => change.Status is SpecChangeStatus.Added or SpecChangeStatus.Modified or SpecChangeStatus.Removed);
+
+    private Color SummaryColor => ChangedCount == 0 ? Color.Default : Color.Warning;
+
+    private static Color ColorFor(SpecChangeStatus status) => status switch
+    {
+        SpecChangeStatus.Added => Color.Success,
+        SpecChangeStatus.Modified => Color.Warning,
+        SpecChangeStatus.Removed => Color.Error,
+        SpecChangeStatus.Unchanged => Color.Default,
+        SpecChangeStatus.Empty => Color.Default,
+        _ => Color.Default
+    };
+
+    private static Variant VariantFor(SpecChangeStatus status) => status switch
+    {
+        SpecChangeStatus.Empty => Variant.Text,
+        _ => Variant.Outlined
+    };
+
+    private static string LabelFor(SpecSectionChange change) => change.Status switch
+    {
+        SpecChangeStatus.Empty => "empty",
+        SpecChangeStatus.Unchanged => "unchanged",
+        SpecChangeStatus.Added => $"added ({change.CurrentSummary})",
+        SpecChangeStatus.Modified => $"modified ({change.BaselineSummary} -> {change.CurrentSummary})",
+        SpecChangeStatus.Removed => $"removed ({change.BaselineSummary})",
+        _ => change.Status.ToString().ToLowerInvariant()
+    };
+}

--- a/src/Honua.Admin/Models/SpecWorkspace/SpecChangeSet.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/SpecChangeSet.cs
@@ -1,0 +1,18 @@
+namespace Honua.Admin.Models.SpecWorkspace;
+
+public sealed record SpecSectionChange
+{
+    public required SpecSectionId Section { get; init; }
+    public required SpecChangeStatus Status { get; init; }
+    public required string CurrentSummary { get; init; }
+    public required string BaselineSummary { get; init; }
+}
+
+public enum SpecChangeStatus
+{
+    Empty,
+    Added,
+    Modified,
+    Removed,
+    Unchanged
+}

--- a/src/Honua.Admin/Models/SpecWorkspace/WorkspaceSnapshot.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/WorkspaceSnapshot.cs
@@ -5,8 +5,8 @@ namespace Honua.Admin.Models.SpecWorkspace;
 
 /// <summary>
 /// What gets serialized to localStorage for "refresh preserves state". Captures the
-/// current spec draft, conversation, layout widths, and principal so different
-/// operators sharing a browser get isolated drafts.
+/// current spec draft, plan baseline, conversation, layout widths, and principal so
+/// different operators sharing a browser get isolated drafts.
 /// </summary>
 public sealed record WorkspaceSnapshot
 {
@@ -30,6 +30,9 @@ public sealed record WorkspaceSnapshot
 
     [JsonPropertyName("sectionTexts")]
     public Dictionary<string, string> SectionTexts { get; init; } = new(StringComparer.Ordinal);
+
+    [JsonPropertyName("planBaselineTexts")]
+    public Dictionary<string, string> PlanBaselineTexts { get; init; } = new(StringComparer.Ordinal);
 }
 
 public sealed record LayoutWidths(

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecWorkspaceState.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecWorkspaceState.cs
@@ -44,6 +44,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
     private string? _activeJobId;
     private Task? _applyTask;
     private Task? _planTask;
+    private IReadOnlyDictionary<SpecSectionId, string>? _planBaselineTexts;
     private int _specRevision;
     private bool _disposed;
     private bool _rehydrated;
@@ -88,6 +89,10 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
     public SpecSectionId ActiveDslSection { get; private set; } = SpecSectionId.Compute;
 
     public IReadOnlyList<ValidationDiagnostic> Diagnostics => _diagnostics;
+
+    public IReadOnlyList<SpecSectionChange> DraftChanges => BuildDraftChanges();
+
+    public bool HasDraftChanges => DraftChanges.Any(change => change.Status is SpecChangeStatus.Added or SpecChangeStatus.Modified or SpecChangeStatus.Removed);
 
     public event Action? OnChanged;
 
@@ -331,6 +336,12 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
         }
 
         PlanResult = result;
+        if (!result.Failed)
+        {
+            _planBaselineTexts = Enum.GetValues<SpecSectionId>()
+                .ToDictionary(section => section, section => NormalizeDiffText(GetSectionText(section)));
+        }
+
         Status = result.Failed ? WorkspaceStatus.Error : WorkspaceStatus.Idle;
         _applyEvents.Clear();
         _telemetry.RecordLatency("spec_plan_completed", watch.ElapsedMilliseconds, new Dictionary<string, object?>
@@ -621,6 +632,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
             _sectionSummaries.Clear();
             _editorDiagnosticsBySection.Clear();
             PlanResult = null;
+            _planBaselineTexts = null;
             Status = WorkspaceStatus.Idle;
             PromptDraft = string.Empty;
             IsJsonView = false;
@@ -890,6 +902,76 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
         PlanResult = null;
         _applyEvents.Clear();
     }
+
+    private IReadOnlyList<SpecSectionChange> BuildDraftChanges()
+    {
+        return Enum.GetValues<SpecSectionId>()
+            .Select(section =>
+            {
+                var current = NormalizeDiffText(GetSectionText(section));
+                var planned = _planBaselineTexts is not null && _planBaselineTexts.TryGetValue(section, out var text)
+                    ? text
+                    : string.Empty;
+                return new SpecSectionChange
+                {
+                    Section = section,
+                    Status = ResolveChangeStatus(planned, current),
+                    CurrentSummary = DescribeSection(section, current),
+                    BaselineSummary = DescribeSection(section, planned)
+                };
+            })
+            .ToArray();
+    }
+
+    private static SpecChangeStatus ResolveChangeStatus(string baseline, string current)
+    {
+        if (baseline.Length == 0 && current.Length == 0)
+        {
+            return SpecChangeStatus.Empty;
+        }
+
+        if (baseline.Length == 0)
+        {
+            return SpecChangeStatus.Added;
+        }
+
+        if (current.Length == 0)
+        {
+            return SpecChangeStatus.Removed;
+        }
+
+        return string.Equals(baseline, current, StringComparison.Ordinal)
+            ? SpecChangeStatus.Unchanged
+            : SpecChangeStatus.Modified;
+    }
+
+    private static string DescribeSection(SpecSectionId section, string text)
+    {
+        if (text.Length == 0)
+        {
+            return "empty";
+        }
+
+        var lineCount = text.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+        var noun = section switch
+        {
+            SpecSectionId.Sources => "source",
+            SpecSectionId.Scope => "scope field",
+            SpecSectionId.Compute => "compute step",
+            SpecSectionId.Map => "map layer",
+            SpecSectionId.Output => "output field",
+            _ => "line"
+        };
+
+        return $"{lineCount} {noun}{(lineCount == 1 ? string.Empty : "s")}";
+    }
+
+    private static string NormalizeDiffText(string? text)
+        => string.Join(
+            "\n",
+            (text ?? string.Empty)
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
 
     private static string StorageKeyFor(string principalId) => $"{StorageKeyPrefix}draft:{principalId}";
 

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecWorkspaceState.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecWorkspaceState.cs
@@ -349,6 +349,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
             ["node_count"] = result.Nodes.Count,
             ["failed"] = result.Failed
         });
+        await PersistAsync(cancellationToken).ConfigureAwait(false);
         Notify();
     }
 
@@ -736,6 +737,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
 
         if (string.IsNullOrWhiteSpace(payload))
         {
+            _planBaselineTexts = null;
             SyncSectionTextsFromSpec();
             return;
         }
@@ -745,6 +747,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
             var snapshot = JsonSerializer.Deserialize(payload, SpecWorkspaceJsonContext.Default.WorkspaceSnapshot);
             if (snapshot is null)
             {
+                _planBaselineTexts = null;
                 SyncSectionTextsFromSpec();
                 return;
             }
@@ -773,6 +776,8 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
                 SyncSectionTextsFromSpec();
             }
 
+            _planBaselineTexts = RestoreSectionTextMap(snapshot.PlanBaselineTexts);
+
             _telemetry.Record("spec_draft_rehydrated", new Dictionary<string, object?>
             {
                 ["conversation_turns"] = _conversation.Count
@@ -781,6 +786,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
         catch (JsonException)
         {
             await _storage.RemoveAsync(StorageKeyFor(PrincipalId), cancellationToken).ConfigureAwait(false);
+            _planBaselineTexts = null;
             SyncSectionTextsFromSpec();
         }
     }
@@ -795,7 +801,8 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
             Layout = Layout,
             PromptDraft = PromptDraft,
             IsJsonView = IsJsonView,
-            SectionTexts = _sectionTexts.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value, StringComparer.Ordinal)
+            SectionTexts = _sectionTexts.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value, StringComparer.Ordinal),
+            PlanBaselineTexts = _planBaselineTexts?.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value, StringComparer.Ordinal) ?? new Dictionary<string, string>(StringComparer.Ordinal)
         };
 
         var json = JsonSerializer.Serialize(snapshot, SpecWorkspaceJsonContext.Default.WorkspaceSnapshot);
@@ -972,6 +979,25 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
             (text ?? string.Empty)
                 .Replace("\r\n", "\n", StringComparison.Ordinal)
                 .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
+
+    private static IReadOnlyDictionary<SpecSectionId, string>? RestoreSectionTextMap(IReadOnlyDictionary<string, string> sectionTexts)
+    {
+        if (sectionTexts.Count == 0)
+        {
+            return null;
+        }
+
+        var restored = new Dictionary<SpecSectionId, string>();
+        foreach (var (key, value) in sectionTexts)
+        {
+            if (Enum.TryParse<SpecSectionId>(key, true, out var section))
+            {
+                restored[section] = NormalizeDiffText(value);
+            }
+        }
+
+        return restored.Count == 0 ? null : restored;
+    }
 
     private static string StorageKeyFor(string principalId) => $"{StorageKeyPrefix}draft:{principalId}";
 

--- a/src/Honua.Admin/wwwroot/css/spec-workspace.css
+++ b/src/Honua.Admin/wwwroot/css/spec-workspace.css
@@ -64,6 +64,12 @@
     border-left: 3px solid #66bb6a;
 }
 
+.spec-change-set {
+    border-top: 1px solid var(--mud-palette-divider, #e0e0e0);
+    border-bottom: 1px solid var(--mud-palette-divider, #e0e0e0);
+    padding: 8px 0;
+}
+
 .spec-nl-history {
     max-height: 100%;
 }

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -284,6 +284,9 @@ public sealed class AdminPageRenderTests : TestContext
         cut.WaitForAssertion(() =>
         {
             cut.Markup.MarkupMatchesContaining("1/5 drafted");
+            cut.Markup.MarkupMatchesContaining("Draft changes");
+            var sourceChange = cut.Find("[data-testid='spec-change-Sources']");
+            Assert.Equal("Added", sourceChange.GetAttribute("data-status"));
         });
     }
 

--- a/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
@@ -502,6 +502,39 @@ public sealed class SpecWorkspaceStateTests
         Assert.Contains("@parcels = parcels", second.GetSectionText(SpecSectionId.Sources), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task InitializeAsync_rehydrates_plan_baseline_for_draft_changes()
+    {
+        var storage = new MemoryBrowserStorageService();
+        var first = new SpecWorkspaceState(
+            new StubSpecWorkspaceClient(),
+            storage,
+            new NullSpecWorkspaceTelemetry(),
+            new CatalogCache());
+
+        await first.InitializeAsync("operator");
+        await first.UpdateSectionTextAsync(SpecSectionId.Sources, "@parcels = parcels");
+        await first.RunPlanAsync();
+
+        Assert.False(first.HasDraftChanges);
+
+        var second = new SpecWorkspaceState(
+            new StubSpecWorkspaceClient(),
+            storage,
+            new NullSpecWorkspaceTelemetry(),
+            new CatalogCache());
+
+        await second.InitializeAsync("operator");
+
+        Assert.Equal(SpecChangeStatus.Unchanged, ChangeFor(second, SpecSectionId.Sources).Status);
+        Assert.False(second.HasDraftChanges);
+
+        await second.UpdateSectionTextAsync(SpecSectionId.Compute, "aggregate inputs=@parcels by=@parcels.county metric=count");
+
+        Assert.Equal(SpecChangeStatus.Added, ChangeFor(second, SpecSectionId.Compute).Status);
+        Assert.True(second.HasDraftChanges);
+    }
+
     private static SpecSectionChange ChangeFor(SpecWorkspaceState state, SpecSectionId section) =>
         state.DraftChanges.Single(change => change.Section == section);
 

--- a/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
@@ -396,6 +396,35 @@ public sealed class SpecWorkspaceStateTests
     }
 
     [Fact]
+    public async Task DraftChanges_track_edits_against_the_last_successful_plan()
+    {
+        var storage = new MemoryBrowserStorageService();
+        var state = new SpecWorkspaceState(
+            new StubSpecWorkspaceClient(),
+            storage,
+            new NullSpecWorkspaceTelemetry(),
+            new CatalogCache());
+
+        await state.InitializeAsync("operator");
+        await state.UpdateSectionTextAsync(SpecSectionId.Sources, "@parcels = parcels");
+
+        Assert.Equal(SpecChangeStatus.Added, ChangeFor(state, SpecSectionId.Sources).Status);
+        Assert.True(state.HasDraftChanges);
+
+        await state.RunPlanAsync();
+
+        Assert.Equal(SpecChangeStatus.Unchanged, ChangeFor(state, SpecSectionId.Sources).Status);
+        Assert.False(state.HasDraftChanges);
+
+        await state.UpdateSectionTextAsync(SpecSectionId.Compute, "aggregate inputs=@parcels by=@parcels.county metric=count");
+        await state.UpdateSectionTextAsync(SpecSectionId.Sources, string.Empty);
+
+        Assert.Equal(SpecChangeStatus.Added, ChangeFor(state, SpecSectionId.Compute).Status);
+        Assert.Equal(SpecChangeStatus.Removed, ChangeFor(state, SpecSectionId.Sources).Status);
+        Assert.True(state.HasDraftChanges);
+    }
+
+    [Fact]
     public async Task RunApplyAsync_replans_after_spec_edit_invalidates_prior_plan()
     {
         var storage = new MemoryBrowserStorageService();
@@ -472,6 +501,9 @@ public sealed class SpecWorkspaceStateTests
         Assert.Single(second.Conversation);
         Assert.Contains("@parcels = parcels", second.GetSectionText(SpecSectionId.Sources), StringComparison.Ordinal);
     }
+
+    private static SpecSectionChange ChangeFor(SpecWorkspaceState state, SpecSectionId section) =>
+        state.DraftChanges.Single(change => change.Section == section);
 
     private sealed class BlockingApplyClient : ISpecWorkspaceClient
     {


### PR DESCRIPTION
## Summary
- add a spec workspace draft change model that compares current section text to the last successful plan baseline
- render a compact Draft changes summary in the preview pane
- cover state transitions and rendered section change status in tests

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal" --filter "SpecWorkspaceStateTests|StubSpecWorkspaceClientTests|AdminPageRenderTests|AdminQualityGateTests"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check

Related to #25 (partial admin UI slice).