### PR TITLE
ui: add app builder interaction links

### DIFF
--- a/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
+++ b/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
@@ -32,6 +32,20 @@ public enum AppWidgetKind
     RichText
 }
 
+public enum AppInteractionEventKind
+{
+    MapFeatureClick,
+    FilterChanged,
+    ListRowSelect
+}
+
+public enum AppInteractionActionKind
+{
+    FilterWidget,
+    HighlightFeature,
+    ZoomToFeature
+}
+
 public sealed record AppBuilderSnapshot
 {
     public IReadOnlyList<AppTemplate> Templates { get; init; } = Array.Empty<AppTemplate>();
@@ -88,6 +102,7 @@ public sealed record AppDraft
     public int AutoRefreshSeconds { get; init; } = 60;
     public bool IsPublished { get; init; }
     public IReadOnlyList<AppWidgetInstance> Widgets { get; init; } = Array.Empty<AppWidgetInstance>();
+    public IReadOnlyList<AppWidgetInteraction> Interactions { get; init; } = Array.Empty<AppWidgetInteraction>();
 }
 
 public sealed record AppWidgetInstance
@@ -100,6 +115,19 @@ public sealed record AppWidgetInstance
     public int Row { get; init; }
     public int Width { get; init; } = 4;
     public int Height { get; init; } = 2;
+}
+
+public sealed record AppWidgetInteraction
+{
+    public string InteractionId { get; init; } = Guid.NewGuid().ToString("n");
+    public string SourceWidgetId { get; init; } = string.Empty;
+    public string SourceTitle { get; init; } = string.Empty;
+    public AppInteractionEventKind Event { get; init; }
+    public string TargetWidgetId { get; init; } = string.Empty;
+    public string TargetTitle { get; init; } = string.Empty;
+    public AppInteractionActionKind Action { get; init; }
+    public string Binding { get; init; } = string.Empty;
+    public bool Enabled { get; init; } = true;
 }
 
 public sealed record AppValidationCheck

--- a/src/Honua.Admin/Pages/Operator/AppBuilder.razor
+++ b/src/Honua.Admin/Pages/Operator/AppBuilder.razor
@@ -116,6 +116,24 @@
                     </article>
                 }
             </div>
+            <MudText Typo="Typo.h6" Class="mt-4">Cross-widget interactions</MudText>
+            <div class="app-builder-interactions" aria-label="Cross-widget interactions" data-testid="app-builder-interactions">
+                @foreach (var interaction in State.Draft.Interactions)
+                {
+                    var link = interaction;
+                    <div class="@InteractionClass(link)" data-testid="@($"app-builder-interaction-{link.InteractionId}")">
+                        <MudIcon Icon="@InteractionIcon(link.Event)" Size="Size.Small" Color="@(link.Enabled ? Color.Primary : Color.Default)" />
+                        <div>
+                            <strong>@link.SourceTitle</strong>
+                            <span>@($"{EventLabel(link.Event)} -> {ActionLabel(link.Action)}")</span>
+                            <small>@($"{link.TargetTitle} via {link.Binding}")</small>
+                        </div>
+                        <MudChip T="string" Size="Size.Small" Color="@(link.Enabled ? Color.Success : Color.Default)" Variant="Variant.Outlined">
+                            @(link.Enabled ? "Enabled" : "Paused")
+                        </MudChip>
+                    </div>
+                }
+            </div>
         </section>
 
         <section class="app-builder-pane" aria-label="App builder configuration">
@@ -280,6 +298,33 @@
         AppPublishChannelKind.IframeEmbed => Icons.Material.Filled.Code,
         AppPublishChannelKind.CustomDomain => Icons.Material.Filled.Language,
         _ => Icons.Material.Filled.Publish
+    };
+
+    private static string InteractionClass(AppWidgetInteraction interaction)
+        => interaction.Enabled ? "app-builder-interaction enabled" : "app-builder-interaction";
+
+    private static string InteractionIcon(AppInteractionEventKind kind) => kind switch
+    {
+        AppInteractionEventKind.MapFeatureClick => Icons.Material.Filled.TouchApp,
+        AppInteractionEventKind.FilterChanged => Icons.Material.Filled.FilterAlt,
+        AppInteractionEventKind.ListRowSelect => Icons.Material.Filled.TableRows,
+        _ => Icons.Material.Filled.SyncAlt
+    };
+
+    private static string EventLabel(AppInteractionEventKind kind) => kind switch
+    {
+        AppInteractionEventKind.MapFeatureClick => "Map feature click",
+        AppInteractionEventKind.FilterChanged => "Filter changed",
+        AppInteractionEventKind.ListRowSelect => "List row select",
+        _ => kind.ToString()
+    };
+
+    private static string ActionLabel(AppInteractionActionKind kind) => kind switch
+    {
+        AppInteractionActionKind.FilterWidget => "filter target",
+        AppInteractionActionKind.HighlightFeature => "highlight feature",
+        AppInteractionActionKind.ZoomToFeature => "zoom to feature",
+        _ => kind.ToString()
     };
 
     private static Color ChannelColor(AppPublishChannel channel)

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -41,6 +41,14 @@ public sealed class AppBuilderState
             var hasWidgets = Draft.Widgets.Count > 0;
             var dataBoundWidgets = Draft.Widgets.Where(widget => WidgetRequiresBinding(widget.Kind)).ToArray();
             var allBindings = dataBoundWidgets.All(widget => !string.IsNullOrWhiteSpace(widget.DataBinding));
