### PR TITLE
ui: add spec workspace parameter bindings

### DIFF
--- a/src/Honua.Admin/Components/SpecWorkspace/DslPane.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/DslPane.razor
@@ -44,7 +44,7 @@
         {
             <div class="spec-dsl-accordions flex-grow-1 overflow-auto">
                 <MudExpansionPanels MultiExpansion="true">
-                    @foreach (var sectionId in Enum.GetValues<SpecSectionId>())
+                    @foreach (var sectionId in SectionOrder)
                     {
                         <MudExpansionPanel Expanded="true" data-testid="@($"section-{sectionId}")">
                             <TitleContent>
@@ -67,6 +67,15 @@
 @code {
     private bool _busy;
     private bool ActiveWork => State.Status is WorkspaceStatus.Planning or WorkspaceStatus.Applying or WorkspaceStatus.Cancelling;
+    private static readonly SpecSectionId[] SectionOrder =
+    [
+        SpecSectionId.Sources,
+        SpecSectionId.Scope,
+        SpecSectionId.Parameters,
+        SpecSectionId.Compute,
+        SpecSectionId.Map,
+        SpecSectionId.Output
+    ];
 
     protected override void OnInitialized()
     {

--- a/src/Honua.Admin/Components/SpecWorkspace/PlanDagView.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/PlanDagView.razor
@@ -26,6 +26,22 @@
             }
         </MudStack>
 
+        @if (Plan.Parameters.Count > 0)
+        {
+            <MudStack Row Wrap="Wrap.Wrap" Spacing="1" data-testid="plan-parameters">
+                @foreach (var parameter in Plan.Parameters)
+                {
+                    <MudChip T="string"
+                             Size="Size.Small"
+                             Color="Color.Info"
+                             Variant="Variant.Outlined"
+                             data-testid="@($"plan-parameter-{parameter.Name}")">
+                        @($"${parameter.Name}: {parameter.Type} = {parameter.Default ?? "(unset)"}")
+                    </MudChip>
+                }
+            </MudStack>
+        }
+
         <MudExpansionPanels MultiExpansion="true" Dense="true">
             @foreach (var group in Plan.Nodes.GroupBy(n => n.Depth).OrderBy(g => g.Key))
             {

--- a/src/Honua.Admin/Components/SpecWorkspace/SpecWorkspaceBody.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/SpecWorkspaceBody.razor
@@ -23,7 +23,7 @@
                 @($"{GrammarOperatorCount} operators")
             </MudChip>
             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@DraftCoverageColor" data-testid="spec-readiness-draft">
-                @($"{DraftSectionCount}/5 drafted")
+                @($"{DraftSectionCount}/{DraftSectionTotal} drafted")
             </MudChip>
             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Success" data-testid="spec-readiness-plan-apply">
                 plan/apply
@@ -82,14 +82,17 @@
     private int DraftSectionCount =>
         (State.Spec.Sources.Count > 0 ? 1 : 0) +
         (State.Spec.Scope.Bbox is not null || !string.IsNullOrWhiteSpace(State.Spec.Scope.Crs) ? 1 : 0) +
+        (State.Spec.Parameters.Count > 0 ? 1 : 0) +
         (State.Spec.Compute.Count > 0 ? 1 : 0) +
         (State.Spec.Map.Layers.Count > 0 ? 1 : 0) +
         (State.Spec.Output.Kind != SpecOutputKind.None ? 1 : 0);
 
+    private int DraftSectionTotal => Enum.GetValues<SpecSectionId>().Length;
+
     private Color DraftCoverageColor => DraftSectionCount switch
     {
         0 => Color.Default,
-        < 5 => Color.Warning,
+        var count when count < DraftSectionTotal => Color.Warning,
         _ => Color.Success
     };
 

--- a/src/Honua.Admin/Models/SpecWorkspace/ApplyEvent.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/ApplyEvent.cs
@@ -72,6 +72,9 @@ public sealed record ApplyPayload
     [JsonPropertyName("tableColumns")]
     public IReadOnlyList<string> TableColumns { get; init; } = System.Array.Empty<string>();
 
+    [JsonPropertyName("parameterBindings")]
+    public IReadOnlyList<PlanParameterBinding> ParameterBindings { get; init; } = System.Array.Empty<PlanParameterBinding>();
+
     [JsonPropertyName("appScaffold")]
     public AppScaffold? AppScaffold { get; init; }
 }

--- a/src/Honua.Admin/Models/SpecWorkspace/PlanResult.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/PlanResult.cs
@@ -18,6 +18,9 @@ public sealed record PlanResult
     [JsonPropertyName("warnings")]
     public IReadOnlyList<PlanWarning> Warnings { get; init; } = System.Array.Empty<PlanWarning>();
 
+    [JsonPropertyName("parameters")]
+    public IReadOnlyList<PlanParameterBinding> Parameters { get; init; } = System.Array.Empty<PlanParameterBinding>();
+
     [JsonPropertyName("failed")]
     public bool Failed { get; init; }
 
@@ -65,6 +68,13 @@ public sealed record PlanWarning(
     [property: JsonPropertyName("nodeId")] string? NodeId,
     [property: JsonPropertyName("severity")] PlanWarningSeverity Severity,
     [property: JsonPropertyName("message")] string Message);
+
+public sealed record PlanParameterBinding(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("default")] string? Default,
+    [property: JsonPropertyName("required")] bool Required,
+    [property: JsonPropertyName("contentHash")] string ContentHash);
 
 public enum PlanWarningSeverity
 {

--- a/src/Honua.Admin/Models/SpecWorkspace/SpecDocument.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/SpecDocument.cs
@@ -97,10 +97,10 @@ public enum SpecOutputKind
 
 public enum SpecSectionId
 {
-    Sources,
-    Scope,
-    Parameters,
-    Compute,
-    Map,
-    Output
+    Sources = 0,
+    Scope = 1,
+    Compute = 2,
+    Map = 3,
+    Output = 4,
+    Parameters = 5
 }

--- a/src/Honua.Admin/Models/SpecWorkspace/SpecDocument.cs
+++ b/src/Honua.Admin/Models/SpecWorkspace/SpecDocument.cs
@@ -4,9 +4,9 @@ using System.Text.Json.Serialization;
 namespace Honua.Admin.Models.SpecWorkspace;
 
 /// <summary>
-/// Canonical in-memory projection of a spec draft. Five named sections mirror the
-/// S1 walking-skeleton resource set (<c>sources</c>, <c>scope</c>, <c>compute</c>,
-/// <c>map</c>, <c>output</c>). JSON is the authoritative form; text projections
+/// Canonical in-memory projection of a spec draft. Named sections mirror the
+/// walking-skeleton resource set (<c>sources</c>, <c>scope</c>, <c>parameters</c>,
+/// <c>compute</c>, <c>map</c>, <c>output</c>). JSON is the authoritative form; text projections
 /// are derived.
 /// </summary>
 public sealed record SpecDocument
@@ -16,6 +16,9 @@ public sealed record SpecDocument
 
     [JsonPropertyName("scope")]
     public SpecScope Scope { get; init; } = new();
+
+    [JsonPropertyName("parameters")]
+    public IReadOnlyList<SpecParameterEntry> Parameters { get; init; } = System.Array.Empty<SpecParameterEntry>();
 
     [JsonPropertyName("compute")]
     public IReadOnlyList<SpecComputeStep> Compute { get; init; } = System.Array.Empty<SpecComputeStep>();
@@ -32,6 +35,7 @@ public sealed record SpecDocument
     {
         SpecSectionId.Sources => this with { Sources = source.Sources },
         SpecSectionId.Scope => this with { Scope = source.Scope },
+        SpecSectionId.Parameters => this with { Parameters = source.Parameters },
         SpecSectionId.Compute => this with { Compute = source.Compute },
         SpecSectionId.Map => this with { Map = source.Map },
         SpecSectionId.Output => this with { Output = source.Output },
@@ -52,6 +56,12 @@ public sealed record SpecScope
     [JsonPropertyName("crs")]
     public string? Crs { get; init; }
 }
+
+public sealed record SpecParameterEntry(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("default")] string? Default = null,
+    [property: JsonPropertyName("required")] bool Required = false);
 
 public sealed record SpecComputeStep(
     [property: JsonPropertyName("op")] string Op,
@@ -89,6 +99,7 @@ public enum SpecSectionId
 {
     Sources,
     Scope,
+    Parameters,
     Compute,
     Map,
     Output

--- a/src/Honua.Admin/Resources/spec-grammar.v1.json
+++ b/src/Honua.Admin/Resources/spec-grammar.v1.json
@@ -3,9 +3,10 @@
   "sections": [
     { "id": "sources", "title": "Sources", "order": 0 },
     { "id": "scope", "title": "Scope", "order": 1 },
-    { "id": "compute", "title": "Compute", "order": 2 },
-    { "id": "map", "title": "Map", "order": 3 },
-    { "id": "output", "title": "Output", "order": 4 }
+    { "id": "parameters", "title": "Parameters", "order": 2 },
+    { "id": "compute", "title": "Compute", "order": 3 },
+    { "id": "map", "title": "Map", "order": 4 },
+    { "id": "output", "title": "Output", "order": 5 }
   ],
   "operators": [
     {

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecSectionTextTranslator.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecSectionTextTranslator.cs
@@ -325,10 +325,43 @@ internal static class SpecSectionTextTranslator
             return false;
         }
 
+        var required = false;
+        var requiredMatch = Regex.Match(rest, @"(?:^|\s)required=(?<value>\S+)\s*$", RegexOptions.IgnoreCase);
+        if (requiredMatch.Success)
+        {
+            var value = requiredMatch.Groups["value"].Value;
+            if (bool.TryParse(value, out var parsed))
+            {
+                required = parsed;
+            }
+            else
+            {
+                diagnostics.Add(new ValidationDiagnostic(
+                    SpecSectionId.Parameters,
+                    ValidationSeverity.Red,
+                    "invalid-parameter-required",
+                    $"Parameter `{name}` has invalid required flag `{value}`.",
+                    value));
+            }
+
+            rest = rest[..requiredMatch.Index].Trim();
+        }
+
         var equalsIndex = rest.IndexOf('=');
         var type = equalsIndex >= 0 ? rest[..equalsIndex].Trim() : rest;
         var defaultValue = equalsIndex >= 0 ? UnquoteParameterValue(rest[(equalsIndex + 1)..].Trim()) : null;
-        entry = new SpecParameterEntry(name, NormalizeParameterType(type), defaultValue);
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            diagnostics.Add(new ValidationDiagnostic(
+                SpecSectionId.Parameters,
+                ValidationSeverity.Red,
+                "missing-parameter-type",
+                $"Parameter `{name}` is missing a type.",
+                name));
+            type = "string";
+        }
+
+        entry = new SpecParameterEntry(name, NormalizeParameterType(type), defaultValue, required);
         return true;
     }
 

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecSectionTextTranslator.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecSectionTextTranslator.cs
@@ -27,6 +27,7 @@ internal static class SpecSectionTextTranslator
     {
         SpecSectionId.Sources => SerializeSources(document),
         SpecSectionId.Scope => SerializeScope(document),
+        SpecSectionId.Parameters => SerializeParameters(document),
         SpecSectionId.Compute => SerializeCompute(document),
         SpecSectionId.Map => SerializeMap(document),
         SpecSectionId.Output => SerializeOutput(document),
@@ -45,6 +46,9 @@ internal static class SpecSectionTextTranslator
 
             case SpecSectionId.Scope:
                 return new SectionParseResult(current with { Scope = ParseScope(normalized, diagnostics) }, diagnostics);
+
+            case SpecSectionId.Parameters:
+                return new SectionParseResult(current with { Parameters = ParseParameters(normalized, diagnostics) }, diagnostics);
 
             case SpecSectionId.Compute:
                 return new SectionParseResult(current with { Compute = ParseCompute(normalized, diagnostics) }, diagnostics);
@@ -152,6 +156,180 @@ internal static class SpecSectionTextTranslator
         }
 
         return scope;
+    }
+
+    private static IReadOnlyList<SpecParameterEntry> ParseParameters(string text, List<ValidationDiagnostic> diagnostics)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return Array.Empty<SpecParameterEntry>();
+        }
+
+        var entries = new List<SpecParameterEntry>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in EnumerateLines(text))
+        {
+            var trimmed = line.Trim();
+            if (!TryParseParameterLine(trimmed, diagnostics, out var entry))
+            {
+                continue;
+            }
+
+            if (!Regex.IsMatch(entry.Name, @"^[a-zA-Z_][\w-]*$"))
+            {
+                diagnostics.Add(new ValidationDiagnostic(
+                    SpecSectionId.Parameters,
+                    ValidationSeverity.Red,
+                    "invalid-parameter-name",
+                    $"Parameter name `{entry.Name}` must start with a letter or underscore.",
+                    entry.Name));
+                continue;
+            }
+
+            if (!seen.Add(entry.Name))
+            {
+                diagnostics.Add(new ValidationDiagnostic(
+                    SpecSectionId.Parameters,
+                    ValidationSeverity.Red,
+                    "duplicate-parameter",
+                    $"Parameter `{entry.Name}` is defined more than once.",
+                    entry.Name));
+                continue;
+            }
+
+            entries.Add(entry);
+        }
+
+        return entries;
+    }
+
+    private static bool TryParseParameterLine(
+        string line,
+        List<ValidationDiagnostic> diagnostics,
+        out SpecParameterEntry entry)
+    {
+        entry = new SpecParameterEntry(string.Empty, "string");
+
+        if (Regex.IsMatch(line, @"^\$?[a-zA-Z_][\w-]*\s*:")
+            && TryParseColonParameterLine(line, diagnostics, out entry))
+        {
+            return true;
+        }
+
+        var tokens = TokenizeComputeLine(line);
+        if (tokens.Count == 0)
+        {
+            return false;
+        }
+
+        var name = tokens[0].TrimStart('$');
+        string? type = null;
+        string? defaultValue = null;
+        var required = false;
+        foreach (var token in tokens.Skip(1))
+        {
+            var equalsIndex = token.IndexOf('=');
+            if (equalsIndex < 0)
+            {
+                if (type is null)
+                {
+                    type = token;
+                    continue;
+                }
+
+                diagnostics.Add(new ValidationDiagnostic(
+                    SpecSectionId.Parameters,
+                    ValidationSeverity.Red,
+                    "invalid-parameter-token",
+                    $"Expected key=value token in `{line}`.",
+                    token));
+                continue;
+            }
+
+            var key = token[..equalsIndex];
+            var value = token[(equalsIndex + 1)..];
+            switch (key.ToLowerInvariant())
+            {
+                case "type":
+                    type = value;
+                    break;
+
+                case "default":
+                    defaultValue = value;
+                    break;
+
+                case "required":
+                    if (bool.TryParse(value, out var parsed))
+                    {
+                        required = parsed;
+                    }
+                    else
+                    {
+                        diagnostics.Add(new ValidationDiagnostic(
+                            SpecSectionId.Parameters,
+                            ValidationSeverity.Red,
+                            "invalid-parameter-required",
+                            $"Parameter `{name}` has invalid required flag `{value}`.",
+                            value));
+                    }
+                    break;
+
+                default:
+                    diagnostics.Add(new ValidationDiagnostic(
+                        SpecSectionId.Parameters,
+                        ValidationSeverity.Yellow,
+                        "unknown-parameter-key",
+                        $"Unknown parameter field `{key}` is ignored.",
+                        key));
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            diagnostics.Add(new ValidationDiagnostic(
+                SpecSectionId.Parameters,
+                ValidationSeverity.Red,
+                "missing-parameter-type",
+                $"Parameter `{name}` is missing type=.",
+                name));
+            type = "string";
+        }
+
+        entry = new SpecParameterEntry(name, NormalizeParameterType(type), defaultValue, required);
+        return true;
+    }
+
+    private static bool TryParseColonParameterLine(
+        string line,
+        List<ValidationDiagnostic> diagnostics,
+        out SpecParameterEntry entry)
+    {
+        entry = new SpecParameterEntry(string.Empty, "string");
+        var colonIndex = line.IndexOf(':');
+        if (colonIndex < 0)
+        {
+            return false;
+        }
+
+        var name = line[..colonIndex].Trim().TrimStart('$');
+        var rest = line[(colonIndex + 1)..].Trim();
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(rest))
+        {
+            diagnostics.Add(new ValidationDiagnostic(
+                SpecSectionId.Parameters,
+                ValidationSeverity.Red,
+                "invalid-parameter",
+                $"Could not parse parameter line `{line}`.",
+                line));
+            return false;
+        }
+
+        var equalsIndex = rest.IndexOf('=');
+        var type = equalsIndex >= 0 ? rest[..equalsIndex].Trim() : rest;
+        var defaultValue = equalsIndex >= 0 ? UnquoteParameterValue(rest[(equalsIndex + 1)..].Trim()) : null;
+        entry = new SpecParameterEntry(name, NormalizeParameterType(type), defaultValue);
+        return true;
     }
 
     private static IReadOnlyList<SpecComputeStep> ParseCompute(string text, List<ValidationDiagnostic> diagnostics)
