### PR TITLE
ui: expose spec cache materialization metadata

### DIFF
--- a/src/Honua.Admin/Components/SpecWorkspace/ApplyStreamView.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/ApplyStreamView.razor
@@ -21,9 +21,21 @@
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@entry.Latest.Status</MudText>
                     </MudStack>
                     <MudSpacer />
+                    @if (!string.IsNullOrWhiteSpace(entry.Latest.CacheKey))
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined" data-testid="apply-cache-key">
+                            @entry.Latest.CacheKey
+                        </MudChip>
+                    }
                     @if (entry.Latest.Status == ApplyNodeStatus.CacheHit)
                     {
                         <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Outlined" data-testid="apply-cache-chip">cache hit</MudChip>
+                    }
+                    @if (entry.Latest.MaterializedResource is not null)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined" data-testid="apply-materialized-resource">
+                            @MaterializationLabel(entry.Latest.MaterializedResource)
+                        </MudChip>
                     }
                 </MudStack>
             </MudPaper>
@@ -86,5 +98,16 @@
         ApplyNodeStatus.Cancelled => Color.Warning,
         ApplyNodeStatus.Failed => Color.Error,
         _ => Color.Default
+    };
+
+    private static string MaterializationLabel(MaterializedResource resource) =>
+        $"{ResourceKindLabel(resource.Kind)} {resource.Version}";
+
+    private static string ResourceKindLabel(PlanMaterializationKind kind) => kind switch
+    {
+        PlanMaterializationKind.DurableDataset => "durable dataset",
+        PlanMaterializationKind.DurableService => "durable service",
+        PlanMaterializationKind.DurableApp => "durable app",
+        _ => "resource"
     };
 }

--- a/src/Honua.Admin/Components/SpecWorkspace/PlanDagView.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/PlanDagView.razor
@@ -46,6 +46,12 @@
                                         <MudText Typo="Typo.caption" Color="Color.Secondary">
                                             rows≈@node.EstimatedRows  |  bytes≈@node.EstimatedBytes  |  dur≈@node.EstimatedMillis ms
                                         </MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary" data-testid="@($"dag-node-cache-{node.Id}")">
+                                            cache: @CacheLabel(node.CachePolicy)@(node.ContentHash is null ? string.Empty : $" ({node.ContentHash})")
+                                        </MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary" data-testid="@($"dag-node-materialization-{node.Id}")">
+                                            state: @MaterializationLabel(node.Materialization)
+                                        </MudText>
                                         @if (node.Inputs.Count > 0)
                                         {
                                             <MudText Typo="Typo.caption" Color="Color.Tertiary">inputs: @string.Join(", ", node.Inputs)</MudText>
@@ -76,6 +82,23 @@
         "buffer" => Icons.Material.Filled.BlurCircular,
         "join" => Icons.Material.Filled.Merge,
         "map" => Icons.Material.Filled.Map,
+        "output" => Icons.Material.Filled.Publish,
         _ => Icons.Material.Filled.Code
+    };
+
+    private static string CacheLabel(PlanCachePolicy policy) => policy switch
+    {
+        PlanCachePolicy.MetadataOnly => "metadata only",
+        PlanCachePolicy.ContentHash => "content-hash",
+        _ => "none"
+    };
+
+    private static string MaterializationLabel(PlanMaterializationKind kind) => kind switch
+    {
+        PlanMaterializationKind.PreviewOnly => "preview only",
+        PlanMaterializationKind.DurableDataset => "durable dataset",
+        PlanMaterializationKind.DurableService => "durable service",
+        PlanMaterializationKind.DurableApp => "durable app",
+        _ => "ephemeral"
     };
 }

--- a/src/Honua.Admin/Models/SpecWorkspace/ApplyEvent.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/ApplyEvent.cs
@@ -41,6 +41,12 @@ public sealed record ApplyEvent
 
     [JsonPropertyName("payload")]
     public ApplyPayload? Payload { get; init; }
+
+    [JsonPropertyName("cacheKey")]
+    public string? CacheKey { get; init; }
+
+    [JsonPropertyName("materializedResource")]
+    public MaterializedResource? MaterializedResource { get; init; }
 }
 
 public enum ApplyEventKind
@@ -87,3 +93,8 @@ public sealed record AppScaffoldParameter(
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("kind")] string Kind,
     [property: JsonPropertyName("default")] string? Default);
+
+public sealed record MaterializedResource(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("kind")] PlanMaterializationKind Kind,
+    [property: JsonPropertyName("version")] string Version);