+            var widgetIds = Draft.Widgets.Select(widget => widget.WidgetId).ToHashSet(StringComparer.Ordinal);
+            var interactionsReferenceWidgets = Draft.Interactions.All(interaction =>
+                widgetIds.Contains(interaction.SourceWidgetId) && widgetIds.Contains(interaction.TargetWidgetId));
+            var interactionMessage = Draft.Interactions.Count == 0
+                ? "No cross-widget interactions configured."
+                : interactionsReferenceWidgets
+                    ? $"{Draft.Interactions.Count} cross-widget interaction(s) configured."
+                    : "Interaction source and target widgets must remain on the canvas.";
 
             return
             [
@@ -71,6 +79,13 @@ public sealed class AppBuilderState
                     Label = "Responsive breakpoints",
                     Passed = SelectedTemplate?.Breakpoints.Count > 0,
                     Message = SelectedTemplate is null ? "Select a template." : string.Join(", ", SelectedTemplate.Breakpoints)
+                },
+                new AppValidationCheck
+                {
+                    Key = "interactions",
+                    Label = "Cross-widget interactions",
+                    Passed = interactionsReferenceWidgets,
+                    Message = interactionMessage
                 }
             ];
         }
@@ -272,10 +287,16 @@ public sealed class AppBuilderState
             return;
         }
 
+        var widgets = Draft.Widgets
+            .Where(widget => !string.Equals(widget.WidgetId, widgetId, StringComparison.Ordinal))
+            .ToArray();
+        var widgetIds = widgets.Select(widget => widget.WidgetId).ToHashSet(StringComparer.Ordinal);
+
         Draft = Draft with
         {
-            Widgets = Draft.Widgets
-                .Where(widget => !string.Equals(widget.WidgetId, widgetId, StringComparison.Ordinal))
+            Widgets = widgets,
+            Interactions = Draft.Interactions
+                .Where(interaction => widgetIds.Contains(interaction.SourceWidgetId) && widgetIds.Contains(interaction.TargetWidgetId))
                 .ToArray()
         };
         ResetTransientPublishState();

--- a/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
@@ -95,10 +95,31 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
                 AutoRefreshSeconds = 60,
                 Widgets =
                 [
-                    Instance(AppWidgetKind.Map, "Operational map", "Harbor assets", 1, 1, 6, 4),
-                    Instance(AppWidgetKind.Indicator, "Open incidents", "Incidents count", 7, 1, 3, 2),
-                    Instance(AppWidgetKind.Chart, "Incidents by type", "Incident types", 7, 3, 3, 2),
-                    Instance(AppWidgetKind.List, "Recent work orders", "Work orders", 1, 5, 9, 2)
+                    Instance("widget-map", AppWidgetKind.Map, "Operational map", "Harbor assets", 1, 1, 6, 4),
+                    Instance("widget-indicator", AppWidgetKind.Indicator, "Open incidents", "Incidents count", 7, 1, 3, 2),
+                    Instance("widget-chart", AppWidgetKind.Chart, "Incidents by type", "Incident types", 7, 3, 3, 2),
+                    Instance("widget-list", AppWidgetKind.List, "Recent work orders", "Work orders", 1, 5, 9, 2)
+                ],
+                Interactions =
+                [
+                    Interaction(
+                        "interaction-map-chart",
+                        "widget-map",
+                        "Operational map",
+                        AppInteractionEventKind.MapFeatureClick,
+                        "widget-chart",
+                        "Incidents by type",
+                        AppInteractionActionKind.FilterWidget,
+                        "asset_id"),
+                    Interaction(
+                        "interaction-map-list",
+                        "widget-map",
+                        "Operational map",
+                        AppInteractionEventKind.MapFeatureClick,
+                        "widget-list",
+                        "Recent work orders",
+                        AppInteractionActionKind.FilterWidget,
+                        "asset_id")
                 ]
             }
         };
@@ -152,6 +173,7 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
         };
 
     private static AppWidgetInstance Instance(
+        string widgetId,
         AppWidgetKind kind,
         string title,
         string binding,
@@ -160,6 +182,7 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
         int width,
         int height) => new()
         {
+            WidgetId = widgetId,
             Kind = kind,
             Title = title,
             DataBinding = binding,
@@ -167,6 +190,27 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
             Row = row,
             Width = width,
             Height = height
+        };
+
+    private static AppWidgetInteraction Interaction(
+        string interactionId,
+        string sourceWidgetId,
+        string sourceTitle,
+        AppInteractionEventKind eventKind,
+        string targetWidgetId,
+        string targetTitle,
+        AppInteractionActionKind action,
+        string binding) => new()
+        {
+            InteractionId = interactionId,
+            SourceWidgetId = sourceWidgetId,
+            SourceTitle = sourceTitle,
+            Event = eventKind,
+            TargetWidgetId = targetWidgetId,
+            TargetTitle = targetTitle,
+            Action = action,
+            Binding = binding,
+            Enabled = true
         };
 
     private static string Slug(string value)