@@ -428,6 +606,32 @@ internal static class SpecSectionTextTranslator
         return string.Join(Environment.NewLine, lines);
     }
 
+    private static string SerializeParameters(SpecDocument document)
+    {
+        if (document.Parameters.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return string.Join(
+            Environment.NewLine,
+            document.Parameters.Select(parameter =>
+            {
+                var tokens = new List<string> { $"${parameter.Name}", $"type={parameter.Type}" };
+                if (!string.IsNullOrWhiteSpace(parameter.Default))
+                {
+                    tokens.Add($"default={QuoteComputeValue(parameter.Default)}");
+                }
+
+                if (parameter.Required)
+                {
+                    tokens.Add("required=true");
+                }
+
+                return string.Join(" ", tokens);
+            }));
+    }
+
     private static string SerializeCompute(SpecDocument document)
     {
         if (document.Compute.Count == 0)
@@ -509,6 +713,20 @@ internal static class SpecSectionTextTranslator
         text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Select(line => line.Trim())
             .Where(line => line.Length > 0 && !line.StartsWith('#'));
+
+    private static string NormalizeParameterType(string value) => value.Trim().ToLowerInvariant();
+
+    private static string UnquoteParameterValue(string value)
+    {
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
 
     private static string Normalize(string? text) => text?.Replace("\r\n", "\n", StringComparison.Ordinal) ?? string.Empty;
 }

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecSectionTextTranslator.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecSectionTextTranslator.cs
@@ -175,13 +175,13 @@ internal static class SpecSectionTextTranslator
                 continue;
             }
 
-            if (!Regex.IsMatch(entry.Name, @"^[a-zA-Z_][\w-]*$"))
+            if (!Regex.IsMatch(entry.Name, @"^[a-zA-Z_]\w*$"))
             {
                 diagnostics.Add(new ValidationDiagnostic(
                     SpecSectionId.Parameters,
                     ValidationSeverity.Red,
                     "invalid-parameter-name",
-                    $"Parameter name `{entry.Name}` must start with a letter or underscore.",
+                    $"Parameter name `{entry.Name}` must use letters, numbers, or underscores and start with a letter or underscore.",
                     entry.Name));
                 continue;
             }
@@ -210,7 +210,7 @@ internal static class SpecSectionTextTranslator
     {
         entry = new SpecParameterEntry(string.Empty, "string");
 
-        if (Regex.IsMatch(line, @"^\$?[a-zA-Z_][\w-]*\s*:")
+        if (Regex.IsMatch(line, @"^\$?[a-zA-Z_]\w*\s*:")
             && TryParseColonParameterLine(line, diagnostics, out entry))
         {
             return true;

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecWorkspaceState.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecWorkspaceState.cs
@@ -964,6 +964,7 @@ public sealed class SpecWorkspaceState : IAsyncDisposable
         {
             SpecSectionId.Sources => "source",
             SpecSectionId.Scope => "scope field",
+            SpecSectionId.Parameters => "parameter",
             SpecSectionId.Compute => "compute step",
             SpecSectionId.Map => "map layer",
             SpecSectionId.Output => "output field",

--- a/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
@@ -305,6 +305,11 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
         var nodes = new List<PlanNode>();
         var warnings = new List<PlanWarning>();
+        var parameterBindings = BuildParameterBindings(document.Parameters);
+        var parameterDefaults = document.Parameters
+            .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        var parameterHash = BuildParameterSetHash(document.Parameters);
         var nodeHashes = new Dictionary<string, string>(StringComparer.Ordinal);
         var depth = 0;
         foreach (var source in document.Sources)
@@ -364,7 +369,9 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 step.Op,
                 string.Join(",", step.Inputs.OrderBy(input => input, StringComparer.Ordinal)),
                 string.Join(",", inputHashes),
-                string.Join(",", step.Args.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"{kv.Key}={kv.Value}")));
+                string.Join(",", step.Args
+                    .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => $"{kv.Key}={ResolveParameterReferences(kv.Value, parameterDefaults)}")));
             nodeHashes[nodeId] = computeHash;
             nodes.Add(new PlanNode
             {
@@ -411,7 +418,8 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 "output",
                 effectiveOutputKind.ToString(),
                 document.Output.Target ?? "preview",
-                string.Join(",", outputInputs.Select(input => ResolveNodeHash(nodeHashes, input))));
+                string.Join(",", outputInputs.Select(input => ResolveNodeHash(nodeHashes, input))),
+                parameterHash);
             nodes.Add(new PlanNode
             {
                 Id = outputId,
@@ -431,7 +439,8 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         {
             JobId = Guid.NewGuid().ToString("n"),
             Nodes = nodes,
-            Warnings = warnings
+            Warnings = warnings,
+            Parameters = parameterBindings
         });
     }
 
@@ -549,6 +558,9 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             SpecSectionId.Scope => document.Scope.Bbox is null && document.Scope.Crs is null
                 ? "global, no CRS pinned"
                 : $"crs={document.Scope.Crs ?? "default"}",
+            SpecSectionId.Parameters => document.Parameters.Count == 0
+                ? "no parameters bound"
+                : $"{document.Parameters.Count} parameter(s)",
             SpecSectionId.Compute => document.Compute.Count == 0
                 ? "no compute steps"
                 : string.Join(" → ", document.Compute.Select(c => c.Op)),
@@ -654,6 +666,14 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
                 }
             }
 