--- a/src/Honua.Admin/Models/SpecWorkspace/PlanResult.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/PlanResult.cs
@@ -50,6 +50,15 @@ public sealed record PlanNode
 
     [JsonPropertyName("warnings")]
     public IReadOnlyList<string> Warnings { get; init; } = System.Array.Empty<string>();
+
+    [JsonPropertyName("contentHash")]
+    public string? ContentHash { get; init; }
+
+    [JsonPropertyName("cachePolicy")]
+    public PlanCachePolicy CachePolicy { get; init; } = PlanCachePolicy.None;
+
+    [JsonPropertyName("materialization")]
+    public PlanMaterializationKind Materialization { get; init; } = PlanMaterializationKind.Ephemeral;
 }
 
 public sealed record PlanWarning(
@@ -61,4 +70,20 @@ public enum PlanWarningSeverity
 {
     Yellow,
     Red
+}
+
+public enum PlanCachePolicy
+{
+    None,
+    MetadataOnly,
+    ContentHash
+}
+
+public enum PlanMaterializationKind
+{
+    Ephemeral,
+    PreviewOnly,
+    DurableDataset,
+    DurableService,
+    DurableApp
 }

--- a/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
@@ -330,7 +330,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 EstimatedBytes = dataset.EstimatedRows * 128,
                 EstimatedMillis = 50,
                 Warnings = nodeWarnings,
-                ContentHash = BuildContentHash("source", source.Dataset, source.Pin ?? "mutable"),
+                ContentHash = BuildContentHash("source", dataset.Id, source.Pin ?? "mutable"),
                 CachePolicy = PlanCachePolicy.MetadataOnly,
                 Materialization = PlanMaterializationKind.Ephemeral
             });
@@ -396,7 +396,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             {
                 Id = outputId,
                 Op = "output",
-                Inputs = ResolveOutputInputs(document),
+                Inputs = ResolveOutputInputs(document, document.Output.Kind),
                 Depth = depth + 1,
                 EstimatedRows = 0,
                 EstimatedBytes = 0,
@@ -958,13 +958,20 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             .ToArray();
     }
 
-    private static IReadOnlyList<string> ResolveOutputInputs(SpecDocument document)
+    private static IReadOnlyList<string> ResolveOutputInputs(SpecDocument document, SpecOutputKind outputKind)
     {
-        if (document.Map.Layers.Count > 0)
+        return outputKind switch
         {
-            return document.Map.Layers.Select(layer => $"map-{layer.Source}").ToArray();
-        }
+            SpecOutputKind.Map when document.Map.Layers.Count > 0 => document.Map.Layers
+                .Select(layer => $"map-{layer.Source}")
+                .ToArray(),
+            SpecOutputKind.AppScaffold => ResolveAppScaffoldInputs(document),
+            _ => ResolveAnalysisInputs(document)
+        };
+    }
 
+    private static IReadOnlyList<string> ResolveAnalysisInputs(SpecDocument document)
+    {
         if (document.Compute.Count > 0)
         {
             var last = document.Compute[^1];
@@ -972,6 +979,24 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         }
 
         return document.Sources.Select(source => source.Id).ToArray();
+    }
+
+    private static IReadOnlyList<string> ResolveAppScaffoldInputs(SpecDocument document)
+    {
+        var inputs = new List<string>();
+        if (document.Compute.Count > 0)
+        {
+            var last = document.Compute[^1];
+            inputs.Add($"{last.Op}-{document.Compute.Count}");
+        }
+
+        inputs.AddRange(document.Map.Layers.Select(layer => $"map-{layer.Source}"));
+        if (inputs.Count == 0)
+        {
+            inputs.AddRange(document.Sources.Select(source => source.Id));
+        }
+
+        return inputs;
     }
 
     private static PlanMaterializationKind MaterializationForOutput(SpecOutputKind kind) => kind switch
@@ -1001,6 +1026,18 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
     private ApplyPayload BuildPayload(SpecDocument document)
     {
+        if (document.Output.Kind == SpecOutputKind.AppScaffold)
+        {
+            return new ApplyPayload
+            {
+                Kind = SpecOutputKind.AppScaffold,
+                AppScaffold = new AppScaffold(
+                    "Preview App",
+                    new[] { new AppScaffoldParameter("date", "date", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)) },
+                    "single-column")
+            };
+        }
+
         if (document.Map.Layers.Count > 0)
         {
             var features = new List<MapFeature>();
@@ -1072,18 +1109,6 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 Kind = SpecOutputKind.Analysis,
                 TableColumns = new[] { "id", "status" },
                 TableRows = rows
-            };
-        }
-
-        if (document.Output.Kind == SpecOutputKind.AppScaffold)
-        {
-            return new ApplyPayload
-            {
-                Kind = SpecOutputKind.AppScaffold,
-                AppScaffold = new AppScaffold(
-                    "Preview App",
-                    new[] { new AppScaffoldParameter("date", "date", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)) },
-                    "single-column")
             };
         }
 

