### PR TITLE
ui: add app builder data binding controls

### DIFF
--- a/src/Honua.Admin/Pages/Operator/AppBuilder.razor
+++ b/src/Honua.Admin/Pages/Operator/AppBuilder.razor
@@ -166,6 +166,38 @@
                              Margin="Margin.Dense"
                              aria-label="Auto refresh seconds" />
 
+            <MudText Typo="Typo.h6" Class="mt-4">Data bindings</MudText>
+            <div class="app-builder-data-bindings" aria-label="App builder data bindings">
+                @if (State.DataBoundWidgets.Count == 0)
+                {
+                    <div class="app-builder-empty" data-testid="app-builder-bindings-empty">
+                        Add a data-bound widget to configure service bindings.
+                    </div>
+                }
+                else
+                {
+                    @foreach (var widget in State.DataBoundWidgets)
+                    {
+                        var item = widget;
+                        <div class="app-builder-binding-row" data-testid="@($"app-builder-binding-{item.WidgetId}")">
+                            <MudIcon Icon="@WidgetIcon(item.Kind)" Size="Size.Small" />
+                            <div>
+                                <strong>@item.Title</strong>
+                                <small>@item.Kind</small>
+                            </div>
+                            <MudTextField T="string"
+                                          Label="Binding"
+                                          Value="@item.DataBinding"
+                                          ValueChanged="@((string? value) => State.SetWidgetDataBinding(item.WidgetId, value))"
+                                          Disabled="@IsBusy"
+                                          Variant="Variant.Outlined"
+                                          Margin="Margin.Dense"
+                                          aria-label="@($"{item.Title} binding")" />
+                        </div>
+                    }
+                }
+            </div>
+
             <MudText Typo="Typo.h6" Class="mt-4">Publishing readiness</MudText>
             <div class="app-builder-publishing-readiness" aria-label="App builder publishing readiness">
                 <div class="app-builder-quota-row" data-testid="app-builder-quota">

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -33,6 +33,13 @@ public sealed class AppBuilderState
     public AppTemplate? SelectedTemplate =>
         Templates.FirstOrDefault(template => string.Equals(template.TemplateId, Draft.TemplateId, StringComparison.OrdinalIgnoreCase));
 
+    public IReadOnlyList<AppWidgetInstance> DataBoundWidgets =>
+        Draft.Widgets
+            .Where(widget => WidgetRequiresBinding(widget.Kind))
+            .OrderBy(widget => widget.Row)
+            .ThenBy(widget => widget.Column)
+            .ToArray();
+
     public IReadOnlyList<AppValidationCheck> ValidationChecks
     {
         get
@@ -299,6 +306,37 @@ public sealed class AppBuilderState
                 .Where(interaction => widgetIds.Contains(interaction.SourceWidgetId) && widgetIds.Contains(interaction.TargetWidgetId))
                 .ToArray()
         };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetWidgetDataBinding(string widgetId, string? dataBinding)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        var updated = false;
+        var widgets = Draft.Widgets
+            .Select(widget =>
+            {
+                if (!string.Equals(widget.WidgetId, widgetId, StringComparison.Ordinal))
+                {
+                    return widget;
+                }
+
+                updated = true;
+                return widget with { DataBinding = dataBinding?.Trim() ?? string.Empty };
+            })
+            .ToArray();
+
+        if (!updated)
+        {
+            return;
+        }
+
+        Draft = Draft with { Widgets = widgets };
         ResetTransientPublishState();
         Notify();
     }

--- a/src/Honua.Admin/wwwroot/css/app-builder.css
+++ b/src/Honua.Admin/wwwroot/css/app-builder.css
@@ -30,7 +30,8 @@
 .app-builder-widget-library,
 .app-builder-validation,
 .app-builder-publishing-readiness,