+            foreach (var parameterName in ExtractParameterReferences(step.Args.Values))
+            {
+                if (!document.Parameters.Any(p => string.Equals(p.Name, parameterName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    diagnostics.Add(new ValidationDiagnostic(SpecSectionId.Compute, ValidationSeverity.Red, "unknown-parameter", $"parameter '${parameterName}' is not declared", parameterName));
+                }
+            }
+
             if (step.Op == "aggregate" && step.Args.TryGetValue("by", out var by))
             {
                 var columnRef = by.TrimStart('@');
@@ -680,6 +700,32 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             {
                 diagnostics.Add(new ValidationDiagnostic(SpecSectionId.Compute, ValidationSeverity.Yellow, "non-deterministic-op", "join can produce non-deterministic row ordering in the stub", "join"));
             }
+        }
+
+        foreach (var parameter in document.Parameters)
+        {
+            if (!IsSupportedParameterType(parameter.Type))
+            {
+                diagnostics.Add(new ValidationDiagnostic(SpecSectionId.Parameters, ValidationSeverity.Red, "unknown-parameter-type", $"parameter '{parameter.Name}' has unsupported type '{parameter.Type}'", parameter.Type));
+            }
+
+            if (parameter.Required && string.IsNullOrWhiteSpace(parameter.Default))
+            {
+                diagnostics.Add(new ValidationDiagnostic(SpecSectionId.Parameters, ValidationSeverity.Yellow, "required-parameter-unbound", $"required parameter '{parameter.Name}' has no default binding", parameter.Name));
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameter.Default) && !DefaultMatchesParameterType(parameter))
+            {
+                diagnostics.Add(new ValidationDiagnostic(SpecSectionId.Parameters, ValidationSeverity.Red, "parameter-default-type-mismatch", $"default for '{parameter.Name}' does not match {parameter.Type}", parameter.Default));
+            }
+        }
+
+        foreach (var duplicate in document.Parameters
+            .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key))
+        {
+            diagnostics.Add(new ValidationDiagnostic(SpecSectionId.Parameters, ValidationSeverity.Red, "duplicate-parameter", $"parameter '{duplicate}' is declared more than once", duplicate));
         }
 
         if (document.Scope.Crs is { Length: > 0 } crs && !(crs.StartsWith("EPSG:", StringComparison.OrdinalIgnoreCase) || crs.Equals("WGS84", StringComparison.OrdinalIgnoreCase)))