--- a/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
@@ -389,21 +389,22 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             });
         }
 
-        if (document.Output.Kind != SpecOutputKind.None)
+        var effectiveOutputKind = ResolveEffectiveOutputKind(document);
+        if (effectiveOutputKind != SpecOutputKind.None)
         {
-            var outputId = $"output-{document.Output.Kind.ToString().ToLowerInvariant()}";
+            var outputId = $"output-{effectiveOutputKind.ToString().ToLowerInvariant()}";
             nodes.Add(new PlanNode
             {
                 Id = outputId,
                 Op = "output",
-                Inputs = ResolveOutputInputs(document, document.Output.Kind),
+                Inputs = ResolveOutputInputs(document, effectiveOutputKind),
                 Depth = depth + 1,
                 EstimatedRows = 0,
                 EstimatedBytes = 0,
-                EstimatedMillis = document.Output.Kind == SpecOutputKind.AppScaffold ? 120 : 25,
-                ContentHash = BuildContentHash("output", document.Output.Kind.ToString(), document.Output.Target ?? "preview"),
-                CachePolicy = document.Output.Kind == SpecOutputKind.AppScaffold ? PlanCachePolicy.None : PlanCachePolicy.ContentHash,
-                Materialization = MaterializationForOutput(document.Output.Kind)
+                EstimatedMillis = effectiveOutputKind == SpecOutputKind.AppScaffold ? 120 : 25,
+                ContentHash = BuildContentHash("output", effectiveOutputKind.ToString(), document.Output.Target ?? "preview"),
+                CachePolicy = effectiveOutputKind == SpecOutputKind.AppScaffold ? PlanCachePolicy.None : PlanCachePolicy.ContentHash,
+                Materialization = MaterializationForOutput(effectiveOutputKind)
             });
         }
 
@@ -999,6 +1000,26 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         return inputs;
     }
 
+    private static SpecOutputKind ResolveEffectiveOutputKind(SpecDocument document)
+    {
+        if (document.Output.Kind == SpecOutputKind.AppScaffold)
+        {
+            return SpecOutputKind.AppScaffold;
+        }
+
+        if (document.Map.Layers.Count > 0)
+        {
+            return SpecOutputKind.Map;
+        }
+
+        if (document.Compute.Any(step => step.Op == "aggregate") || document.Output.Kind == SpecOutputKind.Analysis)
+        {
+            return SpecOutputKind.Analysis;
+        }
+
+        return SpecOutputKind.None;
+    }
+
     private static PlanMaterializationKind MaterializationForOutput(SpecOutputKind kind) => kind switch
     {
         SpecOutputKind.Map => PlanMaterializationKind.PreviewOnly,
@@ -1026,7 +1047,8 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
     private ApplyPayload BuildPayload(SpecDocument document)
     {
-        if (document.Output.Kind == SpecOutputKind.AppScaffold)
+        var effectiveOutputKind = ResolveEffectiveOutputKind(document);
+        if (effectiveOutputKind == SpecOutputKind.AppScaffold)
         {
             return new ApplyPayload
             {
@@ -1038,7 +1060,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             };
         }
 
-        if (document.Map.Layers.Count > 0)
+        if (effectiveOutputKind == SpecOutputKind.Map)
         {
             var features = new List<MapFeature>();
             foreach (var layer in document.Map.Layers)
@@ -1057,7 +1079,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             };
         }
 
-        if (document.Compute.Any(c => c.Op == "aggregate"))
+        if (effectiveOutputKind == SpecOutputKind.Analysis && document.Compute.Any(c => c.Op == "aggregate"))
         {
             var step = document.Compute.First(c => c.Op == "aggregate");
             var groupBy = step.Args.TryGetValue("by", out var by) ? by : "group";
@@ -1088,7 +1110,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             };
         }
 
