### PR TITLE
ui: add open data API access examples

### DIFF
--- a/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
+++ b/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
@@ -30,6 +30,13 @@ public enum OpenDataDownloadFormat
     Kml
 }
 
+public enum OpenDataCodeLanguage
+{
+    Curl,
+    JavaScript,
+    Python
+}
+
 public sealed record OpenDataHubSnapshot
 {
     public IReadOnlyList<OpenDataDataset> Datasets { get; init; } = Array.Empty<OpenDataDataset>();
@@ -54,10 +61,29 @@ public sealed record OpenDataDataset
     public bool EmbedEnabled { get; init; }
     public string StacCollectionId { get; init; } = string.Empty;
     public string SampleResponse { get; init; } = string.Empty;
+    public OpenDataApiAccess ApiAccess { get; init; } = new();
     public IReadOnlyList<string> Keywords { get; init; } = Array.Empty<string>();
     public IReadOnlyList<OpenDataDownloadOption> Downloads { get; init; } = Array.Empty<OpenDataDownloadOption>();
     public IReadOnlyList<OpenDataApiEndpoint> ApiEndpoints { get; init; } = Array.Empty<OpenDataApiEndpoint>();
     public OpenDataEmbedConfig EmbedConfig { get; init; } = new();
+}
+
+public sealed record OpenDataApiAccess
+{
+    public bool PublicKeyEnabled { get; init; }
+    public string PublicKeyLabel { get; init; } = string.Empty;
+    public DateTimeOffset? LastRotated { get; init; }
+    public int AnonymousRateLimitPerMinute { get; init; }
+    public int RegisteredRateLimitPerMinute { get; init; }
+    public bool BulkDownloadEnabled { get; init; }
+    public IReadOnlyList<OpenDataCodeExample> CodeExamples { get; init; } = Array.Empty<OpenDataCodeExample>();
+}
+
+public sealed record OpenDataCodeExample
+{
+    public OpenDataCodeLanguage Language { get; init; }
+    public string Label { get; init; } = string.Empty;
+    public string Snippet { get; init; } = string.Empty;
 }
 
 public sealed record OpenDataDownloadOption

--- a/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
+++ b/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
@@ -202,6 +202,29 @@
 
                 <div class="open-data-delivery-group" aria-label="Open data API endpoints">
                     <MudText Typo="Typo.subtitle2">Civic tech API</MudText>
+                    <div class="open-data-api-access" aria-label="Open data API access" data-testid="open-data-api-access">
+                        <div>
+                            <strong>Public API key</strong>
+                            <span>@selected.ApiAccess.PublicKeyLabel</span>
+                            <small>@($"Last rotated {FormatApiDate(selected.ApiAccess.LastRotated)}")</small>
+                        </div>
+                        <MudChip T="string"
+                                 Size="Size.Small"
+                                 Color="@(selected.ApiAccess.PublicKeyEnabled ? Color.Success : Color.Warning)"
+                                 Variant="Variant.Outlined">
+                            @(selected.ApiAccess.PublicKeyEnabled ? "Enabled" : "Disabled")
+                        </MudChip>
+                        <div>
+                            <strong>@($"{selected.ApiAccess.AnonymousRateLimitPerMinute}/min anonymous")</strong>
+                            <span>@($"{selected.ApiAccess.RegisteredRateLimitPerMinute}/min registered civic apps")</span>
+                        </div>
+                        <MudChip T="string"
+                                 Size="Size.Small"
+                                 Color="@(selected.ApiAccess.BulkDownloadEnabled ? Color.Success : Color.Warning)"
+                                 Variant="Variant.Outlined">
+                            Bulk downloads
+                        </MudChip>
+                    </div>
                     @foreach (var endpoint in selected.ApiEndpoints)
                     {
                         <article class="open-data-api-row" data-testid="@($"open-data-api-{endpoint.Name}")">
@@ -214,6 +237,23 @@
                             </MudChip>
                             <pre class="open-data-code"><code>@endpoint.Example</code></pre>
                         </article>
+                    }
+                    @if (selected.ApiAccess.CodeExamples.Count > 0)
+                    {
+                        <div class="open-data-code-examples" aria-label="Open data code examples">
+                            <MudText Typo="Typo.subtitle2">Code examples</MudText>
+                            @foreach (var example in selected.ApiAccess.CodeExamples)
+                            {
+                                <article class="open-data-code-example" data-testid="@($"open-data-code-example-{example.Language}")">
+                                    <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                                        <strong>@example.Label</strong>
+                                        <MudSpacer />
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@example.Language</MudChip>
+                                    </MudStack>
+                                    <pre class="open-data-code"><code>@example.Snippet</code></pre>
+                                </article>
+                            }
+                        </div>
                     }
                 </div>
 