--- a/src/Honua.Admin/wwwroot/css/app-builder.css
+++ b/src/Honua.Admin/wwwroot/css/app-builder.css
@@ -29,7 +29,8 @@
 .app-builder-template-list,
 .app-builder-widget-library,
 .app-builder-validation,
-.app-builder-publishing-readiness {
+.app-builder-publishing-readiness,
+.app-builder-interactions {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -72,7 +73,8 @@
 .app-builder-widget-definition,
 .app-builder-quota-row,
 .app-builder-publish-channel,
-.app-builder-validation-row {
+.app-builder-validation-row,
+.app-builder-interaction {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -95,11 +97,23 @@
     align-items: flex-start;
 }
 
+.app-builder-interaction {
+    border-left: 4px solid var(--mud-palette-primary, #594ae2);
+}
+
+.app-builder-interaction:not(.enabled) {
+    border-left-color: var(--mud-palette-lines-default, #d7dbe0);
+    opacity: 0.75;
+}
+
 .app-builder-publish-channel strong,
 .app-builder-publish-channel span,
 .app-builder-publish-channel small,
 .app-builder-quota-row strong,
-.app-builder-quota-row span {
+.app-builder-quota-row span,
+.app-builder-interaction strong,
+.app-builder-interaction span,
+.app-builder-interaction small {
     min-width: 0;
     overflow-wrap: anywhere;
 }

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -27,6 +27,8 @@ public sealed class AppBuilderStateTests
         Assert.True(state.Quota.CanPublishMore);
         Assert.Equal("Harbor operations dashboard", state.Draft.Name);
         Assert.NotEmpty(state.Draft.Widgets);
+        Assert.Equal(2, state.Draft.Interactions.Count);
+        Assert.Contains(state.ValidationChecks, check => check.Key == "interactions" && check.Passed);
         Assert.False(state.HasBlockingValidation);
     }
 
@@ -101,6 +103,51 @@ public sealed class AppBuilderStateTests
 
         var added = Assert.Single(state.Draft.Widgets, widget => existing.All(item => item.WidgetId != widget.WidgetId));
         Assert.DoesNotContain(existing, widget => Overlaps(widget, added));
+    }
+
+    [Fact]
+    public async Task RemoveWidget_removes_related_interactions()
+    {
+        var state = new AppBuilderState(new StubAppBuilderClient());
+        await state.LoadAsync();
+
+        state.RemoveWidget("widget-map");
+
+        Assert.DoesNotContain(state.Draft.Widgets, widget => widget.WidgetId == "widget-map");
+        Assert.Empty(state.Draft.Interactions);
+        Assert.Contains(state.ValidationChecks, check => check.Key == "interactions" && check.Passed);
+    }
+
+    [Fact]
+    public async Task Validation_flags_interactions_that_reference_missing_widgets()
+    {
+        var snapshot = Snapshot("Interaction dashboard");
+        var state = new AppBuilderState(new FixedAppBuilderClient(snapshot with
+        {
+            Draft = snapshot.Draft with
+            {
+                Interactions =
+                [
+                    new AppWidgetInteraction
+                    {
+                        InteractionId = "orphan-link",
+                        SourceWidgetId = "missing-widget",
+                        SourceTitle = "Missing map",
+                        Event = AppInteractionEventKind.MapFeatureClick,
+                        TargetWidgetId = "widget-map",
+                        TargetTitle = "Map",
+                        Action = AppInteractionActionKind.FilterWidget,
+                        Binding = "asset_id",
+                    },
+                ],
+            },
+        }));
+        await state.LoadAsync();
+
+        var interactions = Assert.Single(state.ValidationChecks, check => check.Key == "interactions");
+
+        Assert.False(interactions.Passed);
+        Assert.True(state.HasBlockingValidation);
     }
 
     [Fact]
@@ -522,6 +569,7 @@ public sealed class AppBuilderStateTests
                 [
                     new AppWidgetInstance
                     {
+                        WidgetId = "widget-map",
                         Kind = AppWidgetKind.Map,
                         Title = "Map",
                         DataBinding = "Assets",

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -337,6 +337,9 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Standalone URL");
             cut.Markup.MarkupMatchesContaining("Custom domain");
             cut.Markup.MarkupMatchesContaining("App builder validation checks");
+            cut.Markup.MarkupMatchesContaining("Cross-widget interactions");
+            cut.Markup.MarkupMatchesContaining("Map feature click");
+            cut.Find("[data-testid='app-builder-interaction-interaction-map-list']");
         });
     }
 


### PR DESCRIPTION
Related to honua-io/honua-portal#5 (partial admin UI slice).

## Summary
- Add cross-widget interaction links to app-builder draft data.
- Seed map-click interactions that filter the chart and list widgets.
- Render interaction links in the canvas pane and validate that interaction endpoints still exist on the canvas.

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "AppBuilderStateTests|AdminPageRenderTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- git diff --check