@@ -926,6 +972,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         {
             SpecSectionId.Sources => (object)doc.Sources,
             SpecSectionId.Scope => doc.Scope,
+            SpecSectionId.Parameters => doc.Parameters,
             SpecSectionId.Compute => doc.Compute,
             SpecSectionId.Map => doc.Map,
             SpecSectionId.Output => doc.Output,
@@ -1046,6 +1093,30 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
         _ => PlanMaterializationKind.Ephemeral
     };
 
+    private static IReadOnlyList<PlanParameterBinding> BuildParameterBindings(IReadOnlyList<SpecParameterEntry> parameters) =>
+        parameters
+            .OrderBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(parameter => new PlanParameterBinding(
+                parameter.Name,
+                parameter.Type,
+                parameter.Default,
+                parameter.Required,
+                BuildContentHash(
+                    "parameter",
+                    parameter.Name.ToLowerInvariant(),
+                    parameter.Type.ToLowerInvariant(),
+                    parameter.Default ?? string.Empty,
+                    parameter.Required ? "true" : "false")))
+            .ToArray();
+
+    private static string BuildParameterSetHash(IReadOnlyList<SpecParameterEntry> parameters) =>
+        BuildContentHash(
+            "parameters",
+            string.Join(
+                ",",
+                BuildParameterBindings(parameters)
+                    .Select(parameter => $"{parameter.Name}:{parameter.Type}:{parameter.Default}:{parameter.Required}:{parameter.ContentHash}")));
+
     private static MaterializedResource? BuildMaterializedResource(PlanNode node)
     {
         if (node.Materialization is not (PlanMaterializationKind.DurableApp or PlanMaterializationKind.DurableDataset or PlanMaterializationKind.DurableService))
@@ -1067,17 +1138,66 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
     private static string ResolveNodeHash(IReadOnlyDictionary<string, string> nodeHashes, string nodeId) =>
         nodeHashes.TryGetValue(nodeId, out var hash) ? hash : nodeId;
 
+    private static string ResolveParameterReferences(
+        string value,
+        IReadOnlyDictionary<string, SpecParameterEntry> parameters) =>
+        Regex.Replace(value, @"\$([a-zA-Z_][\w-]*)", match =>
+        {
+            var name = match.Groups[1].Value;
+            if (!parameters.TryGetValue(name, out var parameter))
+            {
+                return match.Value;
+            }
+
+            return $"{parameter.Name}:{parameter.Type}:{parameter.Default ?? string.Empty}:{parameter.Required}";
+        });
+
+    private static IReadOnlyList<string> ExtractParameterReferences(IEnumerable<string> values) =>
+        values
+            .SelectMany(value => Regex.Matches(value, @"\$([a-zA-Z_][\w-]*)").Select(match => match.Groups[1].Value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static bool IsSupportedParameterType(string type) =>
+        type.ToLowerInvariant() is "string" or "number" or "boolean" or "date" or "quantity" or "enum";
+
+    private static bool DefaultMatchesParameterType(SpecParameterEntry parameter)
+    {
+        var value = parameter.Default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        return parameter.Type.ToLowerInvariant() switch
+        {
+            "number" => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _),
+            "boolean" => bool.TryParse(value, out _),
+            "quantity" => Regex.IsMatch(value, @"^\d+(?:\.\d+)?(m|km|mi)$", RegexOptions.IgnoreCase),
+            _ => true
+        };
+    }
+
     private ApplyPayload BuildPayload(SpecDocument document)
     {
         var effectiveOutputKind = ResolveEffectiveOutputKind(document);
+        var parameterBindings = BuildParameterBindings(document.Parameters);
         if (effectiveOutputKind == SpecOutputKind.AppScaffold)
         {
+            var scaffoldParameters = document.Parameters.Count > 0
+                ? document.Parameters
+                    .OrderBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(parameter => new AppScaffoldParameter(parameter.Name, parameter.Type, parameter.Default))
+                    .ToArray()
+                : new[] { new AppScaffoldParameter("date", "date", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)) };
+
             return new ApplyPayload
             {
                 Kind = SpecOutputKind.AppScaffold,
+                ParameterBindings = parameterBindings,
                 AppScaffold = new AppScaffold(
                     "Preview App",
-                    new[] { new AppScaffoldParameter("date", "date", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)) },
+                    scaffoldParameters,
                     "single-column")
             };
         }
@@ -1097,6 +1217,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             return new ApplyPayload
             {
                 Kind = SpecOutputKind.Map,
+                ParameterBindings = parameterBindings,
                 MapFeatures = features
             };
         }
