### PR TITLE
ui: add open data usage feedback summaries

### DIFF
--- a/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
+++ b/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
@@ -37,6 +37,21 @@ public enum OpenDataCodeLanguage
     Python
 }
 
+public enum OpenDataFeedbackSeverity
+{
+    Low,
+    Medium,
+    High
+}
+
+public enum OpenDataFeedbackStatus
+{
+    New,
+    Triaged,
+    Accepted,
+    Resolved
+}
+
 public sealed record OpenDataHubSnapshot
 {
     public IReadOnlyList<OpenDataDataset> Datasets { get; init; } = Array.Empty<OpenDataDataset>();
@@ -66,6 +81,8 @@ public sealed record OpenDataDataset
     public IReadOnlyList<OpenDataDownloadOption> Downloads { get; init; } = Array.Empty<OpenDataDownloadOption>();
     public IReadOnlyList<OpenDataApiEndpoint> ApiEndpoints { get; init; } = Array.Empty<OpenDataApiEndpoint>();
     public OpenDataEmbedConfig EmbedConfig { get; init; } = new();
+    public OpenDataUsageSummary Usage { get; init; } = new();
+    public IReadOnlyList<OpenDataFeedbackReport> FeedbackReports { get; init; } = Array.Empty<OpenDataFeedbackReport>();
 }
 
 public sealed record OpenDataApiAccess
@@ -112,6 +129,31 @@ public sealed record OpenDataEmbedConfig
     public string BrandingMode { get; init; } = string.Empty;
     public bool Responsive { get; init; }
     public bool WcagReady { get; init; }
+}
+
+public sealed record OpenDataUsageSummary
+{
+    public int DownloadsLast30Days { get; init; }
+    public int ApiCallsLast30Days { get; init; }
+    public int UniqueConsumersLast30Days { get; init; }
+    public DateTimeOffset? LastApiCallAt { get; init; }
+    public IReadOnlyList<OpenDataFormatUsage> PopularFormats { get; init; } = Array.Empty<OpenDataFormatUsage>();
+}
+
+public sealed record OpenDataFormatUsage
+{
+    public OpenDataDownloadFormat Format { get; init; }
+    public int DownloadsLast30Days { get; init; }
+}
+
+public sealed record OpenDataFeedbackReport
+{
+    public string ReportId { get; init; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; init; }
+    public string Reporter { get; init; } = string.Empty;
+    public OpenDataFeedbackSeverity Severity { get; init; }
+    public OpenDataFeedbackStatus Status { get; init; }
+    public string Summary { get; init; } = string.Empty;
 }
 
 public sealed record OpenDataHubMetric

--- a/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
+++ b/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
@@ -178,6 +178,39 @@
                     }
                 </div>
 
+                <MudText Typo="Typo.h6" Class="mt-4">Usage analytics</MudText>
+                <div class="open-data-usage-grid" aria-label="Open data usage analytics">
+                    <div data-testid="open-data-usage-downloads">
+                        <span>30-day downloads</span>
+                        <strong>@FormatCount(selected.Usage.DownloadsLast30Days)</strong>
+                    </div>
+                    <div data-testid="open-data-usage-api-calls">
+                        <span>30-day API calls</span>
+                        <strong>@FormatCount(selected.Usage.ApiCallsLast30Days)</strong>
+                    </div>
+                    <div data-testid="open-data-usage-consumers">
+                        <span>Unique consumers</span>
+                        <strong>@FormatCount(selected.Usage.UniqueConsumersLast30Days)</strong>
+                    </div>
+                    <div data-testid="open-data-usage-last-api-call">
+                        <span>Last API call</span>
+                        <strong>@FormatApiDate(selected.Usage.LastApiCallAt)</strong>
+                    </div>
+                </div>
+                @if (selected.Usage.PopularFormats.Count > 0)
+                {
+                    <div class="open-data-usage-formats" aria-label="Open data popular formats">
+                        @foreach (var format in selected.Usage.PopularFormats)
+                        {
+                            <div class="open-data-usage-format" data-testid="@($"open-data-format-usage-{format.Format}")">
+                                <MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Small" />
+                                <span>@FormatDownload(format.Format)</span>
+                                <strong>@FormatCount(format.DownloadsLast30Days)</strong>
+                            </div>
+                        }
+                    </div>
+                }
+
                 <MudText Typo="Typo.h6" Class="mt-4">Preview response</MudText>
                 <pre class="open-data-code" aria-label="Open data sample API response"><code>@selected.SampleResponse</code></pre>
             </section>