@@ -313,6 +353,9 @@
 
         return $"{bytes / 1_000d:0.0} KB";
     }
+
+    private static string FormatApiDate(DateTimeOffset? value)
+        => value?.ToLocalTime().ToString("MMM d, yyyy", CultureInfo.CurrentCulture) ?? "not recorded";
 
     private static Color StatusColor(OpenDataHubStatus status) => status switch
     {

--- a/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
@@ -85,7 +85,10 @@ public sealed class OpenDataHubState
             var hasApis = dataset.ApiEnabled &&
                 dataset.ApiEndpoints.Any(endpoint => !endpoint.RequiresApiKey) &&
                 HasText(dataset.StacCollectionId) &&
-                HasText(dataset.SampleResponse);
+                HasText(dataset.SampleResponse) &&
+                dataset.ApiAccess.PublicKeyEnabled &&
+                dataset.ApiAccess.BulkDownloadEnabled &&
+                RequiredCodeExamples.All(language => dataset.ApiAccess.CodeExamples.Any(example => example.Language == language && HasText(example.Snippet)));
             var hasEmbed = !dataset.EmbedEnabled ||
                 dataset.EmbedConfig.Responsive &&
                 dataset.EmbedConfig.WcagReady &&
@@ -114,7 +117,7 @@ public sealed class OpenDataHubState
                     Key = "api",
                     Label = "Civic tech API",
                     Passed = hasApis,
-                    Message = hasApis ? $"{dataset.ApiEndpoints.Count} endpoint(s), including no-auth public access." : "Enable public API endpoints, STAC metadata, and a sample response."
+                    Message = hasApis ? $"{dataset.ApiEndpoints.Count} endpoint(s), public key access, and code examples are ready." : "Enable public API endpoints, STAC metadata, public key access, code examples, and a sample response."
                 },
                 new OpenDataValidationCheck
                 {
@@ -303,6 +306,13 @@ public sealed class OpenDataHubState
         OpenDataDownloadFormat.Shapefile,
         OpenDataDownloadFormat.Csv,
         OpenDataDownloadFormat.Kml
+    ];
+
+    private static readonly OpenDataCodeLanguage[] RequiredCodeExamples =
+    [
+        OpenDataCodeLanguage.Curl,
+        OpenDataCodeLanguage.JavaScript,
+        OpenDataCodeLanguage.Python
     ];
 
     private bool MatchesSearch(OpenDataDataset dataset)

--- a/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
@@ -117,7 +117,7 @@ public sealed class OpenDataHubState
                     Key = "api",
                     Label = "Civic tech API",
                     Passed = hasApis,
-                    Message = hasApis ? $"{dataset.ApiEndpoints.Count} endpoint(s), public key access, and code examples are ready." : "Enable public API endpoints, STAC metadata, public key access, code examples, and a sample response."
+                    Message = hasApis ? $"{dataset.ApiEndpoints.Count} endpoint(s), public key access, bulk downloads, and code examples are ready." : "Enable public API endpoints, STAC metadata, public key access, bulk downloads, code examples, and a sample response."
                 },
                 new OpenDataValidationCheck
                 {

--- a/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
@@ -144,6 +144,7 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
         DateTimeOffset? scheduledPublishAt = null)
     {
         var basePath = $"/open-data/{Slug(datasetId)}";
+        var slug = Slug(datasetId);
         return new OpenDataDataset
         {
             DatasetId = datasetId,
@@ -162,6 +163,16 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
             EmbedEnabled = embedEnabled,
             StacCollectionId = stacCollectionId,
             SampleResponse = sampleResponse,
+            ApiAccess = new OpenDataApiAccess
+            {
+                PublicKeyEnabled = apiEnabled,
+                PublicKeyLabel = $"{slug}-public",
+                LastRotated = DateTimeOffset.Parse("2026-04-21T12:00:00Z"),
+                AnonymousRateLimitPerMinute = 120,
+                RegisteredRateLimitPerMinute = 600,
+                BulkDownloadEnabled = apiEnabled,
+                CodeExamples = apiEnabled ? CodeExamples(slug, stacCollectionId) : []
+            },
             Keywords = keywords,
             Downloads =
             [
@@ -176,8 +187,8 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
                 new OpenDataApiEndpoint
                 {
                     Name = "Features",
-                    Path = $"/api/open-data/{Slug(datasetId)}/features",
-                    Example = $"curl https://data.honua.local/api/open-data/{Slug(datasetId)}/features?limit=100",
+                    Path = $"/api/open-data/{slug}/features",
+                    Example = $"curl https://data.honua.local/api/open-data/{slug}/features?limit=100",
                     RequiresApiKey = false,
                     RateLimitPerMinute = 120
                 },
@@ -192,15 +203,15 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
                 new OpenDataApiEndpoint
                 {
                     Name = "Bulk export",
-                    Path = $"/api/open-data/{Slug(datasetId)}/exports/latest",
-                    Example = $"python -m honua_download https://data.honua.local/api/open-data/{Slug(datasetId)}/exports/latest",
+                    Path = $"/api/open-data/{slug}/exports/latest",
+                    Example = $"python -m honua_download https://data.honua.local/api/open-data/{slug}/exports/latest",
                     RequiresApiKey = true,
                     RateLimitPerMinute = 30
                 }
             ],
             EmbedConfig = new OpenDataEmbedConfig
             {
-                EmbedUrl = $"https://data.honua.local/embed/{Slug(datasetId)}",
+                EmbedUrl = $"https://data.honua.local/embed/{slug}",
                 Basemap = basemap,
                 InitialExtent = extent,
                 BrandingMode = "White label",
@@ -209,6 +220,28 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
             }
         };
     }