@@ -1127,6 +1248,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             return new ApplyPayload
             {
                 Kind = SpecOutputKind.Analysis,
+                ParameterBindings = parameterBindings,
                 TableColumns = new[] { groupBy, metric },
                 TableRows = rows
             };
@@ -1151,6 +1273,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
             return new ApplyPayload
             {
                 Kind = SpecOutputKind.Analysis,
+                ParameterBindings = parameterBindings,
                 TableColumns = new[] { "id", "status" },
                 TableRows = rows
             };
@@ -1158,7 +1281,8 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
         return new ApplyPayload
         {
-            Kind = SpecOutputKind.None
+            Kind = SpecOutputKind.None,
+            ParameterBindings = parameterBindings
         };
     }
 

--- a/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/StubSpecWorkspaceClient.cs
@@ -1141,7 +1141,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
     private static string ResolveParameterReferences(
         string value,
         IReadOnlyDictionary<string, SpecParameterEntry> parameters) =>
-        Regex.Replace(value, @"\$([a-zA-Z_][\w-]*)", match =>
+        Regex.Replace(value, @"\$([a-zA-Z_]\w*)", match =>
         {
             var name = match.Groups[1].Value;
             if (!parameters.TryGetValue(name, out var parameter))
@@ -1154,7 +1154,7 @@ public sealed partial class StubSpecWorkspaceClient : ISpecWorkspaceClient
 
     private static IReadOnlyList<string> ExtractParameterReferences(IEnumerable<string> values) =>
         values
-            .SelectMany(value => Regex.Matches(value, @"\$([a-zA-Z_][\w-]*)").Select(match => match.Groups[1].Value))
+            .SelectMany(value => Regex.Matches(value, @"\$([a-zA-Z_]\w*)").Select(match => match.Groups[1].Value))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -272,7 +272,7 @@ public sealed class AdminPageRenderTests : TestContext
         {
             cut.Markup.MarkupMatchesContaining("Spec workspace S1");
             cut.Markup.MarkupMatchesContaining("grammar v1");
-            cut.Markup.MarkupMatchesContaining("5 sections");
+            cut.Markup.MarkupMatchesContaining("6 sections");
             cut.Markup.MarkupMatchesContaining("plan/apply");
             cut.Markup.MarkupMatchesContaining("map/table/app preview");
             cut.Find("[aria-label='Spec workspace S1 readiness']");
@@ -283,12 +283,15 @@ public sealed class AdminPageRenderTests : TestContext
 
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.MarkupMatchesContaining("1/5 drafted");
+            cut.Markup.MarkupMatchesContaining("1/6 drafted");
             cut.Markup.MarkupMatchesContaining("Draft changes");
             var sourceChange = cut.Find("[data-testid='spec-change-Sources']");
             Assert.Equal("Added", sourceChange.GetAttribute("data-status"));
         });
 
+        await cut.InvokeAsync(() => state.UpdateSectionTextAsync(
+            SpecSectionId.Parameters,
+            "$county type=string default=Honolulu"));
         await cut.InvokeAsync(() => state.UpdateSectionTextAsync(
             SpecSectionId.Compute,
             "aggregate inputs=@parcels by=@parcels.county metric=count"));
@@ -301,8 +304,10 @@ public sealed class AdminPageRenderTests : TestContext
         {
             cut.Markup.MarkupMatchesContaining("content-hash");
             cut.Markup.MarkupMatchesContaining("durable app");
+            cut.Markup.MarkupMatchesContaining("$county: string = Honolulu");
             cut.Find("[data-testid='dag-node-cache-aggregate-1']");
             cut.Find("[data-testid='dag-node-materialization-output-appscaffold']");
+            cut.Find("[data-testid='plan-parameter-county']");
         });
     }
 