@@ -277,6 +310,36 @@
                     </div>
                 </div>
 
+                <div class="open-data-feedback" aria-label="Open data feedback reports">
+                    <MudText Typo="Typo.subtitle2">Feedback and data quality</MudText>
+                    @if (selected.FeedbackReports.Count == 0)
+                    {
+                        <div class="open-data-empty" data-testid="open-data-feedback-empty">
+                            No feedback reports are open for this dataset.
+                        </div>
+                    }
+                    else
+                    {
+                        @foreach (var report in selected.FeedbackReports.OrderByDescending(report => report.CreatedAt))
+                        {
+                            <article class="open-data-feedback-row" data-testid="@($"open-data-feedback-{report.ReportId}")">
+                                <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudChip T="string" Size="Size.Small" Color="@FeedbackSeverityColor(report.Severity)" Variant="Variant.Outlined">
+                                        @report.Severity
+                                    </MudChip>
+                                    <MudChip T="string" Size="Size.Small" Color="@FeedbackStatusColor(report.Status)" Variant="Variant.Outlined">
+                                        @report.Status
+                                    </MudChip>
+                                    <MudSpacer />
+                                    <small>@FormatApiDate(report.CreatedAt)</small>
+                                </MudStack>
+                                <strong>@report.Summary</strong>
+                                <span>@report.Reporter</span>
+                            </article>
+                        }
+                    }
+                </div>
+
                 <div class="open-data-validation" aria-label="Open data validation checks">
                     <MudText Typo="Typo.subtitle2">Readiness checks</MudText>
                     @foreach (var check in State.ValidationChecks)
@@ -354,6 +417,13 @@
         return $"{bytes / 1_000d:0.0} KB";
     }
 
+    private static string FormatCount(int value)
+        => value >= 1_000_000
+            ? $"{value / 1_000_000d:0.0}M"
+            : value >= 1_000
+                ? $"{value / 1_000d:0.0}k"
+                : value.ToString("n0", CultureInfo.CurrentCulture);
+
     private static string FormatApiDate(DateTimeOffset? value)
         => value?.ToLocalTime().ToString("MMM d, yyyy", CultureInfo.CurrentCulture) ?? "not recorded";
 
@@ -372,6 +442,21 @@
         OpenDataDatasetStatus.Scheduled => Color.Info,
         OpenDataDatasetStatus.InReview => Color.Warning,
         OpenDataDatasetStatus.Blocked => Color.Error,
+        _ => Color.Default
+    };
+
+    private static Color FeedbackSeverityColor(OpenDataFeedbackSeverity severity) => severity switch
+    {
+        OpenDataFeedbackSeverity.High => Color.Error,
+        OpenDataFeedbackSeverity.Medium => Color.Warning,
+        _ => Color.Info
+    };
+
+    private static Color FeedbackStatusColor(OpenDataFeedbackStatus status) => status switch
+    {
+        OpenDataFeedbackStatus.Resolved => Color.Success,
+        OpenDataFeedbackStatus.Accepted => Color.Warning,
+        OpenDataFeedbackStatus.Triaged => Color.Info,
         _ => Color.Default
     };
 }

--- a/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
@@ -217,8 +217,111 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
                 BrandingMode = "White label",
                 Responsive = true,
                 WcagReady = embedEnabled