-.app-builder-interactions {
+.app-builder-interactions,
+.app-builder-data-bindings {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -66,7 +67,9 @@
 .app-builder-publish-channel span,
 .app-builder-publish-channel small,
 .app-builder-quota-row span,
-.app-builder-widget-body small {
+.app-builder-widget-body small,
+.app-builder-binding-row small,
+.app-builder-empty {
     color: var(--mud-palette-text-secondary, #607d8b);
 }
 
@@ -74,7 +77,9 @@
 .app-builder-quota-row,
 .app-builder-publish-channel,
 .app-builder-validation-row,
-.app-builder-interaction {
+.app-builder-interaction,
+.app-builder-binding-row,
+.app-builder-empty {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -87,10 +92,24 @@
 .app-builder-widget-definition div,
 .app-builder-quota-row div,
 .app-builder-publish-channel div,
-.app-builder-validation-row div {
+.app-builder-validation-row div,
+.app-builder-binding-row div {
     display: flex;
     flex-direction: column;
     min-width: 0;
+}
+
+.app-builder-binding-row {
+    align-items: flex-start;
+}
+
+.app-builder-binding-row > .mud-input-control {
+    flex: 1 1 160px;
+    min-width: 0;
+}
+
+.app-builder-empty {
+    justify-content: flex-start;
 }
 
 .app-builder-publish-channel {
@@ -113,7 +132,9 @@
 .app-builder-quota-row span,
 .app-builder-interaction strong,
 .app-builder-interaction span,
-.app-builder-interaction small {
+.app-builder-interaction small,
+.app-builder-binding-row strong,
+.app-builder-binding-row small {
     min-width: 0;
     overflow-wrap: anywhere;
 }

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -119,6 +119,27 @@ public sealed class AppBuilderStateTests
     }
 
     [Fact]
+    public async Task SetWidgetDataBinding_updates_widget_and_recomputes_validation()
+    {
+        var state = new AppBuilderState(new StubAppBuilderClient());
+        await state.LoadAsync();
+
+        state.SetWidgetDataBinding("widget-chart", " ");
+
+        var emptyBinding = Assert.Single(state.Draft.Widgets, widget => widget.WidgetId == "widget-chart");
+        Assert.Equal(string.Empty, emptyBinding.DataBinding);
+        Assert.Contains(state.ValidationChecks, check => check.Key == "bindings" && !check.Passed);
+        Assert.True(state.HasBlockingValidation);
+
+        state.SetWidgetDataBinding("widget-chart", "Incident features by type");
+
+        var updated = Assert.Single(state.Draft.Widgets, widget => widget.WidgetId == "widget-chart");
+        Assert.Equal("Incident features by type", updated.DataBinding);
+        Assert.Contains(state.ValidationChecks, check => check.Key == "bindings" && check.Passed);
+        Assert.False(state.HasBlockingValidation);
+    }
+
+    [Fact]
     public async Task Validation_flags_interactions_that_reference_missing_widgets()
     {
         var snapshot = Snapshot("Interaction dashboard");
@@ -181,6 +202,7 @@ public sealed class AppBuilderStateTests
         state.SelectTemplate("public-viewer");
         state.AddWidget(AppWidgetKind.Search);
         state.RemoveWidget(originalDraft.Widgets[0].WidgetId);
+        state.SetWidgetDataBinding(originalDraft.Widgets[0].WidgetId, "Edited binding");
 
         Assert.Equal(AppBuilderStatus.Publishing, state.Status);
         Assert.Equal(originalDraft.Name, state.Draft.Name);
@@ -188,6 +210,7 @@ public sealed class AppBuilderStateTests
         Assert.Equal(originalDraft.AutoRefreshSeconds, state.Draft.AutoRefreshSeconds);
         Assert.Equal(originalDraft.TemplateId, state.Draft.TemplateId);
         Assert.Equal(originalDraft.Widgets.Count, state.Draft.Widgets.Count);
+        Assert.Equal(originalDraft.Widgets[0].DataBinding, state.Draft.Widgets[0].DataBinding);
 
         client.Complete();
         await publishTask;

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -352,9 +352,12 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Publishing readiness");
             cut.Markup.MarkupMatchesContaining("Standalone URL");
             cut.Markup.MarkupMatchesContaining("Custom domain");
+            cut.Markup.MarkupMatchesContaining("Data bindings");
+            cut.Markup.MarkupMatchesContaining("Harbor assets");
             cut.Markup.MarkupMatchesContaining("App builder validation checks");
             cut.Markup.MarkupMatchesContaining("Cross-widget interactions");
             cut.Markup.MarkupMatchesContaining("Map feature click");
+            cut.Find("[data-testid='app-builder-binding-widget-map']");
             cut.Find("[data-testid='app-builder-interaction-interaction-map-list']");
         });
     }


### PR DESCRIPTION
## Summary
- add editable per-widget data binding controls in the app builder configuration pane
- expose ordered data-bound widgets from state and recompute validation when bindings change
- cover binding edits, locked publish behavior, and page rendering

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "AppBuilderStateTests|AdminPageRenderTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1

Related to honua-io/honua-portal#5 (partial admin UI slice).