-        if (document.Output.Kind == SpecOutputKind.Analysis)
+        if (effectiveOutputKind == SpecOutputKind.Analysis)
         {
             IReadOnlyList<IReadOnlyDictionary<string, string>> rows = new[]
             {

--- a/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -327,7 +329,10 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 EstimatedRows = dataset.EstimatedRows,
                 EstimatedBytes = dataset.EstimatedRows * 128,
                 EstimatedMillis = 50,
-                Warnings = nodeWarnings
+                Warnings = nodeWarnings,
+                ContentHash = BuildContentHash("source", source.Dataset, source.Pin ?? "mutable"),
+                CachePolicy = PlanCachePolicy.MetadataOnly,
+                Materialization = PlanMaterializationKind.Ephemeral
             });
         }
 
@@ -355,7 +360,14 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 Depth = depth,
                 EstimatedRows = outRows,
                 EstimatedBytes = outRows * 128,
-                EstimatedMillis = step.Op == "join" ? 1200 : 300
+                EstimatedMillis = step.Op == "join" ? 1200 : 300,
+                ContentHash = BuildContentHash(
+                    "compute",
+                    step.Op,
+                    string.Join(",", step.Inputs.OrderBy(input => input, StringComparer.Ordinal)),
+                    string.Join(",", step.Args.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"{kv.Key}={kv.Value}"))),
+                CachePolicy = PlanCachePolicy.ContentHash,
+                Materialization = PlanMaterializationKind.Ephemeral
             });
             depth++;
         }
@@ -370,7 +382,28 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 Depth = depth,
                 EstimatedRows = 0,
                 EstimatedBytes = 0,
-                EstimatedMillis = 80
+                EstimatedMillis = 80,
+                ContentHash = BuildContentHash("map", layer.Source, layer.Symbology),
+                CachePolicy = PlanCachePolicy.ContentHash,
+                Materialization = PlanMaterializationKind.PreviewOnly
+            });
+        }
+
+        if (document.Output.Kind != SpecOutputKind.None)
+        {
+            var outputId = $"output-{document.Output.Kind.ToString().ToLowerInvariant()}";
+            nodes.Add(new PlanNode
+            {
+                Id = outputId,
+                Op = "output",
+                Inputs = ResolveOutputInputs(document),
+                Depth = depth + 1,
+                EstimatedRows = 0,
+                EstimatedBytes = 0,
+                EstimatedMillis = document.Output.Kind == SpecOutputKind.AppScaffold ? 120 : 25,
+                ContentHash = BuildContentHash("output", document.Output.Kind.ToString(), document.Output.Target ?? "preview"),
+                CachePolicy = document.Output.Kind == SpecOutputKind.AppScaffold ? PlanCachePolicy.None : PlanCachePolicy.ContentHash,
+                Materialization = MaterializationForOutput(document.Output.Kind)
             });
         }
 
@@ -402,7 +435,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
         yield return new ApplyEvent { Kind = ApplyEventKind.Started, JobId = jobId };
 
-        var cacheIndex = 0;
+        var contentHashIndex = 0;
         foreach (var node in plan.Nodes)
         {
             if (IsCancelled(jobId) || cancellationToken.IsCancellationRequested)
@@ -416,14 +449,15 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 yield break;
             }
 
-            var status = cacheIndex == 0 ? ApplyNodeStatus.Running : ApplyNodeStatus.Running;
+            var cacheKey = node.CachePolicy == PlanCachePolicy.ContentHash ? node.ContentHash : null;
             yield return new ApplyEvent
             {
                 Kind = ApplyEventKind.NodeUpdate,
                 JobId = jobId,
                 NodeId = node.Id,
                 NodeOp = node.Op,
-                Status = status
+                Status = ApplyNodeStatus.Running,
+                CacheKey = cacheKey
             };
 
             var delayCancelled = false;
@@ -447,16 +481,24 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 yield break;
             }
 
-            var finalStatus = cacheIndex % 3 == 2 ? ApplyNodeStatus.CacheHit : ApplyNodeStatus.Completed;
+            var finalStatus = node.CachePolicy == PlanCachePolicy.ContentHash && contentHashIndex % 3 == 2
+                ? ApplyNodeStatus.CacheHit
+                : ApplyNodeStatus.Completed;
             yield return new ApplyEvent
             {
                 Kind = ApplyEventKind.NodeUpdate,
                 JobId = jobId,
                 NodeId = node.Id,
                 NodeOp = node.Op,
-                Status = finalStatus
+                Status = finalStatus,
+                CacheKey = cacheKey,
+                MaterializedResource = BuildMaterializedResource(node)
             };