-            }
+            },
+            Usage = UsageFor(datasetId, apiEnabled),
+            FeedbackReports = FeedbackReportsFor(datasetId, status)
         };
+    }
+
+    private static OpenDataUsageSummary UsageFor(string datasetId, bool apiEnabled)
+    {
+        var seed = DeterministicSeed(Slug(datasetId));
+        var downloadBase = 240 + seed % 920;
+        var apiBase = apiEnabled ? 8_000 + seed % 38_000 : seed % 900;
+        return new OpenDataUsageSummary
+        {
+            DownloadsLast30Days = downloadBase,
+            ApiCallsLast30Days = apiBase,
+            UniqueConsumersLast30Days = apiEnabled ? 38 + seed % 180 : 4 + seed % 18,
+            LastApiCallAt = apiEnabled ? DateTimeOffset.Parse("2026-04-27T22:15:00Z") : null,
+            PopularFormats =
+            [
+                new OpenDataFormatUsage
+                {
+                    Format = OpenDataDownloadFormat.GeoJson,
+                    DownloadsLast30Days = Math.Max(downloadBase / 2, 1)
+                },
+                new OpenDataFormatUsage
+                {
+                    Format = OpenDataDownloadFormat.Csv,
+                    DownloadsLast30Days = Math.Max(downloadBase / 3, 1)
+                },
+                new OpenDataFormatUsage
+                {
+                    Format = OpenDataDownloadFormat.GeoParquet,
+                    DownloadsLast30Days = Math.Max(downloadBase / 5, 1)
+                }
+            ]
+        };
+    }
+
+    private static IReadOnlyList<OpenDataFeedbackReport> FeedbackReportsFor(string datasetId, OpenDataDatasetStatus status)
+    {
+        var slug = Slug(datasetId);
+        if (status == OpenDataDatasetStatus.Published)
+        {
+            return
+            [
+                new OpenDataFeedbackReport
+                {
+                    ReportId = $"{slug}-quality-1",
+                    CreatedAt = DateTimeOffset.Parse("2026-04-25T15:20:00Z"),
+                    Reporter = "civic-apps@honua.local",
+                    Severity = OpenDataFeedbackSeverity.Medium,
+                    Status = OpenDataFeedbackStatus.Triaged,
+                    Summary = "Several public API users report stale asset status values near pier 4."
+                },
+                new OpenDataFeedbackReport
+                {
+                    ReportId = $"{slug}-schema-2",
+                    CreatedAt = DateTimeOffset.Parse("2026-04-22T09:00:00Z"),
+                    Reporter = "data-quality@honua.local",
+                    Severity = OpenDataFeedbackSeverity.Low,
+                    Status = OpenDataFeedbackStatus.Resolved,
+                    Summary = "Column description for asset_type was missing from the catalog metadata."
+                }
+            ];
+        }
+
+        if (status == OpenDataDatasetStatus.Blocked)
+        {
+            return
+            [
+                new OpenDataFeedbackReport
+                {
+                    ReportId = $"{slug}-license-1",
+                    CreatedAt = DateTimeOffset.Parse("2026-04-26T18:05:00Z"),
+                    Reporter = "review@honua.local",
+                    Severity = OpenDataFeedbackSeverity.High,
+                    Status = OpenDataFeedbackStatus.Accepted,
+                    Summary = "License terms conflict with public download requirements."
+                }
+            ];
+        }
+
+        return
+        [
+            new OpenDataFeedbackReport
+            {
+                ReportId = $"{slug}-review-1",
+                CreatedAt = DateTimeOffset.Parse("2026-04-24T13:45:00Z"),
+                Reporter = "publisher@honua.local",
+                Severity = OpenDataFeedbackSeverity.Medium,
+                Status = OpenDataFeedbackStatus.New,
+                Summary = "Review requested for geography label and sample response coverage."
+            }
+        ];
+    }
+
+    private static int DeterministicSeed(string value)
+    {
+        var seed = 17;
+        foreach (var character in value)
+        {
+            seed = unchecked(seed * 31 + character);
+        }
+
+        return seed == int.MinValue ? int.MaxValue : Math.Abs(seed);
     }
 
     private static IReadOnlyList<OpenDataCodeExample> CodeExamples(string slug, string stacCollectionId) =>

