### PR TITLE
ci: restore admin dependencies from GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
   pull_request:
     branches: [master, main, trunk]
 
-permissions: {}
+permissions:
+  contents: read
+  packages: read
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -24,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       build-succeeded: ${{ steps.build.outcome == 'success' }}
     steps:
@@ -33,6 +36,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -58,6 +64,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +73,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -110,6 +120,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 10
     env:
       HONUA_ADMIN_CONTAINER_E2E: ${{ vars.HONUA_ADMIN_CONTAINER_E2E || 'false' }}
@@ -123,6 +134,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -159,6 +173,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -166,6 +181,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Restore
         run: dotnet restore Honua.Admin.sln
@@ -218,6 +236,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: read
       security-events: write
     steps:
       - uses: actions/checkout@v4
@@ -231,6 +250,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Restore and Build for Analysis
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Repository Guidance
+
+This repo owns the Blazor/MudBlazor operator UI for Honua Server. Stable admin
+REST clients and shared DTO contracts should live in `honua-sdk-dotnet`, usually
+under `Honua.Sdk.Admin` or a dedicated admin contracts package.
+
+## Belongs Here
+
+- Blazor pages, MudBlazor components, operator workspace layout, navigation,
+  dialogs, page state, view models, and UI-specific validation/presentation.
+- Local demo stubs and sample data used to run the admin UI without a configured
+  server.
+- Admin workflow composition for dashboards, publishing, deploy control,
+  observability, identity, license, spatial SQL, print/export, annotations, and
+  settings.
+- Browser-specific UI integration and same-origin/BFF assumptions.
+
+## Does Not Belong Here
+
+- Stable admin REST DTOs, API envelopes, source-generated JSON contexts, or
+  reusable HTTP clients that are useful outside this UI.
+- SDK auth handlers, SDK service clients, or reusable compatibility matrices.
+- Provider-neutral feature, geometry, scene, routing, offline sync, plugin, or
+  field validation contracts.
+- Canonical gRPC `.proto` definitions. Those stay in `geospatial-grpc`; this UI
+  should consume SDK clients or generated bindings rather than carrying protocol
+  definitions.
+
+## Mismatch Checks
+
+- If a DTO mirrors a stable server API and is not page-specific, check
+  `Honua.Sdk.Admin` first.
+- If a typed `HttpClient` method would be useful from a console app, CI tool,
+  mobile app, or server automation, it belongs in the SDK and this UI should
+  consume it through a versioned NuGet package.
+- Do not copy SDK source or use long-lived sibling `ProjectReference` links to
+  `honua-sdk-dotnet`. Temporary local references need an explicit removal issue.
+- If an admin UI feature depends on server functionality, link the
+  `honua-server` dependency issue from the admin issue.
+- Keep UI-only stubs local, but add fixture tests when a DTO graduates to the
+  SDK so both repos validate the same payloads.
+
+## Companion Repos
+
+- `honua-sdk-dotnet`: reusable admin client, contracts, auth boundaries, and
+  shared test fixtures.
+- `honua-server`: backend API behavior and operator functionality exposed by
+  this UI.

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github-honua" value="https://nuget.pkg.github.com/honua-io/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github-honua">
+      <package pattern="Geospatial.Grpc" />
+      <package pattern="Honua.Core" />
+      <package pattern="Honua.Mobile.*" />
+      <package pattern="Honua.Sdk.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
## Summary

Configures server-admin restores to use Honua GitHub Packages for internal package dependencies.

## Details

- Adds repo-level `NuGet.config` with mappings for `Geospatial.Grpc`, `Honua.Core`, `Honua.Mobile.*`, and `Honua.Sdk.*`.
- Grants CI jobs `packages: read` and authenticates the `github-honua` NuGet source before restore/build/test/publish checks.
- Adds `AGENTS.md` ownership guidance so future agent work keeps admin UI changes in this repo and consumes SDK packages through NuGet.

## Validation

- YAML parse for `.github/workflows/ci.yml`
- XML parse for `NuGet.config`
- `dotnet restore Honua.Admin.sln`
- `git diff --check`