+
+    private static IReadOnlyList<OpenDataCodeExample> CodeExamples(string slug, string stacCollectionId) =>
+    [
+        new OpenDataCodeExample
+        {
+            Language = OpenDataCodeLanguage.Curl,
+            Label = "cURL",
+            Snippet = $"curl 'https://data.honua.local/api/open-data/{slug}/features?limit=100'"
+        },
+        new OpenDataCodeExample
+        {
+            Language = OpenDataCodeLanguage.JavaScript,
+            Label = "JavaScript",
+            Snippet = $"const response = await fetch('https://data.honua.local/api/stac/{stacCollectionId}');\nconst collection = await response.json();"
+        },
+        new OpenDataCodeExample
+        {
+            Language = OpenDataCodeLanguage.Python,
+            Label = "Python",
+            Snippet = $"import requests\nurl = 'https://data.honua.local/api/open-data/{slug}/exports/latest'\nfeatures = requests.get(url, timeout=30).json()"
+        }
+    ];
 
     private static OpenDataDownloadOption Download(OpenDataDownloadFormat format, string url, long sizeBytes)
         => new()

--- a/src/Honua.Admin/wwwroot/css/open-data-hub.css
+++ b/src/Honua.Admin/wwwroot/css/open-data-hub.css
@@ -154,6 +154,8 @@
 .open-data-delivery-row span,
 .open-data-api-row strong,
 .open-data-api-row span,
+.open-data-api-access strong,
+.open-data-api-access span,
 .open-data-validation-row strong,
 .open-data-validation-row span,
 .open-data-embed-preview strong,
@@ -188,6 +190,8 @@
 .open-data-delivery-row,
 .open-data-validation-row,
 .open-data-api-row,