-            cacheIndex++;
+
+            if (node.CachePolicy == PlanCachePolicy.ContentHash)
+            {
+                contentHashIndex++;
+            }
         }
 
         yield return new ApplyEvent
@@ -914,6 +956,47 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 Label = r
             })
             .ToArray();
+    }
+
+    private static IReadOnlyList<string> ResolveOutputInputs(SpecDocument document)
+    {
+        if (document.Map.Layers.Count > 0)
+        {
+            return document.Map.Layers.Select(layer => $"map-{layer.Source}").ToArray();
+        }
+
+        if (document.Compute.Count > 0)
+        {
+            var last = document.Compute[^1];
+            return new[] { $"{last.Op}-{document.Compute.Count}" };
+        }
+
+        return document.Sources.Select(source => source.Id).ToArray();
+    }
+
+    private static PlanMaterializationKind MaterializationForOutput(SpecOutputKind kind) => kind switch
+    {
+        SpecOutputKind.Map => PlanMaterializationKind.PreviewOnly,
+        SpecOutputKind.AppScaffold => PlanMaterializationKind.DurableApp,
+        _ => PlanMaterializationKind.Ephemeral
+    };
+
+    private static MaterializedResource? BuildMaterializedResource(PlanNode node)
+    {
+        if (node.Materialization is not (PlanMaterializationKind.DurableApp or PlanMaterializationKind.DurableDataset or PlanMaterializationKind.DurableService))
+        {
+            return null;
+        }
+
+        var version = node.ContentHash ?? BuildContentHash(node.Id, node.Op);
+        return new MaterializedResource(node.Id, node.Materialization, version);
+    }
+
+    private static string BuildContentHash(params string?[] parts)
+    {
+        var input = string.Join("|", parts.Select(part => part ?? string.Empty));
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return "sha256:" + Convert.ToHexString(hash)[..12].ToLowerInvariant();
     }
 
     private ApplyPayload BuildPayload(SpecDocument document)

--- a/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
@@ -305,6 +305,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
         var nodes = new List<PlanNode>();
         var warnings = new List<PlanWarning>();
+        var nodeHashes = new Dictionary<string, string>(StringComparer.Ordinal);
         var depth = 0;
         foreach (var source in document.Sources)
         {
@@ -321,6 +322,8 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 warnings.Add(new PlanWarning(source.Id, PlanWarningSeverity.Yellow, $"source '{source.Id}' is not pinned; results may drift"));
             }
 
+            var sourceHash = BuildContentHash("source", dataset.Id, source.Pin ?? "mutable");
+            nodeHashes[source.Id] = sourceHash;
             nodes.Add(new PlanNode
             {
                 Id = source.Id,
@@ -330,7 +333,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 EstimatedBytes = dataset.EstimatedRows * 128,
                 EstimatedMillis = 50,
                 Warnings = nodeWarnings,
-                ContentHash = BuildContentHash("source", dataset.Id, source.Pin ?? "mutable"),
+                ContentHash = sourceHash,
                 CachePolicy = PlanCachePolicy.MetadataOnly,
                 Materialization = PlanMaterializationKind.Ephemeral
             });
@@ -352,20 +355,27 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 _ => inputRows
             };
 
+            var nodeId = $"{step.Op}-{depth}";
+            var inputHashes = step.Inputs
+                .OrderBy(input => input, StringComparer.Ordinal)
+                .Select(input => ResolveNodeHash(nodeHashes, input));
+            var computeHash = BuildContentHash(
+                "compute",
+                step.Op,
+                string.Join(",", step.Inputs.OrderBy(input => input, StringComparer.Ordinal)),
+                string.Join(",", inputHashes),
+                string.Join(",", step.Args.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"{kv.Key}={kv.Value}")));
+            nodeHashes[nodeId] = computeHash;
             nodes.Add(new PlanNode
             {
-                Id = $"{step.Op}-{depth}",
+                Id = nodeId,
                 Op = step.Op,
                 Inputs = step.Inputs,
                 Depth = depth,
                 EstimatedRows = outRows,
                 EstimatedBytes = outRows * 128,
                 EstimatedMillis = step.Op == "join" ? 1200 : 300,
-                ContentHash = BuildContentHash(
-                    "compute",
-                    step.Op,
-                    string.Join(",", step.Inputs.OrderBy(input => input, StringComparer.Ordinal)),
-                    string.Join(",", step.Args.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"{kv.Key}={kv.Value}"))),
+                ContentHash = computeHash,
                 CachePolicy = PlanCachePolicy.ContentHash,
                 Materialization = PlanMaterializationKind.Ephemeral
             });
