### PR TITLE
chore: ignore claude local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj/
 ## IDE
 .vs/
 .idea/
+.claude/
 *.swp
 *~
 


### PR DESCRIPTION
## Summary
- add `.claude/` to `.gitignore` so local Claude workspace state is not tracked

## Notes
- `AGENTS.md`, `NuGet.config`, and the improved CI workflow are already present on `master`
- direct push to `master` was blocked by branch protection, so this PR carries the remaining one-line ignore change

## Validation
- git diff --check
