### PR TITLE
ui: expand spec workspace completions

### DIFF
--- a/docs/admin-ui-api-coverage/coverage.yaml
+++ b/docs/admin-ui-api-coverage/coverage.yaml
@@ -1,8 +1,8 @@
 # Admin UI ↔ honua-server API coverage matrix.
 # Authored by `dotnet run --project tools/audit-api-surface -- seed-coverage`.
 # Hand-edit rows for per-endpoint classifications; the seeder preserves them on re-run.
-snapshot_date: 2026-04-26
-honua_server_commit: 1b301c3a98e7c97ff75c394852bfc614d5db8a7a
+snapshot_date: 2026-04-29
+honua_server_commit: 6cf9365a2b8d8bc5a58ca6e6a4eba5b6bf75ceaf
 rows:
   - key: "Admin/AdminAuthEndpoints:GET:/api/v{version:apiVersion}/admin/auth/config"
     coverage: out-of-scope
@@ -312,6 +312,20 @@ rows:
     out_of_scope_reason: ""
     follow_up_ticket: ""
     notes: "Layer/connection metadata edit; deferred to follow-up"
+  - key: "Admin/AdminSldStyleEndpoints:GET:/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/style/export-sld"
+    coverage: missing
+    admin_page: ""
+    priority: deferred
+    out_of_scope_reason: ""
+    follow_up_ticket: ""
+    notes: "TODO: classify this endpoint family in CoverageRules.cs"
+  - key: "Admin/AdminSldStyleEndpoints:POST:/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/style/import-sld"
+    coverage: missing
+    admin_page: ""
+    priority: deferred
+    out_of_scope_reason: ""
+    follow_up_ticket: ""
+    notes: "TODO: classify this endpoint family in CoverageRules.cs"
   - key: "Admin/AdminStyleSuggestionEndpoints:POST:/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/suggest-style"
     coverage: missing
     admin_page: ""
@@ -1236,6 +1250,13 @@ rows:
     out_of_scope_reason: "Liveness/readiness probes consumed by infra, not admin UI"
     follow_up_ticket: ""
     notes: ""
+  - key: Import/CrossServerConsumeProbeEndpoints:GET:/__test/cross-server-consume/proxy
+    coverage: missing
+    admin_page: ""
+    priority: deferred
+    out_of_scope_reason: ""
+    follow_up_ticket: ""
+    notes: "TODO: classify this endpoint family in CoverageRules.cs"
   - key: "Import/GeoServerImportEndpoints:GET:/api/v{version:apiVersion}/admin/import/geoserver/jobs"
     coverage: missing
     admin_page: ""
@@ -3070,6 +3091,20 @@ rows:
     out_of_scope_reason: "Public OGC API surface, not admin"
     follow_up_ticket: ""
     notes: ""
+  - key: "Reporting/AnalysisReportEndpoints:GET:/api/v{version:apiVersion}/analysis/reports/{jobId}/"
+    coverage: missing
+    admin_page: ""
+    priority: deferred
+    out_of_scope_reason: ""
+    follow_up_ticket: ""
+    notes: "TODO: classify this endpoint family in CoverageRules.cs"
+  - key: "Reporting/AnalysisReportEndpoints:GET:/api/v{version:apiVersion}/analysis/reports/{jobId}/render"
+    coverage: missing
+    admin_page: ""
+    priority: deferred
+    out_of_scope_reason: ""
+    follow_up_ticket: ""
+    notes: "TODO: classify this endpoint family in CoverageRules.cs"
   - key: "Spec/SpecEndpoints:GET:/v1/spec/artifact/{hash}"
     coverage: out-of-scope
     admin_page: ""
@@ -3092,6 +3127,13 @@ rows:
     follow_up_ticket: "honua-server-admin#26 (delivered via PR #27)"
     notes: ""
   - key: Spec/SpecEndpoints:POST:/v1/spec/plan