--- a/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
@@ -59,6 +59,27 @@ public sealed class SpecWorkspaceStateTests
     }
 
     [Fact]
+    public async Task Parameters_section_parses_defaults_and_required_bindings()
+    {
+        var storage = new MemoryBrowserStorageService();
+        var state = new SpecWorkspaceState(
+            new StubSpecWorkspaceClient(),
+            storage,
+            new NullSpecWorkspaceTelemetry(),
+            new CatalogCache());
+
+        await state.InitializeAsync("operator");
+        await state.UpdateSectionTextAsync(SpecSectionId.Parameters, "$county type=string default=\"Big Island\" required=true");
+
+        var parameter = Assert.Single(state.Spec.Parameters);
+        Assert.Equal("county", parameter.Name);
+        Assert.Equal("string", parameter.Type);
+        Assert.Equal("Big Island", parameter.Default);
+        Assert.True(parameter.Required);
+        Assert.DoesNotContain(state.Diagnostics, d => d.Section == SpecSectionId.Parameters && d.Severity == ValidationSeverity.Red);
+    }
+
+    [Fact]
     public async Task ClearDraftAsync_cancels_in_flight_apply_and_leaves_idle_empty_state()
     {
         var storage = new MemoryBrowserStorageService();

--- a/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
@@ -80,6 +80,38 @@ public sealed class SpecWorkspaceStateTests
     }
 
     [Fact]