@@ -374,16 +384,19 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
         foreach (var layer in document.Map.Layers)
         {
+            var mapId = $"map-{layer.Source}";
+            var mapHash = BuildContentHash("map", layer.Source, ResolveNodeHash(nodeHashes, layer.Source), layer.Symbology);
+            nodeHashes[mapId] = mapHash;
             nodes.Add(new PlanNode
             {
-                Id = $"map-{layer.Source}",
+                Id = mapId,
                 Op = "map",
                 Inputs = new[] { layer.Source },
                 Depth = depth,
                 EstimatedRows = 0,
                 EstimatedBytes = 0,
                 EstimatedMillis = 80,
-                ContentHash = BuildContentHash("map", layer.Source, layer.Symbology),
+                ContentHash = mapHash,
                 CachePolicy = PlanCachePolicy.ContentHash,
                 Materialization = PlanMaterializationKind.PreviewOnly
             });
@@ -393,16 +406,22 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         if (effectiveOutputKind != SpecOutputKind.None)
         {
             var outputId = $"output-{effectiveOutputKind.ToString().ToLowerInvariant()}";
+            var outputInputs = ResolveOutputInputs(document, effectiveOutputKind);
+            var outputHash = BuildContentHash(
+                "output",
+                effectiveOutputKind.ToString(),
+                document.Output.Target ?? "preview",
+                string.Join(",", outputInputs.Select(input => ResolveNodeHash(nodeHashes, input))));
             nodes.Add(new PlanNode
             {
                 Id = outputId,
                 Op = "output",
-                Inputs = ResolveOutputInputs(document, effectiveOutputKind),
+                Inputs = outputInputs,
                 Depth = depth + 1,
                 EstimatedRows = 0,
                 EstimatedBytes = 0,
                 EstimatedMillis = effectiveOutputKind == SpecOutputKind.AppScaffold ? 120 : 25,
-                ContentHash = BuildContentHash("output", effectiveOutputKind.ToString(), document.Output.Target ?? "preview"),
+                ContentHash = outputHash,
                 CachePolicy = effectiveOutputKind == SpecOutputKind.AppScaffold ? PlanCachePolicy.None : PlanCachePolicy.ContentHash,
                 Materialization = MaterializationForOutput(effectiveOutputKind)
             });
@@ -1044,6 +1063,9 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
         return "sha256:" + Convert.ToHexString(hash)[..12].ToLowerInvariant();
     }
+
+    private static string ResolveNodeHash(IReadOnlyDictionary<string, string> nodeHashes, string nodeId) =>
+        nodeHashes.TryGetValue(nodeId, out var hash) ? hash : nodeId;
 
     private ApplyPayload BuildPayload(SpecDocument document)
     {

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -288,6 +288,22 @@ public sealed class AdminPageRenderTests : TestContext
             var sourceChange = cut.Find("[data-testid='spec-change-Sources']");
             Assert.Equal("Added", sourceChange.GetAttribute("data-status"));
         });
+
+        await cut.InvokeAsync(() => state.UpdateSectionTextAsync(
+            SpecSectionId.Compute,
+            "aggregate inputs=@parcels by=@parcels.county metric=count"));
+        await cut.InvokeAsync(() => state.UpdateSectionTextAsync(
+            SpecSectionId.Output,
+            "kind: AppScaffold\ntarget: preview"));
+        await cut.InvokeAsync(() => state.RunPlanAsync());
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("content-hash");
+            cut.Markup.MarkupMatchesContaining("durable app");
+            cut.Find("[data-testid='dag-node-cache-aggregate-1']");
+            cut.Find("[data-testid='dag-node-materialization-output-appscaffold']");
+        });
     }
 
     [Fact]

--- a/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
@@ -50,6 +50,46 @@ public sealed class StubSpecWorkspaceClientTests
         Assert.All(payload.MapFeatures, feature => Assert.Equal("study", feature.Source));
     }
 