--- a/src/Honua.Admin/wwwroot/css/open-data-hub.css
+++ b/src/Honua.Admin/wwwroot/css/open-data-hub.css
@@ -56,11 +56,15 @@
 .open-data-dataset small,
 .open-data-dataset em,
 .open-data-metadata-grid span,
+.open-data-usage-grid span,
+.open-data-usage-format span,
 .open-data-delivery-row span,
 .open-data-api-row span,
 .open-data-validation-row span,
 .open-data-embed-preview span,
-.open-data-embed-preview small {
+.open-data-embed-preview small,
+.open-data-feedback-row span,
+.open-data-feedback-row small {
     color: var(--mud-palette-text-secondary, #607d8b);
 }
 
@@ -170,6 +174,65 @@
     flex-wrap: wrap;
     gap: 6px;
     margin-top: 12px;
+}
+
+.open-data-usage-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.open-data-usage-grid div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 3px;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+    background: #f8fbff;
+}
+
+.open-data-usage-grid strong {
+    font-size: 1.25rem;
+    line-height: 1.2;
+}
+
+.open-data-usage-formats,
+.open-data-feedback {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.open-data-usage-format,
+.open-data-feedback-row {
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-radius: 6px;
+    padding: 10px;
+    background: #ffffff;
+}
+
+.open-data-usage-format {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+}
+
+.open-data-feedback-row {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.open-data-feedback-row strong,
+.open-data-feedback-row span {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .open-data-code {
@@ -282,6 +345,7 @@
 
     .open-data-metrics,
     .open-data-metadata-grid,
+    .open-data-usage-grid,
     .open-data-api-row,
     .open-data-api-access {
         grid-template-columns: 1fr;

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -26,6 +26,9 @@ public sealed class OpenDataHubStateTests
         Assert.Equal("harbor-assets", state.SelectedDataset?.DatasetId);
         Assert.Equal("harbor-assets-public", state.SelectedDataset?.ApiAccess.PublicKeyLabel);
         Assert.Contains(state.SelectedDataset!.ApiAccess.CodeExamples, example => example.Language == OpenDataCodeLanguage.JavaScript);
+        Assert.True(state.SelectedDataset.Usage.DownloadsLast30Days > 0);
+        Assert.True(state.SelectedDataset.Usage.ApiCallsLast30Days > 0);
+        Assert.Contains(state.SelectedDataset.FeedbackReports, report => report.Status == OpenDataFeedbackStatus.Triaged);
         Assert.False(state.HasBlockingValidation);
     }
 

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -374,8 +374,13 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Public API key");
             cut.Markup.MarkupMatchesContaining("Code examples");
             cut.Markup.MarkupMatchesContaining("JavaScript");
+            cut.Markup.MarkupMatchesContaining("Usage analytics");
+            cut.Markup.MarkupMatchesContaining("Feedback and data quality");
+            cut.Markup.MarkupMatchesContaining("stale asset status values");
             cut.Find("[data-testid='open-data-api-access']");
             cut.Find("[data-testid='open-data-code-example-Python']");
+            cut.Find("[data-testid='open-data-usage-downloads']");
+            cut.Find("[data-testid='open-data-feedback-harbor-assets-quality-1']");
             cut.Markup.MarkupMatchesContaining("Readiness checks");
         });
     }


### PR DESCRIPTION
## Summary
- add per-dataset usage summary and popular download format models for the open data hub
- seed usage analytics and feedback/data quality report fixtures in the stub client
- render dataset usage and feedback sections with state and page render coverage

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "OpenDataHubStateTests|AdminPageRenderTests|AdminQualityGateTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1

Related to honua-io/honua-portal#6 (partial admin UI slice).