### PR TITLE
ui: add app builder branding controls

### DIFF
--- a/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
+++ b/src/Honua.Admin/Models/AppBuilder/AppBuilderModels.cs
@@ -99,6 +99,11 @@ public sealed record AppDraft
     public string Name { get; init; } = "Operations dashboard";
     public string TemplateId { get; init; } = "operations-dashboard";
     public string ThemeName { get; init; } = "Civic light";
+    public string PrimaryColor { get; init; } = "#1b7895";
+    public string AccentColor { get; init; } = "#2f7d55";
+    public string FontFamily { get; init; } = "Inter";
+    public string LogoUrl { get; init; } = "https://assets.honua.local/branding/honua-city.svg";
+    public bool WhiteLabel { get; init; }
     public int AutoRefreshSeconds { get; init; } = 60;
     public bool IsPublished { get; init; }
     public IReadOnlyList<AppWidgetInstance> Widgets { get; init; } = Array.Empty<AppWidgetInstance>();

--- a/src/Honua.Admin/Pages/Operator/AppBuilder.razor
+++ b/src/Honua.Admin/Pages/Operator/AppBuilder.razor
@@ -88,6 +88,11 @@
                 <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
                     @State.SelectedTemplate?.Name
                 </MudChip>
+                <div class="app-builder-theme-summary" aria-label="App theme summary">
+                    <span class="app-builder-swatch" style="@SwatchStyle(State.Draft.PrimaryColor)"></span>
+                    <span class="app-builder-swatch" style="@SwatchStyle(State.Draft.AccentColor)"></span>
+                    <small>@State.Draft.ThemeName</small>
+                </div>
                 <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
                     @($"{State.Draft.AutoRefreshSeconds}s refresh")
                 </MudChip>
@@ -146,6 +151,16 @@
                           Variant="Variant.Outlined"
                           Margin="Margin.Dense"
                           aria-label="App name" />
+
+            <MudText Typo="Typo.subtitle2" Class="mt-3">Branding</MudText>
+            <div class="app-builder-brand-preview" style="@BrandPreviewStyle" aria-label="App builder branding preview">
+                <MudIcon Icon="@Icons.Material.Filled.Image" Size="Size.Small" />
+                <div>
+                    <strong>@State.Draft.ThemeName</strong>
+                    <span>@State.Draft.FontFamily</span>
+                    <small>@(State.Draft.WhiteLabel ? "White-label app" : "Honua co-branded app")</small>
+                </div>
+            </div>
             <MudTextField T="string"
                           Label="Theme"
                           Value="@State.Draft.ThemeName"
@@ -154,6 +169,54 @@
                           Variant="Variant.Outlined"
                           Margin="Margin.Dense"
                           aria-label="App theme" />
+            <div class="app-builder-color-grid" aria-label="App builder color controls">
+                <div class="app-builder-color-control" data-testid="app-builder-primary-color">
+                    <span class="app-builder-swatch" style="@SwatchStyle(State.Draft.PrimaryColor)"></span>
+                    <MudTextField T="string"
+                                  Label="Primary color"
+                                  Value="@State.Draft.PrimaryColor"
+                                  ValueChanged="State.SetPrimaryColor"
+                                  Disabled="@IsBusy"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  aria-label="Primary color" />
+                </div>
+                <div class="app-builder-color-control" data-testid="app-builder-accent-color">
+                    <span class="app-builder-swatch" style="@SwatchStyle(State.Draft.AccentColor)"></span>
+                    <MudTextField T="string"
+                                  Label="Accent color"
+                                  Value="@State.Draft.AccentColor"
+                                  ValueChanged="State.SetAccentColor"
+                                  Disabled="@IsBusy"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  aria-label="Accent color" />
+                </div>
+            </div>
+            <MudTextField T="string"
+                          Label="Font family"
+                          Value="@State.Draft.FontFamily"
+                          ValueChanged="State.SetFontFamily"
+                          Disabled="@IsBusy"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          aria-label="Font family" />
+            <MudTextField T="string"
+                          Label="Logo URL"
+                          Value="@State.Draft.LogoUrl"
+                          ValueChanged="State.SetLogoUrl"
+                          Disabled="@IsBusy"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          aria-label="Logo URL" />
+            <MudSwitch T="bool"
+                       Label="White-label"
+                       Value="@State.Draft.WhiteLabel"
+                       ValueChanged="State.SetWhiteLabel"
+                       Disabled="@IsBusy"
+                       Color="Color.Primary"
+                       aria-label="White-label"
+                       data-testid="app-builder-white-label" />
             <MudNumericField T="int"
                              Label="Auto refresh seconds"
                              Value="@State.Draft.AutoRefreshSeconds"