+    [Fact]
+    public async Task PlanAsync_marks_compute_cache_keys_and_durable_app_outputs()
+    {
+        var document = BuildAppScaffoldDocument();
+
+        var plan = await _client.PlanAsync(document, CancellationToken.None);
+
+        var aggregate = Assert.Single(plan.Nodes, node => node.Op == "aggregate");
+        Assert.Equal(PlanCachePolicy.ContentHash, aggregate.CachePolicy);
+        Assert.StartsWith("sha256:", aggregate.ContentHash, StringComparison.Ordinal);
+        Assert.Equal(PlanMaterializationKind.Ephemeral, aggregate.Materialization);
+
+        var output = Assert.Single(plan.Nodes, node => node.Id == "output-appscaffold");
+        Assert.Equal(PlanCachePolicy.None, output.CachePolicy);
+        Assert.Equal(PlanMaterializationKind.DurableApp, output.Materialization);
+        Assert.StartsWith("sha256:", output.ContentHash, StringComparison.Ordinal);
+        Assert.Equal(new[] { "aggregate-1" }, output.Inputs);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_emits_cache_keys_and_materialized_durable_outputs()
+    {
+        var document = BuildAppScaffoldDocument();
+        var events = new List<ApplyEvent>();
+
+        await foreach (var evt in _client.ApplyAsync(document, Guid.NewGuid().ToString("n"), CancellationToken.None))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Contains(events, evt =>
+            evt.NodeOp == "aggregate"
+            && evt.Status is ApplyNodeStatus.Completed or ApplyNodeStatus.CacheHit
+            && evt.CacheKey?.StartsWith("sha256:", StringComparison.Ordinal) == true);
+
+        var output = Assert.Single(events, evt => evt.NodeId == "output-appscaffold" && evt.MaterializedResource is not null);
+        Assert.Equal(PlanMaterializationKind.DurableApp, output.MaterializedResource!.Kind);
+        Assert.StartsWith("sha256:", output.MaterializedResource.Version, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("buffer @parcels by 100mi", "100mi")]
     [InlineData("buffer @parcels by 100km", "100km")]
@@ -99,4 +139,21 @@ public sealed class StubSpecWorkspaceClientTests
 
         return null;
     }
+
+    private static SpecDocument BuildAppScaffoldDocument() => new()
+    {
+        Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
+        Compute = new[]
+        {
+            new SpecComputeStep(
+                "aggregate",
+                new[] { "parcels" },
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["by"] = "@parcels.county",
+                    ["metric"] = "count"
+                })
+        },
+        Output = new SpecOutput { Kind = SpecOutputKind.AppScaffold, Target = "preview" }
+    };
 }

--- a/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
@@ -85,6 +85,30 @@ public sealed class StubSpecWorkspaceClientTests
     }
 
     [Fact]
+    public async Task PlanAsync_includes_source_revision_in_compute_cache_hash()
+    {
+        var first = await _client.PlanAsync(BuildAppScaffoldDocument("v1"), CancellationToken.None);
+        var second = await _client.PlanAsync(BuildAppScaffoldDocument("v2"), CancellationToken.None);
+
+        var firstAggregate = Assert.Single(first.Nodes, node => node.Op == "aggregate");
+        var secondAggregate = Assert.Single(second.Nodes, node => node.Op == "aggregate");
+
+        Assert.NotEqual(firstAggregate.ContentHash, secondAggregate.ContentHash);
+    }
+
+    [Fact]
+    public async Task PlanAsync_includes_input_hashes_in_output_content_hash()
+    {
+        var first = await _client.PlanAsync(BuildAppScaffoldDocument("v1"), CancellationToken.None);
+        var second = await _client.PlanAsync(BuildAppScaffoldDocument("v2"), CancellationToken.None);
+
+        var firstOutput = Assert.Single(first.Nodes, node => node.Id == "output-appscaffold");
+        var secondOutput = Assert.Single(second.Nodes, node => node.Id == "output-appscaffold");
+
+        Assert.NotEqual(firstOutput.ContentHash, secondOutput.ContentHash);
+    }
+
+    [Fact]
     public async Task PlanAsync_uses_output_kind_for_app_scaffold_inputs_when_map_layers_exist()
     {
         var document = BuildAppScaffoldDocument() with
@@ -229,9 +253,9 @@ public sealed class StubSpecWorkspaceClientTests
         return null;
     }
 
