### PR TITLE
ui: add open data export manifest readiness

### DIFF
--- a/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
+++ b/src/Honua.Admin/Models/OpenDataHub/OpenDataHubModels.cs
@@ -30,6 +30,14 @@ public enum OpenDataDownloadFormat
     Kml
 }
 
+public enum OpenDataDownloadReadiness
+{
+    Ready,
+    Generating,
+    Stale,
+    Failed
+}
+
 public enum OpenDataCodeLanguage
 {
     Curl,
@@ -107,8 +115,13 @@ public sealed record OpenDataDownloadOption
 {
     public OpenDataDownloadFormat Format { get; init; }
     public string Url { get; init; } = string.Empty;
+    public string ContentType { get; init; } = string.Empty;
+    public string Checksum { get; init; } = string.Empty;
     public long SizeBytes { get; init; }
     public DateTimeOffset GeneratedAt { get; init; }
+    public OpenDataDownloadReadiness Readiness { get; init; } = OpenDataDownloadReadiness.Ready;
+    public bool SupportsBulkExport { get; init; }
+    public bool SupportsDeltaExport { get; init; }
 }
 
 public sealed record OpenDataApiEndpoint

--- a/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
+++ b/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
@@ -219,14 +219,30 @@
                 <MudText Typo="Typo.h6">Distribution</MudText>
 
                 <div class="open-data-delivery-group" aria-label="Open data downloads">
-                    <MudText Typo="Typo.subtitle2">Downloads</MudText>
+                    <MudText Typo="Typo.subtitle2">Download export manifest</MudText>
                     @foreach (var download in selected.Downloads)
                     {
-                        <div class="open-data-delivery-row" data-testid="@($"open-data-download-{download.Format}")">
-                            <MudIcon Icon="@Icons.Material.Filled.Download" Size="Size.Small" />
-                            <div>
+                        <div class="open-data-delivery-row open-data-download-row" data-testid="@($"open-data-download-{download.Format}")">
+                            <MudIcon Icon="@Icons.Material.Filled.Download"
+                                     Color="@DownloadReadinessColor(download.Readiness)"
+                                     Size="Size.Small" />
+                            <div class="open-data-download-main">
                                 <strong>@FormatDownload(download.Format)</strong>
                                 <span>@download.Url</span>
+                                <small>@download.ContentType | @ShortChecksum(download.Checksum) | generated @FormatApiDate(download.GeneratedAt)</small>
+                            </div>
+                            <div class="open-data-download-tags">
+                                <MudChip T="string" Size="Size.Small" Color="@DownloadReadinessColor(download.Readiness)" Variant="Variant.Outlined">
+                                    @download.Readiness
+                                </MudChip>
+                                @if (download.SupportsBulkExport)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">Bulk</MudChip>
+                                }
+                                @if (download.SupportsDeltaExport)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">Delta</MudChip>
+                                }
                             </div>
                             <small>@FormatBytes(download.SizeBytes)</small>
                         </div>
@@ -427,6 +443,16 @@
     private static string FormatApiDate(DateTimeOffset? value)
         => value?.ToLocalTime().ToString("MMM d, yyyy", CultureInfo.CurrentCulture) ?? "not recorded";
 
+    private static string ShortChecksum(string checksum)
+    {
+        if (string.IsNullOrWhiteSpace(checksum))
+        {
+            return "checksum missing";
+        }
+
+        return checksum.Length <= 18 ? checksum : checksum[..18];
+    }
+
     private static Color StatusColor(OpenDataHubStatus status) => status switch
     {
         OpenDataHubStatus.Error => Color.Error,
@@ -442,6 +468,15 @@
         OpenDataDatasetStatus.Scheduled => Color.Info,
         OpenDataDatasetStatus.InReview => Color.Warning,
         OpenDataDatasetStatus.Blocked => Color.Error,
+        _ => Color.Default
+    };
+
+    private static Color DownloadReadinessColor(OpenDataDownloadReadiness readiness) => readiness switch
+    {
+        OpenDataDownloadReadiness.Ready => Color.Success,
+        OpenDataDownloadReadiness.Generating => Color.Info,
+        OpenDataDownloadReadiness.Stale => Color.Warning,
+        OpenDataDownloadReadiness.Failed => Color.Error,
         _ => Color.Default
     };
 