+    coverage: out-of-scope
+    admin_page: ""
+    priority: n/a
+    out_of_scope_reason: "Spec workspace shipped in #27; admin coverage lives in /operator/spec"
+    follow_up_ticket: "honua-server-admin#26 (delivered via PR #27)"
+    notes: ""
+  - key: Spec/SpecEndpoints:POST:/v1/spec/validate
     coverage: out-of-scope
     admin_page: ""
     priority: n/a

--- a/docs/admin-ui-api-coverage/endpoints.generated.json
+++ b/docs/admin-ui-api-coverage/endpoints.generated.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "honua_server_commit": "1b301c3a98e7c97ff75c394852bfc614d5db8a7a",
-  "generated_count": 447,
+  "honua_server_commit": "6cf9365a2b8d8bc5a58ca6e6a4eba5b6bf75ceaf",
+  "generated_count": 453,
   "endpoints": [
     {
       "key": "Admin/AdminAuthEndpoints:GET:/api/v{version:apiVersion}/admin/auth/config",
@@ -442,6 +442,26 @@
       "route": "/api/v{version:apiVersion}/admin/manifest/apply",
       "source_file": "Admin/AdminMetadataEndpoints.cs",
       "source_line": 52
+    },
+    {
+      "key": "Admin/AdminSldStyleEndpoints:GET:/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/style/export-sld",
+      "feature": "Admin",
+      "file": "AdminSldStyleEndpoints",
+      "kind": "http",
+      "verb": "GET",
+      "route": "/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/style/export-sld",
+      "source_file": "Admin/AdminSldStyleEndpoints.cs",
+      "source_line": 46
+    },
+    {
+      "key": "Admin/AdminSldStyleEndpoints:POST:/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/style/import-sld",
+      "feature": "Admin",
+      "file": "AdminSldStyleEndpoints",
+      "kind": "http",
+      "verb": "POST",
+      "route": "/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/style/import-sld",
+      "source_file": "Admin/AdminSldStyleEndpoints.cs",
+      "source_line": 36
     },
     {
       "key": "Admin/AdminStyleSuggestionEndpoints:POST:/api/v{version:apiVersion}/admin/metadata/layers/{layerId:int}/suggest-style",
@@ -1181,7 +1201,7 @@
       "verb": "DELETE",
       "route": "/api/v{version:apiVersion}/admin/connections/{id:guid}",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 94
+      "source_line": 95
     },
     {
       "key": "Admin/SecureConnectionEndpoints:GET:/api/v{version:apiVersion}/admin/connections/",
@@ -1191,7 +1211,7 @@
       "verb": "GET",
       "route": "/api/v{version:apiVersion}/admin/connections/",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 74
+      "source_line": 75
     },
     {
       "key": "Admin/SecureConnectionEndpoints:GET:/api/v{version:apiVersion}/admin/connections/{id:guid}",
@@ -1201,7 +1221,7 @@
       "verb": "GET",
       "route": "/api/v{version:apiVersion}/admin/connections/{id:guid}",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 78
+      "source_line": 79
     },
     {
       "key": "Admin/SecureConnectionEndpoints:POST:/api/v{version:apiVersion}/admin/connections/",
@@ -1211,7 +1231,7 @@
       "verb": "POST",
       "route": "/api/v{version:apiVersion}/admin/connections/",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 82
+      "source_line": 83
     },
     {
       "key": "Admin/SecureConnectionEndpoints:POST:/api/v{version:apiVersion}/admin/connections/encryption/rotate-key",
@@ -1221,7 +1241,7 @@
       "verb": "POST",
       "route": "/api/v{version:apiVersion}/admin/connections/encryption/rotate-key",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 108
+      "source_line": 109
     },
     {
       "key": "Admin/SecureConnectionEndpoints:POST:/api/v{version:apiVersion}/admin/connections/encryption/validate",
@@ -1231,7 +1251,7 @@
       "verb": "POST",
       "route": "/api/v{version:apiVersion}/admin/connections/encryption/validate",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 104
+      "source_line": 105
     },
     {
       "key": "Admin/SecureConnectionEndpoints:POST:/api/v{version:apiVersion}/admin/connections/test",
@@ -1241,7 +1261,7 @@
       "verb": "POST",
       "route": "/api/v{version:apiVersion}/admin/connections/test",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 86
+      "source_line": 87
     },
     {
       "key": "Admin/SecureConnectionEndpoints:POST:/api/v{version:apiVersion}/admin/connections/{id:guid}/test",
@@ -1251,7 +1271,7 @@
       "verb": "POST",
       "route": "/api/v{version:apiVersion}/admin/connections/{id:guid}/test",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 99
+      "source_line": 100
     },
     {
       "key": "Admin/SecureConnectionEndpoints:PUT:/api/v{version:apiVersion}/admin/connections/{id:guid}",
@@ -1261,7 +1281,7 @@
       "verb": "PUT",
       "route": "/api/v{version:apiVersion}/admin/connections/{id:guid}",
       "source_file": "Admin/SecureConnectionEndpoints.cs",
-      "source_line": 90
+      "source_line": 91
     },
     {
       "key": "Admin/ServiceSettingsEndpoints:GET:/api/v{version:apiVersion}/admin/services/",
@@ -1764,6 +1784,16 @@
       "source_line": 36
     },
     {
+      "key": "Import/CrossServerConsumeProbeEndpoints:GET:/__test/cross-server-consume/proxy",
+      "feature": "Import",
+      "file": "CrossServerConsumeProbeEndpoints",
+      "kind": "http",
+      "verb": "GET",
+      "route": "/__test/cross-server-consume/proxy",
+      "source_file": "Import/CrossServerConsumeProbeEndpoints.cs",
+      "source_line": 19
+    },
+    {
       "key": "Import/GeoServerImportEndpoints:GET:/api/v{version:apiVersion}/admin/import/geoserver/jobs",
       "feature": "Import",
       "file": "GeoServerImportEndpoints",
@@ -2081,7 +2111,7 @@
       "verb": "GET",
       "route": "/monitoring/alerts",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 55
+      "source_line": 57
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/health/comprehensive",
@@ -2091,7 +2121,7 @@
       "verb": "GET",
       "route": "/monitoring/health/comprehensive",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 67
+      "source_line": 69
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/health/production",
@@ -2101,7 +2131,7 @@
       "verb": "GET",
       "route": "/monitoring/health/production",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 31
+      "source_line": 33
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/metrics/cache",
@@ -2111,7 +2141,7 @@
       "verb": "GET",
       "route": "/monitoring/metrics/cache",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 43
+      "source_line": 45
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/metrics/connection-pool",
@@ -2121,7 +2151,7 @@
       "verb": "GET",
       "route": "/monitoring/metrics/connection-pool",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 37
+      "source_line": 39
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/metrics/database-resilience",
@@ -2131,7 +2161,7 @@
       "verb": "GET",
       "route": "/monitoring/metrics/database-resilience",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 73
+      "source_line": 75
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/metrics/resources",
@@ -2141,7 +2171,7 @@
       "verb": "GET",
       "route": "/monitoring/metrics/resources",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 49
+      "source_line": 51
     },
     {
       "key": "Infrastructure/ProductionMonitoringEndpoints:GET:/monitoring/metrics/upload-queue",
@@ -2151,7 +2181,7 @@
       "verb": "GET",
       "route": "/monitoring/metrics/upload-queue",
       "source_file": "Infrastructure/Monitoring/ProductionMonitoringEndpoints.cs",
-      "source_line": 61
+      "source_line": 63
     },
     {
       "key": "Infrastructure/StyleEndpoints:GET:/api/styles/{layerId:int}.json",
@@ -4384,6 +4414,26 @@
       "source_line": 62
     },
     {
+      "key": "Reporting/AnalysisReportEndpoints:GET:/api/v{version:apiVersion}/analysis/reports/{jobId}/",
+      "feature": "Reporting",
+      "file": "AnalysisReportEndpoints",
+      "kind": "http",
+      "verb": "GET",
+      "route": "/api/v{version:apiVersion}/analysis/reports/{jobId}/",
+      "source_file": "Reporting/AnalysisReportEndpoints.cs",
+      "source_line": 39
+    },
+    {
+      "key": "Reporting/AnalysisReportEndpoints:GET:/api/v{version:apiVersion}/analysis/reports/{jobId}/render",
+      "feature": "Reporting",
+      "file": "AnalysisReportEndpoints",
+      "kind": "http",
+      "verb": "GET",
+      "route": "/api/v{version:apiVersion}/analysis/reports/{jobId}/render",
+      "source_file": "Reporting/AnalysisReportEndpoints.cs",
+      "source_line": 43
+    },
+    {
       "key": "Spec/SpecEndpoints:GET:/v1/spec/artifact/{hash}",
       "feature": "Spec",
       "file": "SpecEndpoints",
@@ -4391,7 +4441,7 @@
       "verb": "GET",
       "route": "/v1/spec/artifact/{hash}",
       "source_file": "Spec/SpecEndpoints.cs",
-      "source_line": 51
+      "source_line": 59
     },
     {
       "key": "Spec/SpecEndpoints:POST:/v1/spec/apply",
@@ -4401,7 +4451,7 @@
       "verb": "POST",
       "route": "/v1/spec/apply",
       "source_file": "Spec/SpecEndpoints.cs",
-      "source_line": 38
+      "source_line": 46
     },
     {
       "key": "Spec/SpecEndpoints:POST:/v1/spec/cancel",
@@ -4411,7 +4461,7 @@
       "verb": "POST",
       "route": "/v1/spec/cancel",
       "source_file": "Spec/SpecEndpoints.cs",
-      "source_line": 44
+      "source_line": 52
     },
     {
       "key": "Spec/SpecEndpoints:POST:/v1/spec/plan",
@@ -4421,7 +4471,17 @@
       "verb": "POST",
       "route": "/v1/spec/plan",
       "source_file": "Spec/SpecEndpoints.cs",
-      "source_line": 31
+      "source_line": 39
+    },
+    {
+      "key": "Spec/SpecEndpoints:POST:/v1/spec/validate",
+      "feature": "Spec",
+      "file": "SpecEndpoints",
+      "kind": "http",
+      "verb": "POST",
+      "route": "/v1/spec/validate",
+      "source_file": "Spec/SpecEndpoints.cs",
+      "source_line": 32
     },
     {
       "key": "StaticMap/StaticMapEndpoints:GET:/static/{serviceId}/bbox/{bbox}/{dimensions}.{format}",

--- a/src/Honua.Admin/Components/SpecWorkspace/DslSectionEditor.razor
+++ b/src/Honua.Admin/Components/SpecWorkspace/DslSectionEditor.razor
@@ -79,7 +79,7 @@
     private IReadOnlyList<CatalogCandidate> _candidates = Array.Empty<CatalogCandidate>();
     private long _lastLatencyMs;
     private string _lastCached = "–";
-    private CompletionRequest? _completion;
+    private SpecCompletionRequest? _completion;
 
     [Parameter] public SpecSectionId SectionId { get; set; }
 
@@ -131,7 +131,11 @@
         var selection = await ReadSelectionAsync();
         State.SetDslSelection(SectionId, selection.Start, selection.End);
 
-        var query = BuildCompletionRequest(State.GetSectionText(SectionId), selection.Start);
+        var query = SpecCompletionQueryBuilder.Build(
+            State.GetSectionText(SectionId),
+            selection.Start,
+            SectionId,
+            State.PrincipalId);
         _completion = query;
         if (query is null)
         {
@@ -148,12 +152,7 @@
 
     private async Task InsertCandidateAsync(CatalogCandidate candidate)
     {
-        var token = candidate.Kind switch
-        {
-            CatalogCandidateKind.Dataset => $"@{candidate.Id}",
-            CatalogCandidateKind.Column => $"@{candidate.Parent}.{candidate.Label}",
-            _ => candidate.Label
-        };
+        var token = SpecCompletionQueryBuilder.GetInsertionText(candidate, _completion);
 
         await State.InsertDslTokenAsync(token);
         _candidates = Array.Empty<CatalogCandidate>();
@@ -171,73 +170,6 @@
             var length = State.GetSectionText(SectionId).Length;
             return new TextSelection(length, length);
         }
-    }
-
-    private CompletionRequest? BuildCompletionRequest(string text, int cursor)
-    {
-        if (cursor < 0 || cursor > text.Length)
-        {
-            return null;
-        }
-
-        var prefixText = text[..cursor];
-        var atIndex = prefixText.LastIndexOf('@');
-        if (atIndex < 0)
-        {
-            return null;
-        }
-
-        var tail = prefixText[atIndex..];
-        if (tail.Any(ch => char.IsWhiteSpace(ch) || ch == ',' || ch == ')' || ch == '(' || ch == ':'))
-        {
-            return null;
-        }
-
-        var raw = prefixText[(atIndex + 1)..];
-        if (raw.Length == 0)
-        {
-            return new CompletionRequest(
-                new ResolveQuery
-                {
-                    Trigger = CatalogTrigger.AtMention,
-                    Prefix = string.Empty,
-                    PrincipalId = State.PrincipalId
-                },
-                atIndex,
-                cursor);
-        }
-
-        var dotIndex = raw.IndexOf('.');
-        if (dotIndex >= 0)
-        {
-            var parent = raw[..dotIndex];
-            var memberPrefix = raw[(dotIndex + 1)..];
-            if (parent.Length == 0)
-            {
-                return null;
-            }
-
-            return new CompletionRequest(
-                new ResolveQuery
-                {
-                    Trigger = CatalogTrigger.DotMember,
-                    Parent = parent,
-                    Prefix = memberPrefix,
-                    PrincipalId = State.PrincipalId
-                },
-                atIndex,
-                cursor);
-        }
-
-        return new CompletionRequest(
-            new ResolveQuery
-            {
-                Trigger = CatalogTrigger.AtMention,
-                Prefix = raw,
-                PrincipalId = State.PrincipalId
-            },
-            atIndex,
-            cursor);
     }
 
     private string BuildHighlightedMarkup()
@@ -330,8 +262,6 @@
         CatalogCandidateKind.SymbologyRamp => Icons.Material.Filled.Palette,
         _ => Icons.Material.Filled.Code
     };
-
-    private sealed record CompletionRequest(ResolveQuery Query, int ReplaceStart, int ReplaceEnd);
 
     private sealed record TextSelection(int Start, int End);
 

--- a/src/Honua.Admin/Services/SpecWorkspace/SpecCompletionQueryBuilder.cs
+++ b/src/Honua.Admin/Services/SpecWorkspace/SpecCompletionQueryBuilder.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Linq;
+using Honua.Admin.Models.SpecWorkspace;
+
+namespace Honua.Admin.Services.SpecWorkspace;
+
+public sealed record SpecCompletionRequest(ResolveQuery Query, int ReplaceStart, int ReplaceEnd);
+
+public static class SpecCompletionQueryBuilder
+{
+    public static SpecCompletionRequest? Build(string? text, int cursor, SpecSectionId section, string principalId)
+    {
+        text ??= string.Empty;
+        if (cursor < 0 || cursor > text.Length)
+        {
+            return null;
+        }
+
+        var atMention = BuildAtMentionRequest(text, cursor, principalId);
+        if (atMention is not null)
+        {
+            return atMention;
+        }
+
+        if (section == SpecSectionId.Map)
+        {
+            var symbology = BuildSymbologyRequest(text, cursor, principalId);
+            if (symbology is not null)
+            {
+                return symbology;
+            }
+        }
+
+        return section == SpecSectionId.Compute
+            ? BuildParamListRequest(text, cursor, principalId)
+            : null;
+    }
+
+    public static string GetInsertionText(CatalogCandidate candidate, SpecCompletionRequest? completion) =>
+        completion?.Query.Trigger switch
+        {
+            CatalogTrigger.AtMention when candidate.Kind == CatalogCandidateKind.Dataset => $"@{candidate.Id}",
+            CatalogTrigger.DotMember when candidate.Kind == CatalogCandidateKind.Column => $"@{candidate.Parent}.{candidate.Label}",
+            CatalogTrigger.ParamList => $"{candidate.Label}=",
+            CatalogTrigger.SymbologyRamp => candidate.Label,
+            _ => candidate.Kind switch
+            {
+                CatalogCandidateKind.Dataset => $"@{candidate.Id}",
+                CatalogCandidateKind.Column => $"@{candidate.Parent}.{candidate.Label}",
+                _ => candidate.Label
+            }
+        };
+
+    private static SpecCompletionRequest? BuildAtMentionRequest(string text, int cursor, string principalId)
+    {
+        var prefixText = text[..cursor];
+        var atIndex = prefixText.LastIndexOf('@');
+        if (atIndex < 0)
+        {
+            return null;
+        }
+
+        var tail = prefixText[atIndex..];
+        if (tail.Any(ch => char.IsWhiteSpace(ch) || ch == ',' || ch == ')' || ch == '(' || ch == ':'))
+        {
+            return null;
+        }
+
+        var raw = prefixText[(atIndex + 1)..];
+        if (raw.Length == 0)
+        {
+            return new SpecCompletionRequest(
+                new ResolveQuery
+                {
+                    Trigger = CatalogTrigger.AtMention,
+                    Prefix = string.Empty,
+                    PrincipalId = principalId
+                },
+                atIndex,
+                cursor);
+        }
+
+        var dotIndex = raw.IndexOf('.');
+        if (dotIndex >= 0)
+        {
+            var parent = raw[..dotIndex];
+            var memberPrefix = raw[(dotIndex + 1)..];
+            if (parent.Length == 0)
+            {
+                return null;
+            }
+
+            return new SpecCompletionRequest(
+                new ResolveQuery
+                {
+                    Trigger = CatalogTrigger.DotMember,
+                    Parent = parent,
+                    Prefix = memberPrefix,
+                    PrincipalId = principalId
+                },
+                atIndex,
+                cursor);
+        }
+
+        return new SpecCompletionRequest(
+            new ResolveQuery
+            {
+                Trigger = CatalogTrigger.AtMention,
+                Prefix = raw,
+                PrincipalId = principalId
+            },
+            atIndex,
+            cursor);
+    }
+
+    private static SpecCompletionRequest? BuildSymbologyRequest(string text, int cursor, string principalId)
+    {
+        var prefixText = text[..cursor];
+        var lineStart = LastLineStart(prefixText);
+        var linePrefix = prefixText[lineStart..];
+
+        var valueStart = LastTokenValueStart(linePrefix, "symbology=");
+        valueStart ??= LastCallArgumentStart(linePrefix, "symbology(");
+        if (valueStart is not { } localStart)
+        {
+            return null;
+        }
+
+        var replaceStart = lineStart + localStart;
+        var prefix = text[replaceStart..cursor];
+        if (!IsCompletionWord(prefix))
+        {
+            return null;
+        }
+
+        return new SpecCompletionRequest(
+            new ResolveQuery
+            {
+                Trigger = CatalogTrigger.SymbologyRamp,
+                Prefix = prefix,
+                PrincipalId = principalId
+            },
+            replaceStart,
+            cursor);
+    }
+
+    private static SpecCompletionRequest? BuildParamListRequest(string text, int cursor, string principalId)
+    {
+        var prefixText = text[..cursor];
+        var lineStart = LastLineStart(prefixText);
+        var linePrefix = prefixText[lineStart..];
+        var tokenStart = LastTokenStart(linePrefix);
+        var prefix = linePrefix[tokenStart..];
+        if (!HasPriorToken(linePrefix, tokenStart)
+            || prefix.Contains('=', StringComparison.Ordinal)
+            || prefix.Contains('@', StringComparison.Ordinal)
+            || prefix.Contains('.', StringComparison.Ordinal)
+            || !IsIdentifierPrefix(prefix))
+        {
+            return null;
+        }
+
+        var replaceStart = lineStart + tokenStart;
+        return new SpecCompletionRequest(
+            new ResolveQuery
+            {
+                Trigger = CatalogTrigger.ParamList,
+                Prefix = prefix,
+                PrincipalId = principalId
+            },
+            replaceStart,
+            cursor);
+    }
+
+    private static int LastLineStart(string text)
+    {
+        var newline = text.LastIndexOfAny(['\n', '\r']);
+        return newline < 0 ? 0 : newline + 1;
+    }
+
+    private static int LastTokenStart(string linePrefix)
+    {
+        var index = linePrefix.Length - 1;
+        while (index >= 0 && !char.IsWhiteSpace(linePrefix[index]) && linePrefix[index] is not ',' and not '(' and not ')')
+        {
+            index--;
+        }
+
+        return index + 1;
+    }
+
+    private static int? LastTokenValueStart(string linePrefix, string marker)
+    {
+        var markerIndex = linePrefix.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            return null;
+        }
+
+        var valueStart = markerIndex + marker.Length;
+        var valuePrefix = linePrefix[valueStart..];
+        return valuePrefix.Any(ch => char.IsWhiteSpace(ch) || ch == ',' || ch == ')' || ch == '(')
+            ? null
+            : valueStart;
+    }
+
+    private static int? LastCallArgumentStart(string linePrefix, string marker)
+    {
+        var markerIndex = linePrefix.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            return null;
+        }
+
+        var valueStart = markerIndex + marker.Length;
+        var valuePrefix = linePrefix[valueStart..];
+        if (valuePrefix.Contains(')', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var commaIndex = valuePrefix.LastIndexOf(',');
+        if (commaIndex >= 0)
+        {
+            valueStart += commaIndex + 1;
+        }
+
+        while (valueStart < linePrefix.Length && char.IsWhiteSpace(linePrefix[valueStart]))
+        {
+            valueStart++;
+        }
+
+        return valueStart;
+    }
+
+    private static bool HasPriorToken(string linePrefix, int tokenStart) =>
+        linePrefix[..tokenStart].Any(ch => !char.IsWhiteSpace(ch) && ch is not ',' and not '(' and not ')');
+
+    private static bool IsCompletionWord(string value) =>
+        value.All(ch => char.IsLetterOrDigit(ch) || ch == '_' || ch == '-');
+
+    private static bool IsIdentifierPrefix(string value) =>
+        value.All(ch => char.IsLetter(ch) || ch == '_');
+}

--- a/tests/Honua.Admin.Tests/SpecCompletionQueryBuilderTests.cs
+++ b/tests/Honua.Admin.Tests/SpecCompletionQueryBuilderTests.cs
@@ -1,0 +1,97 @@
+using Honua.Admin.Models.SpecWorkspace;
+using Honua.Admin.Services.SpecWorkspace;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class SpecCompletionQueryBuilderTests
+{
+    [Fact]
+    public void Build_returns_dataset_completion_for_at_mentions()
+    {
+        const string text = "source=@par";
+
+        var completion = SpecCompletionQueryBuilder.Build(text, text.Length, SpecSectionId.Sources, "operator");
+
+        Assert.NotNull(completion);
+        Assert.Equal(CatalogTrigger.AtMention, completion.Query.Trigger);
+        Assert.Equal("par", completion.Query.Prefix);
+        Assert.Equal(7, completion.ReplaceStart);
+        Assert.Equal(11, completion.ReplaceEnd);
+    }
+
+    [Fact]
+    public void Build_returns_column_completion_for_dot_members()
+    {
+        const string text = "aggregate inputs=@parcels.co";
+
+        var completion = SpecCompletionQueryBuilder.Build(text, text.Length, SpecSectionId.Compute, "operator");
+
+        Assert.NotNull(completion);
+        Assert.Equal(CatalogTrigger.DotMember, completion.Query.Trigger);
+        Assert.Equal("parcels", completion.Query.Parent);
+        Assert.Equal("co", completion.Query.Prefix);
+    }
+
+    [Fact]
+    public void Build_returns_param_list_completion_for_compute_argument_prefix()
+    {
+        const string text = "aggregate inputs=@parcels me";
+
+        var completion = SpecCompletionQueryBuilder.Build(text, text.Length, SpecSectionId.Compute, "operator");
+
+        Assert.NotNull(completion);
+        Assert.Equal(CatalogTrigger.ParamList, completion.Query.Trigger);
+        Assert.Equal("me", completion.Query.Prefix);
+        Assert.Equal(text.LastIndexOf("me", StringComparison.Ordinal), completion.ReplaceStart);
+        Assert.Equal(text.Length, completion.ReplaceEnd);
+    }
+
+    [Fact]
+    public void Build_returns_symbology_completion_for_map_section_assignment()
+    {
+        const string text = "layer source=@parcels symbology=vi";
+
+        var completion = SpecCompletionQueryBuilder.Build(text, text.Length, SpecSectionId.Map, "operator");
+
+        Assert.NotNull(completion);
+        Assert.Equal(CatalogTrigger.SymbologyRamp, completion.Query.Trigger);
+        Assert.Equal("vi", completion.Query.Prefix);
+        Assert.Equal(text.LastIndexOf("vi", StringComparison.Ordinal), completion.ReplaceStart);
+    }
+
+    [Fact]
+    public void Build_returns_symbology_completion_for_map_symbology_call()
+    {
+        const string text = "map.symbology(pl";
+
+        var completion = SpecCompletionQueryBuilder.Build(text, text.Length, SpecSectionId.Map, "operator");
+
+        Assert.NotNull(completion);
+        Assert.Equal(CatalogTrigger.SymbologyRamp, completion.Query.Trigger);
+        Assert.Equal("pl", completion.Query.Prefix);
+    }
+
+    [Fact]
+    public void GetInsertionText_adds_equals_for_param_list_candidates()
+    {
+        var completion = new SpecCompletionRequest(
+            new ResolveQuery
+            {
+                Trigger = CatalogTrigger.ParamList,
+                Prefix = "me"
+            },
+            0,
+            2);
+        var candidate = new CatalogCandidate
+        {
+            Id = "metric",
+            Kind = CatalogCandidateKind.Operator,
+            Label = "metric"
+        };
+
+        var text = SpecCompletionQueryBuilder.GetInsertionText(candidate, completion);
+
+        Assert.Equal("metric=", text);
+    }
+}


### PR DESCRIPTION
Related to #25. This is an admin-side readiness slice; it does not close the epic because SDK and gRPC follow-up contracts are still tracked separately.

## Summary
- extract spec DSL completion query parsing into a reusable helper
- add compute parameter-list completions and map symbology ramp completions while preserving @ dataset and . column completions
- refresh generated admin API coverage inventory and seed rows for new honua-server endpoints

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
- Playwright smoke against http://localhost:5117/operator/spec for dataset, compute parameter, and symbology completions

## Dependency status checked
- honua-server#788 closed
- honua-server#789 closed
- honua-server#790 closed
- honua-server-admin#26 closed
- honua-sdk-dotnet#74 open follow-up
- geospatial-grpc#12 open follow-up