@@ -292,6 +355,8 @@
         ? $"{State.Quota.PublishedApps} published apps, unlimited {State.Quota.Edition} allowance."
         : $"{State.Quota.PublishedApps} of {State.Quota.AppLimit.Value} published apps used.";
 
+    private string BrandPreviewStyle => $"border-left-color: {SafeCssColor(State.Draft.PrimaryColor)}; --app-builder-accent-color: {SafeCssColor(State.Draft.AccentColor)};";
+
     private string TemplateClass(AppTemplate template)
         => string.Equals(template.TemplateId, State.Draft.TemplateId, StringComparison.OrdinalIgnoreCase)
             ? "app-builder-template selected"
@@ -308,6 +373,22 @@
         var height = Math.Clamp(widget.Height, 1, 6);
 
         return $"grid-column: {column} / span {width}; grid-row: {row} / span {height};";
+    }
+
+    private static string SwatchStyle(string color)
+        => $"background: {SafeCssColor(color)};";
+
+    private static string SafeCssColor(string color)
+        => IsCssHexColor(color) ? color : "#d7dbe0";
+
+    private static bool IsCssHexColor(string color)
+    {
+        if (color.Length != 7 || color[0] != '#')
+        {
+            return false;
+        }
+
+        return color[1..].All(Uri.IsHexDigit);
     }
 
     private static string WidgetIcon(AppWidgetKind kind) => kind switch

--- a/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
+++ b/src/Honua.Admin/Services/AppBuilder/AppBuilderState.cs
@@ -48,6 +48,10 @@ public sealed class AppBuilderState
             var hasWidgets = Draft.Widgets.Count > 0;
             var dataBoundWidgets = Draft.Widgets.Where(widget => WidgetRequiresBinding(widget.Kind)).ToArray();
             var allBindings = dataBoundWidgets.All(widget => !string.IsNullOrWhiteSpace(widget.DataBinding));
+            var hasBranding = IsHexColor(Draft.PrimaryColor) &&
+                IsHexColor(Draft.AccentColor) &&
+                HasText(Draft.FontFamily) &&
+                (!Draft.WhiteLabel || HasText(Draft.LogoUrl));
             var widgetIds = Draft.Widgets.Select(widget => widget.WidgetId).ToHashSet(StringComparer.Ordinal);
             var interactionsReferenceWidgets = Draft.Interactions.All(interaction =>
                 widgetIds.Contains(interaction.SourceWidgetId) && widgetIds.Contains(interaction.TargetWidgetId));
@@ -86,6 +90,13 @@ public sealed class AppBuilderState
                     Label = "Responsive breakpoints",
                     Passed = SelectedTemplate?.Breakpoints.Count > 0,
                     Message = SelectedTemplate is null ? "Select a template." : string.Join(", ", SelectedTemplate.Breakpoints)
+                },
+                new AppValidationCheck
+                {
+                    Key = "branding",
+                    Label = "Branding",
+                    Passed = hasBranding,
+                    Message = hasBranding ? $"{Draft.ThemeName} theme with {Draft.FontFamily} typography is ready." : "Branding needs valid hex colors, a font family, and a logo URL when white-label mode is enabled."
                 },
                 new AppValidationCheck
                 {
@@ -243,6 +254,66 @@ public sealed class AppBuilderState
         Notify();
     }
 