--- a/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
+++ b/src/Honua.Admin/Pages/Operator/OpenDataHub.razor
@@ -229,7 +229,7 @@
                             <div class="open-data-download-main">
                                 <strong>@FormatDownload(download.Format)</strong>
                                 <span>@download.Url</span>
-                                <small>@download.ContentType | @ShortChecksum(download.Checksum) | generated @FormatApiDate(download.GeneratedAt)</small>
+                                <small>@download.ContentType | @ShortChecksum(download.Checksum) | generated @FormatGeneratedDate(download.GeneratedAt)</small>
                             </div>
                             <div class="open-data-download-tags">
                                 <MudChip T="string" Size="Size.Small" Color="@DownloadReadinessColor(download.Readiness)" Variant="Variant.Outlined">
@@ -442,6 +442,9 @@
 
     private static string FormatApiDate(DateTimeOffset? value)
         => value?.ToLocalTime().ToString("MMM d, yyyy", CultureInfo.CurrentCulture) ?? "not recorded";
+
+    private static string FormatGeneratedDate(DateTimeOffset value)
+        => value == default ? "not recorded" : FormatApiDate(value);
 
     private static string ShortChecksum(string checksum)
     {

--- a/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
@@ -81,7 +81,8 @@ public sealed class OpenDataHubState
                 HasText(dataset.License) &&
                 HasText(dataset.Contact) &&
                 HasText(dataset.UpdateFrequency);
-            var hasDownloads = RequiredDownloadFormats.All(format => dataset.Downloads.Any(download => download.Format == format));
+            var hasDownloads = RequiredDownloadFormats
+                .All(format => dataset.Downloads.FirstOrDefault(download => download.Format == format) is { } download && IsDownloadReady(download));
             var hasApis = dataset.ApiEnabled &&
                 dataset.ApiEndpoints.Any(endpoint => !endpoint.RequiresApiKey) &&
                 HasText(dataset.StacCollectionId) &&
@@ -110,7 +111,7 @@ public sealed class OpenDataHubState
                     Key = "downloads",
                     Label = "Download formats",
                     Passed = hasDownloads,
-                    Message = hasDownloads ? "GeoJSON, GeoParquet, Shapefile, CSV, and KML exports are available." : "All required download formats must be generated."
+                    Message = hasDownloads ? "GeoJSON, GeoParquet, Shapefile, CSV, and KML exports have ready URLs, MIME types, checksums, and bulk manifests." : "All required download formats need ready URLs, MIME types, checksums, positive sizes, and bulk manifests."
                 },
                 new OpenDataValidationCheck
                 {
@@ -373,6 +374,15 @@ public sealed class OpenDataHubState
 
     private static bool HasText(string value)
         => !string.IsNullOrWhiteSpace(value);
+
+    private static bool IsDownloadReady(OpenDataDownloadOption download)
+        => download.Readiness == OpenDataDownloadReadiness.Ready &&
+            download.SupportsBulkExport &&
+            download.SizeBytes > 0 &&
+            download.GeneratedAt != default &&
+            HasText(download.Url) &&
+            HasText(download.ContentType) &&
+            HasText(download.Checksum);
 
     private static bool IsAll(string value)
         => string.Equals(value, "All", StringComparison.OrdinalIgnoreCase);

--- a/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/OpenDataHubState.cs
@@ -82,7 +82,7 @@ public sealed class OpenDataHubState
                 HasText(dataset.Contact) &&
                 HasText(dataset.UpdateFrequency);
             var hasDownloads = RequiredDownloadFormats
-                .All(format => dataset.Downloads.FirstOrDefault(download => download.Format == format) is { } download && IsDownloadReady(download));
+                .All(format => dataset.Downloads.Any(download => download.Format == format && IsDownloadReady(download)));
             var hasApis = dataset.ApiEnabled &&
                 dataset.ApiEndpoints.Any(endpoint => !endpoint.RequiresApiKey) &&
                 HasText(dataset.StacCollectionId) &&

--- a/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
+++ b/src/Honua.Admin/Services/OpenDataHub/StubOpenDataHubClient.cs
@@ -351,9 +351,24 @@ public sealed class StubOpenDataHubClient : IOpenDataHubClient
         {
             Format = format,
             Url = url,
+            ContentType = ContentTypeFor(format),
+            Checksum = $"sha256:{Slug($"{format}-{url}-{sizeBytes}")}",
             SizeBytes = sizeBytes,
-            GeneratedAt = DateTimeOffset.Parse("2026-04-27T18:30:00Z")
+            GeneratedAt = DateTimeOffset.Parse("2026-04-27T18:30:00Z"),
+            Readiness = OpenDataDownloadReadiness.Ready,
+            SupportsBulkExport = true,
+            SupportsDeltaExport = format is OpenDataDownloadFormat.GeoJson or OpenDataDownloadFormat.GeoParquet or OpenDataDownloadFormat.Csv
         };
+
+    private static string ContentTypeFor(OpenDataDownloadFormat format) => format switch
+    {
+        OpenDataDownloadFormat.GeoJson => "application/geo+json",
+        OpenDataDownloadFormat.GeoParquet => "application/vnd.apache.parquet",
+        OpenDataDownloadFormat.Shapefile => "application/zip",
+        OpenDataDownloadFormat.Csv => "text/csv",
+        OpenDataDownloadFormat.Kml => "application/vnd.google-earth.kml+xml",
+        _ => "application/octet-stream"
+    };
 
     private static string Slug(string value)
     {

--- a/src/Honua.Admin/wwwroot/css/open-data-hub.css
+++ b/src/Honua.Admin/wwwroot/css/open-data-hub.css
@@ -286,6 +286,28 @@
     white-space: nowrap;
 }
 
+.open-data-download-row {
+    align-items: flex-start;
+}
+
+.open-data-download-main small {
+    margin-left: 0;
+    white-space: normal;
+}
+
+.open-data-delivery-row .open-data-download-tags {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 4px;
+    margin-left: auto;
+}
+
+.open-data-download-row > small {
+    margin-left: 0;
+}
+
 .open-data-api-row {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
@@ -353,6 +375,11 @@
 
     .open-data-delivery-row {
         align-items: flex-start;
+    }
+
+    .open-data-delivery-row .open-data-download-tags {
+        justify-content: flex-start;
+        margin-left: 0;
     }
 
     .open-data-delivery-row small {

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Honua.Admin.Models.OpenDataHub;
@@ -26,6 +27,8 @@ public sealed class OpenDataHubStateTests
         Assert.Equal("harbor-assets", state.SelectedDataset?.DatasetId);
         Assert.Equal("harbor-assets-public", state.SelectedDataset?.ApiAccess.PublicKeyLabel);
         Assert.Contains(state.SelectedDataset!.ApiAccess.CodeExamples, example => example.Language == OpenDataCodeLanguage.JavaScript);
+        Assert.All(state.SelectedDataset.Downloads, download => Assert.Equal(OpenDataDownloadReadiness.Ready, download.Readiness));
+        Assert.Contains(state.SelectedDataset.Downloads, download => download.Format == OpenDataDownloadFormat.GeoParquet && download.SupportsBulkExport && !string.IsNullOrWhiteSpace(download.Checksum));
         Assert.True(state.SelectedDataset.Usage.DownloadsLast30Days > 0);
         Assert.True(state.SelectedDataset.Usage.ApiCallsLast30Days > 0);
         Assert.Contains(state.SelectedDataset.FeedbackReports, report => report.Status == OpenDataFeedbackStatus.Triaged);
@@ -122,6 +125,29 @@ public sealed class OpenDataHubStateTests
         Assert.False(api.Passed);
         Assert.Contains("public key access", api.Message);
         Assert.Contains("bulk downloads", api.Message);
+        Assert.True(state.HasBlockingValidation);
+    }
+
+    [Fact]
+    public async Task ValidationChecks_require_ready_download_manifests()
+    {
+        var snapshot = Snapshot("download-dataset", "Download dataset");
+        var dataset = snapshot.Datasets[0] with
+        {
+            Downloads = snapshot.Datasets[0].Downloads
+                .Select(download => download.Format == OpenDataDownloadFormat.Csv
+                    ? download with { Checksum = string.Empty, Readiness = OpenDataDownloadReadiness.Stale }
+                    : download)
+                .ToArray(),
+        };
+        var state = new OpenDataHubState(new FixedOpenDataHubClient(snapshot with { Datasets = [dataset] }));
+
+        await state.LoadAsync();
+
+        var downloads = Assert.Single(state.ValidationChecks, check => check.Key == "downloads");
+        Assert.False(downloads.Passed);
+        Assert.Contains("checksums", downloads.Message);
+        Assert.Contains("bulk manifests", downloads.Message);
         Assert.True(state.HasBlockingValidation);
     }
 
@@ -430,8 +456,13 @@ public sealed class OpenDataHubStateTests
         {
             Format = format,
             Url = $"/downloads/{format}",
+            ContentType = format == OpenDataDownloadFormat.Csv ? "text/csv" : "application/octet-stream",
+            Checksum = $"sha256:{format}",
             SizeBytes = 100,
             GeneratedAt = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+            Readiness = OpenDataDownloadReadiness.Ready,
+            SupportsBulkExport = true,
+            SupportsDeltaExport = format is OpenDataDownloadFormat.GeoJson or OpenDataDownloadFormat.GeoParquet or OpenDataDownloadFormat.Csv,
         };
 
     private static OpenDataCodeExample CodeExample(OpenDataCodeLanguage language)

--- a/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
+++ b/tests/Honua.Admin.Tests/OpenDataHubStateTests.cs
@@ -152,6 +152,28 @@ public sealed class OpenDataHubStateTests
     }
 
     [Fact]
+    public async Task ValidationChecks_accept_ready_download_manifest_when_stale_duplicate_is_first()
+    {
+        var snapshot = Snapshot("duplicate-download-dataset", "Duplicate download dataset");
+        var csvDownload = Assert.Single(snapshot.Datasets[0].Downloads, download => download.Format == OpenDataDownloadFormat.Csv);
+        var dataset = snapshot.Datasets[0] with
+        {
+            Downloads =
+            [
+                csvDownload with { Checksum = string.Empty, Readiness = OpenDataDownloadReadiness.Stale },
+                .. snapshot.Datasets[0].Downloads,
+            ],
+        };
+        var state = new OpenDataHubState(new FixedOpenDataHubClient(snapshot with { Datasets = [dataset] }));
+
+        await state.LoadAsync();
+
+        var downloads = Assert.Single(state.ValidationChecks, check => check.Key == "downloads");
+        Assert.True(downloads.Passed);
+        Assert.False(state.HasBlockingValidation);
+    }
+
+    [Fact]
     public async Task Mutators_ignore_changes_while_publish_is_in_flight()
     {
         var client = new BlockingPublishOpenDataHubClient();

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using Honua.Admin.Models.Admin;
+using Honua.Admin.Models.OpenDataHub;
 using Honua.Admin.Models.SpecWorkspace;
 using Honua.Admin.Pages.Admin;
 using Honua.Admin.Services.Admin;
@@ -396,6 +397,21 @@ public sealed class AdminPageRenderTests : TestContext
         });
     }
 