+    public async Task Parameters_section_parses_required_flag_from_colon_style_lines()
+    {
+        var storage = new MemoryBrowserStorageService();
+        var state = new SpecWorkspaceState(
+            new StubSpecWorkspaceClient(),
+            storage,
+            new NullSpecWorkspaceTelemetry(),
+            new CatalogCache());
+
+        await state.InitializeAsync("operator");
+        await state.UpdateSectionTextAsync(
+            SpecSectionId.Parameters,
+            "$county: string = Honolulu required=true\n$start_date: date required=true");
+
+        Assert.Collection(
+            state.Spec.Parameters,
+            county =>
+            {
+                Assert.Equal("county", county.Name);
+                Assert.Equal("Honolulu", county.Default);
+                Assert.True(county.Required);
+            },
+            startDate =>
+            {
+                Assert.Equal("start_date", startDate.Name);
+                Assert.Null(startDate.Default);
+                Assert.True(startDate.Required);
+            });
+        Assert.DoesNotContain(state.Diagnostics, d => d.Section == SpecSectionId.Parameters && d.Severity == ValidationSeverity.Red);
+    }
+
+    [Fact]
     public async Task ClearDraftAsync_cancels_in_flight_apply_and_leaves_idle_empty_state()
     {
         var storage = new MemoryBrowserStorageService();

--- a/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
+++ b/tests/Honua.Admin.Tests/SpecWorkspaceStateTests.cs
@@ -7,6 +7,17 @@ namespace Honua.Admin.Tests;
 public sealed class SpecWorkspaceStateTests
 {
     [Fact]
+    public void SpecSectionId_keeps_legacy_serialized_values()
+    {
+        Assert.Equal(0, (int)SpecSectionId.Sources);
+        Assert.Equal(1, (int)SpecSectionId.Scope);
+        Assert.Equal(2, (int)SpecSectionId.Compute);
+        Assert.Equal(3, (int)SpecSectionId.Map);
+        Assert.Equal(4, (int)SpecSectionId.Output);
+        Assert.Equal(5, (int)SpecSectionId.Parameters);
+    }
+
+    [Fact]
     public async Task InsertDslTokenAsync_replaces_the_active_editor_selection()
     {
         var storage = new MemoryBrowserStorageService();

--- a/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
@@ -124,6 +124,22 @@ public sealed class StubSpecWorkspaceClientTests
     }
 
     [Fact]
+    public async Task PlanAsync_treats_subtraction_after_parameter_reference_as_expression_text()
+    {
+        var first = BuildFilterDocument("10", "@parcels.acreage>$limit-5", "limit");
+        var second = BuildFilterDocument("20", "@parcels.acreage>$limit-5", "limit");
+
+        var diagnostics = _client.Validate(first);
+        var firstPlan = await _client.PlanAsync(first, CancellationToken.None);
+        var secondPlan = await _client.PlanAsync(second, CancellationToken.None);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Code == "unknown-parameter");
+        Assert.NotEqual(
+            Assert.Single(firstPlan.Nodes, node => node.Op == "filter").ContentHash,
+            Assert.Single(secondPlan.Nodes, node => node.Op == "filter").ContentHash);
+    }
+
+    [Fact]
     public async Task PlanAndApply_expose_parameter_bindings_for_app_scaffolds()
     {
         var document = BuildAppScaffoldDocument() with
@@ -310,20 +326,24 @@ public sealed class StubSpecWorkspaceClientTests
         Output = new SpecOutput { Kind = SpecOutputKind.AppScaffold, Target = "preview" }
     };
 
-    private static SpecDocument BuildFilterDocument(string countyDefault) => new()
-    {
-        Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
-        Parameters = new[] { new SpecParameterEntry("county", "string", countyDefault) },
-        Compute = new[]
+    private static SpecDocument BuildFilterDocument(
+        string defaultValue,
+        string where = "@parcels.county=$county",
+        string parameterName = "county")
+        => new()
         {
-            new SpecComputeStep(
-                "filter",
-                new[] { "parcels" },
-                new Dictionary<string, string>(StringComparer.Ordinal)
-                {
-                    ["where"] = "@parcels.county=$county"
-                })
-        },
-        Output = new SpecOutput { Kind = SpecOutputKind.Analysis, Target = "preview" }
-    };
+            Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
+            Parameters = new[] { new SpecParameterEntry(parameterName, "string", defaultValue) },
+            Compute = new[]
+            {
+                new SpecComputeStep(
+                    "filter",
+                    new[] { "parcels" },
+                    new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["where"] = where
+                    })
+            },
+            Output = new SpecOutput { Kind = SpecOutputKind.Analysis, Target = "preview" }
+        };
 }