+.open-data-api-access,
+.open-data-code-example,
 .open-data-embed-preview {
     border: 1px solid var(--mud-palette-divider, #d7dbe0);
     border-radius: 6px;
@@ -205,6 +209,7 @@
 .open-data-delivery-row div,
 .open-data-validation-row div,
 .open-data-api-row div,
+.open-data-api-access div,
 .open-data-embed-preview div {
     display: flex;
     min-width: 0;
@@ -224,7 +229,29 @@
     gap: 8px;
 }
 
-.open-data-api-row .open-data-code {
+.open-data-api-access {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    background: #f8fbff;
+}
+
+.open-data-api-access small {
+    color: var(--mud-palette-text-secondary, #607d8b);
+}
+
+.open-data-code-examples {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.open-data-code-example {
+    min-width: 0;
+}
+
+.open-data-api-row .open-data-code,
+.open-data-code-example .open-data-code {
     grid-column: 1 / -1;
 }
 
@@ -255,7 +282,8 @@
 
     .open-data-metrics,
     .open-data-metadata-grid,
-    .open-data-api-row {
+    .open-data-api-row,
+    .open-data-api-access {
         grid-template-columns: 1fr;
     }
 

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -24,6 +24,8 @@ public sealed class OpenDataHubStateTests
         Assert.Contains(state.Metrics, metric => metric.Label == "Published datasets");
         Assert.Contains(state.Datasets, dataset => dataset.DatasetId == "harbor-assets");
         Assert.Equal("harbor-assets", state.SelectedDataset?.DatasetId);
+        Assert.Equal("harbor-assets-public", state.SelectedDataset?.ApiAccess.PublicKeyLabel);
+        Assert.Contains(state.SelectedDataset!.ApiAccess.CodeExamples, example => example.Language == OpenDataCodeLanguage.JavaScript);
         Assert.False(state.HasBlockingValidation);
     }
 
@@ -94,6 +96,28 @@ public sealed class OpenDataHubStateTests
         Assert.Equal(OpenDataHubStatus.Error, state.Status);
         Assert.Equal("Resolve validation checks before publishing.", state.LastError);
         Assert.Null(state.LastPublish);
+        Assert.True(state.HasBlockingValidation);
+    }
+
+    [Fact]
+    public async Task ValidationChecks_require_public_api_access_and_code_examples()
+    {
+        var snapshot = Snapshot("api-dataset", "API dataset");
+        var dataset = snapshot.Datasets[0] with
+        {
+            ApiAccess = snapshot.Datasets[0].ApiAccess with
+            {
+                PublicKeyEnabled = false,
+                CodeExamples = [],
+            },
+        };
+        var state = new OpenDataHubState(new FixedOpenDataHubClient(snapshot with { Datasets = [dataset] }));
+
+        await state.LoadAsync();
+
+        var api = Assert.Single(state.ValidationChecks, check => check.Key == "api");
+        Assert.False(api.Passed);
+        Assert.Contains("public key access", api.Message);
         Assert.True(state.HasBlockingValidation);
     }
 
@@ -219,6 +243,29 @@ public sealed class OpenDataHubStateTests
             => _loads[index].SetResult(snapshot);
     }
 
+    private sealed class FixedOpenDataHubClient : IOpenDataHubClient
+    {
+        private readonly OpenDataHubSnapshot _snapshot;
+
+        public FixedOpenDataHubClient(OpenDataHubSnapshot snapshot)
+        {
+            _snapshot = snapshot;
+        }
+
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => Task.FromResult(_snapshot);
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+            => Task.FromResult(new OpenDataPublishResult
+            {
+                DatasetId = datasetId,
+                CatalogUrl = "https://data.honua.local/datasets/test",
+                ApiDocsUrl = "https://data.honua.local/api/docs/test",
+                PublishedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+                Message = "Published",
+            });
+    }
+
     private sealed class FailingRetryOpenDataHubClient : IOpenDataHubClient
     {
         private readonly StubOpenDataHubClient _inner = new();
@@ -327,6 +374,21 @@ public sealed class OpenDataHubStateTests
                     EmbedEnabled = true,
                     StacCollectionId = $"collections/{datasetId}",
                     SampleResponse = "{}",
+                    ApiAccess = new OpenDataApiAccess
+                    {
+                        PublicKeyEnabled = true,
+                        PublicKeyLabel = $"{datasetId}-public",
+                        LastRotated = DateTimeOffset.Parse("2026-04-21T12:00:00Z"),
+                        AnonymousRateLimitPerMinute = 120,
+                        RegisteredRateLimitPerMinute = 600,
+                        BulkDownloadEnabled = true,
+                        CodeExamples =
+                        [
+                            CodeExample(OpenDataCodeLanguage.Curl),
+                            CodeExample(OpenDataCodeLanguage.JavaScript),
+                            CodeExample(OpenDataCodeLanguage.Python),
+                        ],
+                    },
                     Keywords = ["public"],
                     Downloads =
                     [
@@ -366,5 +428,13 @@ public sealed class OpenDataHubStateTests
             Url = $"/downloads/{format}",
             SizeBytes = 100,
             GeneratedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+        };
+
+    private static OpenDataCodeExample CodeExample(OpenDataCodeLanguage language)
+        => new()
+        {
+            Language = language,
+            Label = language.ToString(),
+            Snippet = $"{language} example",
         };
 }

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -118,6 +118,7 @@ public sealed class OpenDataHubStateTests
         var api = Assert.Single(state.ValidationChecks, check => check.Key == "api");
         Assert.False(api.Passed);
         Assert.Contains("public key access", api.Message);
+        Assert.Contains("bulk downloads", api.Message);
         Assert.True(state.HasBlockingValidation);
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -352,6 +352,11 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Harbor assets");
             cut.Markup.MarkupMatchesContaining("GeoJSON");
             cut.Markup.MarkupMatchesContaining("Civic tech API");
+            cut.Markup.MarkupMatchesContaining("Public API key");
+            cut.Markup.MarkupMatchesContaining("Code examples");
+            cut.Markup.MarkupMatchesContaining("JavaScript");
+            cut.Find("[data-testid='open-data-api-access']");
+            cut.Find("[data-testid='open-data-code-example-Python']");
             cut.Markup.MarkupMatchesContaining("Readiness checks");
         });
     }


### PR DESCRIPTION
## Summary
- add open data API access metadata for public keys, rate limits, bulk export readiness, and code examples
- render public API access and cURL/JavaScript/Python examples in the open data hub delivery pane
- require public API access and code examples in civic-tech API readiness validation

## Validation
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal" --filter "OpenDataHubStateTests|AdminPageRenderTests|AdminQualityGateTests"
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check

Related to honua-io/honua-portal#6 (partial admin UI slice).