+    [Fact]
+    public void OpenDataHub_RendersMissingExportTimestampAsNotRecorded()
+    {
+        Services.AddScoped<IOpenDataHubClient, MissingExportTimestampOpenDataHubClient>();
+
+        var cut = RenderWithMudHost<Honua.Admin.Pages.Operator.OpenDataHub>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.MarkupMatchesContaining("Missing timestamp dataset");
+            cut.Markup.MarkupMatchesContaining("generated not recorded");
+            Assert.DoesNotContain("Jan 1, 0001", cut.Markup);
+        });
+    }
+
     private IRenderedFragment RenderAdminPage(Type pageType)
     {
         return Render(builder =>
@@ -458,6 +474,51 @@ public sealed class AdminPageRenderTests : TestContext
         public override Task<IReadOnlyList<ConnectionSummary>> ListConnectionsAsync(CancellationToken cancellationToken)
             => Task.FromResult<IReadOnlyList<ConnectionSummary>>(
                 [Connections[0] with { HealthStatus = "Unhealthy" }]);
+    }
+
+    private sealed class MissingExportTimestampOpenDataHubClient : IOpenDataHubClient
+    {
+        public Task<OpenDataHubSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new OpenDataHubSnapshot
+            {
+                Datasets =
+                [
+                    new OpenDataDataset
+                    {
+                        DatasetId = "missing-timestamp",
+                        Title = "Missing timestamp dataset",
+                        Description = "Dataset with a pending export manifest.",
+                        Category = "Infrastructure",
+                        Geography = "Harbor",
+                        License = "CC BY 4.0",
+                        Contact = "gis@honua.local",
+                        UpdateFrequency = "Daily",
+                        Status = OpenDataDatasetStatus.InReview,
+                        LastUpdated = DateTimeOffset.Parse("2026-04-28T00:00:00Z"),
+                        PublicCatalogEnabled = true,
+                        ApiEnabled = false,
+                        EmbedEnabled = false,
+                        StacCollectionId = "collections/missing-timestamp",
+                        SampleResponse = "{}",
+                        Downloads =
+                        [
+                            new OpenDataDownloadOption
+                            {
+                                Format = OpenDataDownloadFormat.GeoJson,
+                                Url = "/open-data/missing-timestamp.geojson",
+                                ContentType = "application/geo+json",
+                                Checksum = "sha256:missing-timestamp",
+                                SizeBytes = 100,
+                                Readiness = OpenDataDownloadReadiness.Generating,
+                                SupportsBulkExport = false,
+                            },
+                        ],
+                    },
+                ],
+            });
+
+        public Task<OpenDataPublishResult> PublishAsync(string datasetId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
     }
 
     private sealed class NullAdminTelemetry : IAdminTelemetry

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -378,6 +378,9 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Published datasets");
             cut.Markup.MarkupMatchesContaining("Harbor assets");
             cut.Markup.MarkupMatchesContaining("GeoJSON");
+            cut.Markup.MarkupMatchesContaining("Download export manifest");
+            cut.Markup.MarkupMatchesContaining("sha256:");
+            cut.Markup.MarkupMatchesContaining("Bulk");
             cut.Markup.MarkupMatchesContaining("Civic tech API");
             cut.Markup.MarkupMatchesContaining("Public API key");
             cut.Markup.MarkupMatchesContaining("Code examples");


### PR DESCRIPTION
## Summary
- add explicit download export readiness metadata for Open Data Hub formats
- require ready URLs, MIME types, checksums, positive sizes, and bulk manifests before publishing
- surface readiness, bulk/delta badges, generated dates, and checksums in the distribution pane

## Tests
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "OpenDataHubStateTests|AdminPageRenderTests|AdminQualityGateTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- git diff --check
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1

Related to honua-io/honua-portal#6 (partial admin UI slice).