+    public void SetPrimaryColor(string? color)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { PrimaryColor = color?.Trim() ?? string.Empty };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetAccentColor(string? color)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { AccentColor = color?.Trim() ?? string.Empty };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetFontFamily(string? fontFamily)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { FontFamily = fontFamily?.Trim() ?? string.Empty };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetLogoUrl(string? logoUrl)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { LogoUrl = logoUrl?.Trim() ?? string.Empty };
+        ResetTransientPublishState();
+        Notify();
+    }
+
+    public void SetWhiteLabel(bool whiteLabel)
+    {
+        if (IsDraftLocked)
+        {
+            return;
+        }
+
+        Draft = Draft with { WhiteLabel = whiteLabel };
+        ResetTransientPublishState();
+        Notify();
+    }
+
     public void SetAutoRefreshSeconds(int seconds)
     {
         if (IsDraftLocked)
@@ -390,6 +461,19 @@ public sealed class AppBuilderState
 
     private bool WidgetRequiresBinding(AppWidgetKind kind)
         => WidgetLibrary.FirstOrDefault(widget => widget.Kind == kind)?.SupportsDataBinding == true;
+
+    private static bool HasText(string value)
+        => !string.IsNullOrWhiteSpace(value);
+
+    private static bool IsHexColor(string value)
+    {
+        if (value.Length != 7 || value[0] != '#')
+        {
+            return false;
+        }
+
+        return value[1..].All(Uri.IsHexDigit);
+    }
 
     private bool IsCurrentLoad(int loadVersion) => loadVersion == Volatile.Read(ref _loadRequestVersion);
 

--- a/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
+++ b/src/Honua.Admin/Services/AppBuilder/StubAppBuilderClient.cs
@@ -92,6 +92,11 @@ public sealed class StubAppBuilderClient : IAppBuilderClient
                 Name = "Harbor operations dashboard",
                 TemplateId = "operations-dashboard",
                 ThemeName = "Civic light",
+                PrimaryColor = "#1b7895",
+                AccentColor = "#2f7d55",
+                FontFamily = "Inter",
+                LogoUrl = "https://assets.honua.local/branding/harbor-ops.svg",
+                WhiteLabel = true,
                 AutoRefreshSeconds = 60,
                 Widgets =
                 [

--- a/src/Honua.Admin/wwwroot/css/app-builder.css
+++ b/src/Honua.Admin/wwwroot/css/app-builder.css
@@ -73,6 +73,72 @@
     color: var(--mud-palette-text-secondary, #607d8b);
 }
 
+.app-builder-theme-summary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--mud-palette-text-secondary, #607d8b);
+}
+
+.app-builder-swatch {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    flex: 0 0 18px;
+    border: 1px solid rgba(16, 24, 32, 0.18);
+    border-radius: 50%;
+}
+
+.app-builder-brand-preview {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 8px;
+    border: 1px solid var(--mud-palette-divider, #d7dbe0);
+    border-left: 4px solid var(--mud-palette-primary, #594ae2);
+    border-radius: 6px;
+    padding: 10px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 1), rgba(248, 251, 252, 0.92));
+}
+
+.app-builder-brand-preview .mud-icon-root {
+    color: var(--app-builder-accent-color, var(--mud-palette-primary, #594ae2));
+}
+
+.app-builder-brand-preview div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+}
+
+.app-builder-brand-preview strong,
+.app-builder-brand-preview span,
+.app-builder-brand-preview small {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.app-builder-brand-preview span,
+.app-builder-brand-preview small {
+    color: var(--mud-palette-text-secondary, #607d8b);
+}
+
+.app-builder-color-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.app-builder-color-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.app-builder-color-control .mud-input-control {
+    min-width: 0;
+}
+
 .app-builder-widget-definition,
 .app-builder-quota-row,
 .app-builder-publish-channel,
@@ -217,6 +283,10 @@
 @media (max-width: 720px) {
     .app-builder-root {
         padding: 10px;
+    }
+
+    .app-builder-color-grid {
+        grid-template-columns: 1fr;
     }
 
     .app-builder-canvas {

--- a/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
+++ b/tests/Honua.Admin.Tests/AppBuilderStateTests.cs
@@ -26,8 +26,13 @@ public sealed class AppBuilderStateTests
         Assert.Equal("Pro", state.Quota.Edition);
         Assert.True(state.Quota.CanPublishMore);
         Assert.Equal("Harbor operations dashboard", state.Draft.Name);
+        Assert.Equal("#1b7895", state.Draft.PrimaryColor);
+        Assert.Equal("#2f7d55", state.Draft.AccentColor);
+        Assert.Equal("Inter", state.Draft.FontFamily);
+        Assert.True(state.Draft.WhiteLabel);
         Assert.NotEmpty(state.Draft.Widgets);
         Assert.Equal(2, state.Draft.Interactions.Count);
+        Assert.Contains(state.ValidationChecks, check => check.Key == "branding" && check.Passed);
         Assert.Contains(state.ValidationChecks, check => check.Key == "interactions" && check.Passed);
         Assert.False(state.HasBlockingValidation);
     }
@@ -140,6 +145,41 @@ public sealed class AppBuilderStateTests
     }
 
     [Fact]
+    public async Task Branding_validation_requires_hex_colors_font_and_white_label_logo()
+    {
+        var snapshot = Snapshot("Brand dashboard");
+        var state = new AppBuilderState(new FixedAppBuilderClient(snapshot with
+        {
+            Draft = snapshot.Draft with
+            {
+                PrimaryColor = "blue",
+                AccentColor = "#12345",
+                FontFamily = " ",
+                LogoUrl = " ",
+                WhiteLabel = true,
+            },
+        }));
+        await state.LoadAsync();
+
+        var branding = Assert.Single(state.ValidationChecks, check => check.Key == "branding");
+        Assert.False(branding.Passed);
+        Assert.Contains("valid hex colors", branding.Message);
+        Assert.True(state.HasBlockingValidation);
+
+        state.SetPrimaryColor(" #123456 ");
+        state.SetAccentColor("#abcdef");
+        state.SetFontFamily(" Source Sans 3 ");
+        state.SetLogoUrl(" https://assets.example.gov/logo.svg ");
+
+        Assert.Equal("#123456", state.Draft.PrimaryColor);
+        Assert.Equal("#abcdef", state.Draft.AccentColor);
+        Assert.Equal("Source Sans 3", state.Draft.FontFamily);
+        Assert.Equal("https://assets.example.gov/logo.svg", state.Draft.LogoUrl);
+        Assert.Contains(state.ValidationChecks, check => check.Key == "branding" && check.Passed);
+        Assert.False(state.HasBlockingValidation);
+    }
+
+    [Fact]
     public async Task Validation_flags_interactions_that_reference_missing_widgets()
     {
         var snapshot = Snapshot("Interaction dashboard");
@@ -198,6 +238,11 @@ public sealed class AppBuilderStateTests
         await client.PublishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         state.SetName("Edited during publish");
         state.SetTheme("Dark");
+        state.SetPrimaryColor("#000000");
+        state.SetAccentColor("#111111");
+        state.SetFontFamily("Edited font");
+        state.SetLogoUrl("https://assets.example.gov/edited.svg");
+        state.SetWhiteLabel(!originalDraft.WhiteLabel);
         state.SetAutoRefreshSeconds(15);
         state.SelectTemplate("public-viewer");
         state.AddWidget(AppWidgetKind.Search);
@@ -207,6 +252,11 @@ public sealed class AppBuilderStateTests
         Assert.Equal(AppBuilderStatus.Publishing, state.Status);
         Assert.Equal(originalDraft.Name, state.Draft.Name);
         Assert.Equal(originalDraft.ThemeName, state.Draft.ThemeName);
+        Assert.Equal(originalDraft.PrimaryColor, state.Draft.PrimaryColor);
+        Assert.Equal(originalDraft.AccentColor, state.Draft.AccentColor);
+        Assert.Equal(originalDraft.FontFamily, state.Draft.FontFamily);
+        Assert.Equal(originalDraft.LogoUrl, state.Draft.LogoUrl);
+        Assert.Equal(originalDraft.WhiteLabel, state.Draft.WhiteLabel);
         Assert.Equal(originalDraft.AutoRefreshSeconds, state.Draft.AutoRefreshSeconds);
         Assert.Equal(originalDraft.TemplateId, state.Draft.TemplateId);
         Assert.Equal(originalDraft.Widgets.Count, state.Draft.Widgets.Count);

--- a/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/AdminPageRenderTests.cs
@@ -361,10 +361,15 @@ public sealed class AdminPageRenderTests : TestContext
             cut.Markup.MarkupMatchesContaining("Data bindings");
             cut.Markup.MarkupMatchesContaining("Harbor assets");
             cut.Markup.MarkupMatchesContaining("App builder validation checks");
+            cut.Markup.MarkupMatchesContaining("Branding");
+            cut.Markup.MarkupMatchesContaining("#1b7895");
+            cut.Markup.MarkupMatchesContaining("White-label app");
             cut.Markup.MarkupMatchesContaining("Cross-widget interactions");
             cut.Markup.MarkupMatchesContaining("Map feature click");
             cut.Find("[data-testid='app-builder-binding-widget-map']");
             cut.Find("[data-testid='app-builder-interaction-interaction-map-list']");
+            cut.Find("[data-testid='app-builder-primary-color']");
+            cut.Find("[data-testid='app-builder-white-label']");
         });
     }
 


### PR DESCRIPTION
## Summary
- add app-builder branding fields for primary/accent colors, font, logo URL, and white-label mode
- validate branding readiness before publish and keep invalid color/logo states visible
- surface swatches, branding preview, and accessible controls in the configuration pane

## Tests
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --logger "console;verbosity=minimal" --filter "AppBuilderStateTests|AdminPageRenderTests|AdminQualityGateTests"
- dotnet build Honua.Admin.sln --configuration Release /p:TreatWarningsAsErrors=true
- git diff --check
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- dotnet test Honua.Admin.sln --configuration Release --no-build --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1

Related to honua-io/honua-portal#5 (partial admin UI slice).