-    private static SpecDocument BuildAppScaffoldDocument() => new()
+    private static SpecDocument BuildAppScaffoldDocument(string sourcePin = "v1") => new()
     {
-        Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
+        Sources = new[] { new SpecSourceEntry("parcels", "parcels", sourcePin) },
         Compute = new[]
         {
             new SpecComputeStep(

--- a/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
@@ -104,6 +104,43 @@ public sealed class StubSpecWorkspaceClientTests
     }
 
     [Fact]
+    public async Task PlanAsync_uses_effective_map_output_when_analysis_output_has_map_layers()
+    {
+        var document = new SpecDocument
+        {
+            Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
+            Map = new SpecMap
+            {
+                Layers = new[] { new SpecMapLayer("parcels", "viridis") }
+            },
+            Output = new SpecOutput { Kind = SpecOutputKind.Analysis, Target = "preview" }
+        };
+
+        var plan = await _client.PlanAsync(document, CancellationToken.None);
+        var payload = await CollectCompletedPayloadAsync(document);
+
+        var output = Assert.Single(plan.Nodes, node => node.Id == "output-map");
+        Assert.Equal(PlanMaterializationKind.PreviewOnly, output.Materialization);
+        Assert.Equal(SpecOutputKind.Map, payload!.Kind);
+    }
+
+    [Fact]
+    public async Task PlanAsync_skips_output_node_when_requested_map_has_no_effective_payload()
+    {
+        var document = new SpecDocument
+        {
+            Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
+            Output = new SpecOutput { Kind = SpecOutputKind.Map, Target = "preview" }
+        };
+
+        var plan = await _client.PlanAsync(document, CancellationToken.None);
+        var payload = await CollectCompletedPayloadAsync(document);
+
+        Assert.DoesNotContain(plan.Nodes, node => node.Op == "output");
+        Assert.Equal(SpecOutputKind.None, payload!.Kind);
+    }
+
+    [Fact]
     public async Task ApplyAsync_emits_cache_keys_and_materialized_durable_outputs()
     {
         var document = BuildAppScaffoldDocument();

--- a/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
@@ -70,6 +70,40 @@ public sealed class StubSpecWorkspaceClientTests
     }
 
     [Fact]
+    public async Task PlanAsync_normalizes_source_dataset_casing_for_cache_hashes()
+    {
+        var lower = await _client.PlanAsync(new SpecDocument
+        {
+            Sources = new[] { new SpecSourceEntry("study", "parcels", "v1") },
+        }, CancellationToken.None);
+        var mixed = await _client.PlanAsync(new SpecDocument
+        {
+            Sources = new[] { new SpecSourceEntry("study", "Parcels", "v1") },
+        }, CancellationToken.None);
+
+        Assert.Equal(lower.Nodes[0].ContentHash, mixed.Nodes[0].ContentHash);
+    }
+
+    [Fact]
+    public async Task PlanAsync_uses_output_kind_for_app_scaffold_inputs_when_map_layers_exist()
+    {
+        var document = BuildAppScaffoldDocument() with
+        {
+            Map = new SpecMap
+            {
+                Layers = new[] { new SpecMapLayer("parcels", "viridis") }
+            }
+        };
+
+        var plan = await _client.PlanAsync(document, CancellationToken.None);
+
+        var output = Assert.Single(plan.Nodes, node => node.Id == "output-appscaffold");
+        Assert.Equal(PlanMaterializationKind.DurableApp, output.Materialization);
+        Assert.Contains("aggregate-1", output.Inputs);
+        Assert.Contains("map-parcels", output.Inputs);
+    }
+
+    [Fact]
     public async Task ApplyAsync_emits_cache_keys_and_materialized_durable_outputs()
     {
         var document = BuildAppScaffoldDocument();
@@ -88,6 +122,24 @@ public sealed class StubSpecWorkspaceClientTests
         var output = Assert.Single(events, evt => evt.NodeId == "output-appscaffold" && evt.MaterializedResource is not null);
         Assert.Equal(PlanMaterializationKind.DurableApp, output.MaterializedResource!.Kind);
         Assert.StartsWith("sha256:", output.MaterializedResource.Version, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_returns_app_scaffold_payload_when_app_output_has_map_layers()
+    {
+        var document = BuildAppScaffoldDocument() with
+        {
+            Map = new SpecMap
+            {
+                Layers = new[] { new SpecMapLayer("parcels", "viridis") }
+            }
+        };
+
+        var payload = await CollectCompletedPayloadAsync(document);
+
+        Assert.NotNull(payload);
+        Assert.Equal(SpecOutputKind.AppScaffold, payload!.Kind);
+        Assert.NotNull(payload.AppScaffold);
     }
 
     [Theory]


### PR DESCRIPTION
Related to #25 (partial admin UI slice).

## Summary
- Add spec plan metadata for cache policy, content hashes, and materialization kind.
- Emit content-hash cache keys and durable app materialization events from the stub plan/apply path.
- Surface cache and materialization details in the DAG and apply stream previews.

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "SpecWorkspaceStateTests|StubSpecWorkspaceClientTests|AdminPageRenderTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- git diff --check