--- a/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
+++ b/tests/Honua.Admin.Tests/StubSpecWorkspaceClientTests.cs
@@ -109,6 +109,46 @@ public sealed class StubSpecWorkspaceClientTests
     }
 
     [Fact]
+    public async Task PlanAsync_includes_parameter_defaults_in_compute_cache_hash()
+    {
+        var first = BuildFilterDocument("Alpha");
+        var second = BuildFilterDocument("Beta");
+
+        var firstPlan = await _client.PlanAsync(first, CancellationToken.None);
+        var secondPlan = await _client.PlanAsync(second, CancellationToken.None);
+
+        var firstFilter = Assert.Single(firstPlan.Nodes, node => node.Op == "filter");
+        var secondFilter = Assert.Single(secondPlan.Nodes, node => node.Op == "filter");
+
+        Assert.NotEqual(firstFilter.ContentHash, secondFilter.ContentHash);
+    }
+
+    [Fact]
+    public async Task PlanAndApply_expose_parameter_bindings_for_app_scaffolds()
+    {
+        var document = BuildAppScaffoldDocument() with
+        {
+            Parameters = new[] { new SpecParameterEntry("county", "string", "Honolulu", Required: true) }
+        };
+
+        var plan = await _client.PlanAsync(document, CancellationToken.None);
+        var binding = Assert.Single(plan.Parameters);
+
+        Assert.Equal("county", binding.Name);
+        Assert.Equal("string", binding.Type);
+        Assert.Equal("Honolulu", binding.Default);
+        Assert.True(binding.Required);
+        Assert.StartsWith("sha256:", binding.ContentHash, StringComparison.Ordinal);
+
+        var payload = await CollectCompletedPayloadAsync(document);
+        var scaffoldParameter = Assert.Single(payload!.AppScaffold!.Parameters);
+
+        Assert.Equal("county", scaffoldParameter.Name);
+        Assert.Equal("Honolulu", scaffoldParameter.Default);
+        Assert.Single(payload.ParameterBindings);
+    }
+
+    [Fact]
     public async Task PlanAsync_uses_output_kind_for_app_scaffold_inputs_when_map_layers_exist()
     {
         var document = BuildAppScaffoldDocument() with
@@ -268,5 +308,22 @@ public sealed class StubSpecWorkspaceClientTests
                 })
         },
         Output = new SpecOutput { Kind = SpecOutputKind.AppScaffold, Target = "preview" }
+    };
+
+    private static SpecDocument BuildFilterDocument(string countyDefault) => new()
+    {
+        Sources = new[] { new SpecSourceEntry("parcels", "parcels", "v1") },
+        Parameters = new[] { new SpecParameterEntry("county", "string", countyDefault) },
+        Compute = new[]
+        {
+            new SpecComputeStep(
+                "filter",
+                new[] { "parcels" },
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["where"] = "@parcels.county=$county"
+                })
+        },
+        Output = new SpecOutput { Kind = SpecOutputKind.Analysis, Target = "preview" }
     };
 }


### PR DESCRIPTION
## Summary
- add a spec workspace parameters section to the canonical document and embedded grammar
- parse/serialize parameter defaults and required bindings in the DSL editor
- surface parameter binding metadata in plan/apply payloads and app scaffold preview

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "SpecWorkspaceStateTests|StubSpecWorkspaceClientTests|AdminPageRenderTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1

Related to #25 (partial admin UI slice).