### PR TITLE
feat: route admin client through SDK surfaces

### DIFF
--- a/src/Honua.Admin/Services/Admin/HonuaAdminClient.cs
+++ b/src/Honua.Admin/Services/Admin/HonuaAdminClient.cs
@@ -11,11 +11,15 @@ using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using Honua.Admin.Models.Admin;
+using Honua.Sdk.Admin.Exceptions;
+using SdkAdminClient = Honua.Sdk.Admin.IHonuaAdminClient;
+using SdkAdminHttpClient = Honua.Sdk.Admin.HonuaAdminClient;
 
 namespace Honua.Admin.Services.Admin;
 
 /// <summary>
-/// Hand-rolled typed HttpClient implementation of <see cref="IHonuaAdminClient"/>.
+/// Admin UI client that delegates SDK-stable REST contracts to Honua.Sdk.Admin
+/// while keeping admin-only endpoints in this repo.
 /// Authentication and base-URL rebasing live in <c>AdminAuthHandler</c>; 401/CORS
 /// handling lives in <c>GlobalErrorHandler</c>.
 /// </summary>
@@ -25,11 +29,18 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
 
     private readonly HttpClient _http;
     private readonly IAdminTelemetry _telemetry;
+    private readonly SdkAdminClient _sdk;
 
     public HonuaAdminClient(HttpClient http, IAdminTelemetry telemetry)
+        : this(http, telemetry, new SdkAdminHttpClient(http))
+    {
+    }
+
+    public HonuaAdminClient(HttpClient http, IAdminTelemetry telemetry, SdkAdminClient sdk)
     {
         _http = http;
         _telemetry = telemetry;
+        _sdk = sdk;
     }
 
     public Task<FeatureOverview> GetFeatureOverviewAsync(CancellationToken cancellationToken)
@@ -62,175 +73,192 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         => GetAsync(nameof(GetAdminOpenApiAsync), $"{ApiVersionPrefix}/openapi.json", TypeInfo<JsonElement>(), cancellationToken);
 
     public async Task<IReadOnlyList<ConnectionSummary>> ListConnectionsAsync(CancellationToken cancellationToken)
-        => await GetApiAsync(nameof(ListConnectionsAsync), $"{ApiVersionPrefix}/connections/", TypeInfo<AdminApiResponse<ConnectionSummary[]>>(), cancellationToken)
+        => await ExecuteSdkAsync(
+                nameof(ListConnectionsAsync),
+                async ct => SdkAdminModelMapper.MapList(
+                    await _sdk.ListConnectionsAsync(ct).ConfigureAwait(false),
+                    SdkAdminModelMapper.ToConnectionSummary),
+                cancellationToken)
             .ConfigureAwait(false);
 
     public Task<ConnectionDetail> GetConnectionAsync(string connectionId, CancellationToken cancellationToken)
-        => GetApiAsync(nameof(GetConnectionAsync), $"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}", TypeInfo<AdminApiResponse<ConnectionDetail>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetConnectionAsync),
+            async ct => SdkAdminModelMapper.ToConnectionDetail(await _sdk.GetConnectionAsync(connectionId, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ConnectionSummary> CreateConnectionAsync(CreateConnectionRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(
+        => ExecuteSdkAsync(
             nameof(CreateConnectionAsync),
-            HttpMethod.Post,
-            $"{ApiVersionPrefix}/connections/",
-            request,
-            TypeInfo<CreateConnectionRequest>(),
-            TypeInfo<AdminApiResponse<ConnectionSummary>>(),
+            async ct => SdkAdminModelMapper.ToConnectionSummary(
+                await _sdk.CreateConnectionAsync(SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
             cancellationToken);
 
     public Task<ConnectionSummary> UpdateConnectionAsync(string connectionId, UpdateConnectionRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(
+        => ExecuteSdkAsync(
             nameof(UpdateConnectionAsync),
-            HttpMethod.Put,
-            $"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}",
-            request,
-            TypeInfo<UpdateConnectionRequest>(),
-            TypeInfo<AdminApiResponse<ConnectionSummary>>(),
+            async ct => SdkAdminModelMapper.ToConnectionSummary(
+                await _sdk.UpdateConnectionAsync(connectionId, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
             cancellationToken);
 
-    public async Task DeleteConnectionAsync(string connectionId, CancellationToken cancellationToken)
-    {
-        try
+    public Task DeleteConnectionAsync(string connectionId, CancellationToken cancellationToken)
+        => ExecuteSdkAsync(
+            nameof(DeleteConnectionAsync),
+            async ct =>
         {
-            using var response = await _http.DeleteAsync(
-                $"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}",
-                cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-        }
-        catch (HttpRequestException ex)
-        {
-            _telemetry.ClientRequestFailed(nameof(DeleteConnectionAsync), ex.Message);
-            throw;
-        }
-    }
+            await _sdk.DeleteConnectionAsync(connectionId, ct).ConfigureAwait(false);
+        },
+            cancellationToken);
 
     public Task<TestConnectionResult> TestDraftConnectionAsync(CreateConnectionRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(
+        => ExecuteSdkAsync(
             nameof(TestDraftConnectionAsync),
-            HttpMethod.Post,
-            $"{ApiVersionPrefix}/connections/test",
-            request,
-            TypeInfo<CreateConnectionRequest>(),
-            TypeInfo<AdminApiResponse<TestConnectionResult>>(),
+            async ct => SdkAdminModelMapper.ToTestConnectionResult(
+                await _sdk.TestDraftConnectionAsync(SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
             cancellationToken);
 
     public Task<TestConnectionResult> TestConnectionAsync(string connectionId, CancellationToken cancellationToken)
-        => PostEmptyApiAsync<TestConnectionResult>(
+        => ExecuteSdkAsync(
             nameof(TestConnectionAsync),
-            $"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}/test",
-            TypeInfo<AdminApiResponse<TestConnectionResult>>(),
+            async ct => SdkAdminModelMapper.ToTestConnectionResult(await _sdk.TestConnectionAsync(connectionId, ct).ConfigureAwait(false)),
             cancellationToken);
 
     public Task<EncryptionValidationResult> ValidateEncryptionAsync(CancellationToken cancellationToken)
-        => PostEmptyApiAsync<EncryptionValidationResult>(
+        => ExecuteSdkAsync(
             nameof(ValidateEncryptionAsync),
-            $"{ApiVersionPrefix}/connections/encryption/validate",
-            TypeInfo<AdminApiResponse<EncryptionValidationResult>>(),
+            async ct => SdkAdminModelMapper.ToEncryptionValidationResult(await _sdk.ValidateEncryptionAsync(ct).ConfigureAwait(false)),
             cancellationToken);
 
     public Task<KeyRotationResult> RotateEncryptionKeyAsync(CancellationToken cancellationToken)
-        => PostEmptyApiAsync<KeyRotationResult>(
+        => ExecuteSdkAsync(
             nameof(RotateEncryptionKeyAsync),
-            $"{ApiVersionPrefix}/connections/encryption/rotate-key",
-            TypeInfo<AdminApiResponse<KeyRotationResult>>(),
+            async ct => SdkAdminModelMapper.ToKeyRotationResult(await _sdk.RotateEncryptionKeyAsync(ct).ConfigureAwait(false)),
             cancellationToken);
 
-    public async Task<IReadOnlyList<DiscoveredTable>> DiscoverConnectionTablesAsync(string connectionId, CancellationToken cancellationToken)
-    {
-        var response = await GetAsync(
+    public Task<IReadOnlyList<DiscoveredTable>> DiscoverConnectionTablesAsync(string connectionId, CancellationToken cancellationToken)
+        => ExecuteSdkAsync(
             nameof(DiscoverConnectionTablesAsync),
-            $"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}/tables",
-            TypeInfo<TableDiscoveryResponse>(),
-            cancellationToken).ConfigureAwait(false);
-        return response.Tables;
-    }
+            async ct => SdkAdminModelMapper.MapList(
+                (await _sdk.DiscoverTablesAsync(connectionId, ct).ConfigureAwait(false)).Tables,
+                SdkAdminModelMapper.ToDiscoveredTable),
+            cancellationToken);
 
     public async Task<IReadOnlyList<LayerSummary>> ListLayersAsync(string connectionId, string? serviceName, CancellationToken cancellationToken)
-        => await GetApiAsync(
+        => await ExecuteSdkAsync(
                 nameof(ListLayersAsync),
-                WithServiceName($"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}/layers/", serviceName),
-                TypeInfo<AdminApiResponse<LayerSummary[]>>(),
+                async ct => SdkAdminModelMapper.MapList(
+                    await _sdk.ListLayersAsync(connectionId, serviceName, ct).ConfigureAwait(false),
+                    SdkAdminModelMapper.ToLayerSummary),
                 cancellationToken)
             .ConfigureAwait(false);
 
     public Task<LayerSummary> PublishLayerAsync(string connectionId, PublishLayerRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(
+        => ExecuteSdkAsync(
             nameof(PublishLayerAsync),
-            HttpMethod.Post,
-            $"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}/layers/",
-            request,
-            TypeInfo<PublishLayerRequest>(),
-            TypeInfo<AdminApiResponse<LayerSummary>>(),
+            async ct => SdkAdminModelMapper.ToLayerSummary(
+                await _sdk.PublishLayerAsync(connectionId, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
             cancellationToken);
 
     public Task<LayerSummary> SetLayerEnabledAsync(string connectionId, int layerId, bool enabled, string? serviceName, CancellationToken cancellationToken)
-        => SendApiAsync(
+        => ExecuteSdkAsync(
             nameof(SetLayerEnabledAsync),
-            HttpMethod.Put,
-            WithServiceName($"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}/layers/{layerId}/enabled", serviceName),
-            new LayerEnabledRequest { Enabled = enabled },
-            TypeInfo<LayerEnabledRequest>(),
-            TypeInfo<AdminApiResponse<LayerSummary>>(),
+            async ct => SdkAdminModelMapper.ToLayerSummary(
+                await _sdk.SetLayerEnabledAsync(connectionId, layerId, enabled, serviceName, ct).ConfigureAwait(false)),
             cancellationToken);
 
     public async Task<IReadOnlyList<LayerSummary>> SetServiceLayersEnabledAsync(string connectionId, bool enabled, string? serviceName, CancellationToken cancellationToken)
-        => await SendApiAsync(
+        => await ExecuteSdkAsync(
                 nameof(SetServiceLayersEnabledAsync),
-                HttpMethod.Put,
-                WithServiceName($"{ApiVersionPrefix}/connections/{Uri.EscapeDataString(connectionId)}/layers/enabled", serviceName),
-                new LayerEnabledRequest { Enabled = enabled },
-                TypeInfo<LayerEnabledRequest>(),
-                TypeInfo<AdminApiResponse<LayerSummary[]>>(),
+                async ct => SdkAdminModelMapper.MapList(
+                    await _sdk.SetServiceLayersEnabledAsync(connectionId, enabled, serviceName, ct).ConfigureAwait(false),
+                    SdkAdminModelMapper.ToLayerSummary),
                 cancellationToken)
             .ConfigureAwait(false);
 
     public Task<LayerStyle> GetLayerStyleAsync(int layerId, CancellationToken cancellationToken)
-        => GetApiAsync(nameof(GetLayerStyleAsync), $"{ApiVersionPrefix}/metadata/layers/{layerId}/style", TypeInfo<AdminApiResponse<LayerStyle>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetLayerStyleAsync),
+            async ct => SdkAdminModelMapper.ToLayerStyle(await _sdk.GetLayerStyleAsync(layerId, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<LayerStyle> UpdateLayerStyleAsync(int layerId, LayerStyleUpdateRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(
+        => ExecuteSdkAsync(
             nameof(UpdateLayerStyleAsync),
-            HttpMethod.Put,
-            $"{ApiVersionPrefix}/metadata/layers/{layerId}/style",
-            request,
-            TypeInfo<LayerStyleUpdateRequest>(),
-            TypeInfo<AdminApiResponse<LayerStyle>>(),
+            async ct => SdkAdminModelMapper.ToLayerStyle(
+                await _sdk.UpdateLayerStyleAsync(layerId, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
             cancellationToken);
 
     public async Task<IReadOnlyList<ServiceSummary>> ListServicesAsync(CancellationToken cancellationToken)
-        => await GetApiAsync(nameof(ListServicesAsync), $"{ApiVersionPrefix}/services/", TypeInfo<AdminApiResponse<ServiceSummary[]>>(), cancellationToken)
+        => await ExecuteSdkAsync(
+                nameof(ListServicesAsync),
+                async ct => SdkAdminModelMapper.MapList(
+                    await _sdk.ListServicesAsync(ct).ConfigureAwait(false),
+                    SdkAdminModelMapper.ToServiceSummary),
+                cancellationToken)
             .ConfigureAwait(false);
 
     public Task<ServiceSettings> GetServiceSettingsAsync(string serviceName, CancellationToken cancellationToken)
-        => GetApiAsync(nameof(GetServiceSettingsAsync), $"{ApiVersionPrefix}/services/{Uri.EscapeDataString(serviceName)}/settings", TypeInfo<AdminApiResponse<ServiceSettings>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetServiceSettingsAsync),
+            async ct => SdkAdminModelMapper.ToServiceSettings(await _sdk.GetServiceSettingsAsync(serviceName, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ServiceSettings> UpdateServiceProtocolsAsync(string serviceName, UpdateProtocolsRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(nameof(UpdateServiceProtocolsAsync), HttpMethod.Put, $"{ApiVersionPrefix}/services/{Uri.EscapeDataString(serviceName)}/protocols", request, TypeInfo<UpdateProtocolsRequest>(), TypeInfo<AdminApiResponse<ServiceSettings>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(UpdateServiceProtocolsAsync),
+            async ct => SdkAdminModelMapper.ToServiceSettings(
+                await _sdk.UpdateProtocolsAsync(serviceName, request.EnabledProtocols, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ServiceSettings> UpdateServiceMapServerAsync(string serviceName, MapServerSettings request, CancellationToken cancellationToken)
-        => SendApiAsync(nameof(UpdateServiceMapServerAsync), HttpMethod.Put, $"{ApiVersionPrefix}/services/{Uri.EscapeDataString(serviceName)}/mapserver", request, TypeInfo<MapServerSettings>(), TypeInfo<AdminApiResponse<ServiceSettings>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(UpdateServiceMapServerAsync),
+            async ct => SdkAdminModelMapper.ToServiceSettings(
+                await _sdk.UpdateMapServerSettingsAsync(serviceName, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ServiceSettings> UpdateServiceAccessPolicyAsync(string serviceName, AccessPolicySettings request, CancellationToken cancellationToken)
-        => SendApiAsync(nameof(UpdateServiceAccessPolicyAsync), HttpMethod.Put, $"{ApiVersionPrefix}/services/{Uri.EscapeDataString(serviceName)}/access-policy", request, TypeInfo<AccessPolicySettings>(), TypeInfo<AdminApiResponse<ServiceSettings>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(UpdateServiceAccessPolicyAsync),
+            async ct => SdkAdminModelMapper.ToServiceSettings(
+                await _sdk.UpdateAccessPolicyAsync(serviceName, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ServiceSettings> UpdateServiceTimeInfoAsync(string serviceName, TimeInfoSettings request, CancellationToken cancellationToken)
-        => SendApiAsync(nameof(UpdateServiceTimeInfoAsync), HttpMethod.Put, $"{ApiVersionPrefix}/services/{Uri.EscapeDataString(serviceName)}/timeinfo", request, TypeInfo<TimeInfoSettings>(), TypeInfo<AdminApiResponse<ServiceSettings>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(UpdateServiceTimeInfoAsync),
+            async ct => SdkAdminModelMapper.ToServiceSettings(
+                await _sdk.UpdateTimeInfoAsync(serviceName, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<LayerMetadataResponse> UpdateServiceLayerMetadataAsync(string serviceName, int layerId, UpdateLayerMetadataRequest request, CancellationToken cancellationToken)
-        => SendApiAsync(nameof(UpdateServiceLayerMetadataAsync), HttpMethod.Put, $"{ApiVersionPrefix}/services/{Uri.EscapeDataString(serviceName)}/layers/{layerId}/metadata", request, TypeInfo<UpdateLayerMetadataRequest>(), TypeInfo<AdminApiResponse<LayerMetadataResponse>>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(UpdateServiceLayerMetadataAsync),
+            async ct => SdkAdminModelMapper.ToLayerMetadataResponse(
+                await _sdk.UpdateLayerMetadataAsync(serviceName, layerId, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public async Task<IReadOnlyList<MetadataResource>> ListMetadataResourcesAsync(string? kind, string? resourceNamespace, CancellationToken cancellationToken)
-        => await GetApiAsync(
+        => await ExecuteSdkAsync(
                 nameof(ListMetadataResourcesAsync),
-                WithMetadataResourceQuery($"{ApiVersionPrefix}/metadata/resources/", kind, resourceNamespace),
-                TypeInfo<AdminApiResponse<MetadataResource[]>>(),
+                async ct => SdkAdminModelMapper.MapList(
+                    await _sdk.ListMetadataResourcesAsync(kind, resourceNamespace, ct).ConfigureAwait(false),
+                    SdkAdminModelMapper.ToMetadataResource),
                 cancellationToken)
             .ConfigureAwait(false);
 
     public Task<MetadataResourceResponse> GetMetadataResourceAsync(string kind, string resourceNamespace, string name, CancellationToken cancellationToken)
-        => GetMetadataResourceCoreAsync(
+        => ExecuteSdkAsync(
             nameof(GetMetadataResourceAsync),
-            MetadataResourcePath(kind, resourceNamespace, name),
+            async ct =>
+            {
+                var (resource, eTag) = await _sdk.GetMetadataResourceAsync(kind, resourceNamespace, name, ct).ConfigureAwait(false);
+                return new MetadataResourceResponse
+                {
+                    Resource = SdkAdminModelMapper.ToMetadataResource(resource),
+                    ETag = eTag,
+                };
+            },
             cancellationToken);
 
     public Task<MetadataResourceResponse> CreateMetadataResourceAsync(MetadataResource resource, CancellationToken cancellationToken)
@@ -261,7 +289,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
             cancellationToken);
     }
 
-    public async Task DeleteMetadataResourceAsync(
+    public Task DeleteMetadataResourceAsync(
         string kind,
         string resourceNamespace,
         string name,
@@ -270,18 +298,13 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     {
         EnsureIfMatch(ifMatch, nameof(DeleteMetadataResourceAsync));
 
-        try
+        return ExecuteSdkAsync(
+            nameof(DeleteMetadataResourceAsync),
+            async ct =>
         {
-            using var message = new HttpRequestMessage(HttpMethod.Delete, MetadataResourcePath(kind, resourceNamespace, name));
-            message.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-            using var response = await _http.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-        }
-        catch (HttpRequestException ex)
-        {
-            _telemetry.ClientRequestFailed(nameof(DeleteMetadataResourceAsync), ex.Message);
-            throw;
-        }
+            await _sdk.DeleteMetadataResourceAsync(kind, resourceNamespace, name, ifMatch, ct).ConfigureAwait(false);
+        },
+            cancellationToken);
     }
 
     public Task<DeployPreflightResult> GetDeployPreflightAsync(CancellationToken cancellationToken)
@@ -443,6 +466,58 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     private static JsonTypeInfo<T> TypeInfo<T>()
         => (JsonTypeInfo<T>)AdminJsonContext.Default.GetTypeInfo(typeof(T))!;
 
+    private async Task ExecuteSdkAsync(
+        string operation,
+        Func<CancellationToken, Task> action,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await action(cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            _telemetry.ClientRequestFailed(operation, ex.Message);
+            throw;
+        }
+        catch (HonuaAdminApiException ex)
+        {
+            _telemetry.ClientRequestFailed(operation, ex.Message);
+            throw;
+        }
+        catch (HonuaAdminOperationException ex)
+        {
+            _telemetry.ClientRequestFailed(operation, ex.Message);
+            throw;
+        }
+    }
+
+    private async Task<T> ExecuteSdkAsync<T>(
+        string operation,
+        Func<CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await action(cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            _telemetry.ClientRequestFailed(operation, ex.Message);
+            throw;
+        }
+        catch (HonuaAdminApiException ex)
+        {
+            _telemetry.ClientRequestFailed(operation, ex.Message);
+            throw;
+        }
+        catch (HonuaAdminOperationException ex)
+        {
+            _telemetry.ClientRequestFailed(operation, ex.Message);
+            throw;
+        }
+    }
+
     private async Task<T> GetAsync<T>(string operation, string path, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken)
     {
         try
@@ -578,26 +653,6 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         return Unwrap(operation, envelope);
     }
 
-    private async Task<T> PostEmptyApiAsync<T>(
-        string operation,
-        string path,
-        JsonTypeInfo<AdminApiResponse<T>> responseTypeInfo,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var response = await _http.PostAsync(path, content: null, cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-            var envelope = await response.Content.ReadFromJsonAsync(responseTypeInfo, cancellationToken).ConfigureAwait(false);
-            return Unwrap(operation, envelope ?? throw new InvalidOperationException($"{operation} returned an empty response."));
-        }
-        catch (HttpRequestException ex)
-        {
-            _telemetry.ClientRequestFailed(operation, ex.Message);
-            throw;
-        }
-    }
-
     private static T Unwrap<T>(string operation, AdminApiResponse<T> envelope)
     {
         if (!envelope.Success)
@@ -608,29 +663,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         return envelope.Data ?? throw new InvalidOperationException($"{operation} returned an empty data payload.");
     }
 
-    private static string WithServiceName(string path, string? serviceName)
-        => string.IsNullOrWhiteSpace(serviceName)
-            ? path
-            : $"{path}?serviceName={Uri.EscapeDataString(serviceName)}";
-
     private static string MetadataResourcePath(string kind, string resourceNamespace, string name)
         => $"{ApiVersionPrefix}/metadata/resources/{Uri.EscapeDataString(kind)}/{Uri.EscapeDataString(resourceNamespace)}/{Uri.EscapeDataString(name)}";
-
-    private static string WithMetadataResourceQuery(string path, string? kind, string? resourceNamespace)
-    {
-        var query = new List<string>();
-        if (!string.IsNullOrWhiteSpace(kind))
-        {
-            query.Add($"kind={Uri.EscapeDataString(kind)}");
-        }
-
-        if (!string.IsNullOrWhiteSpace(resourceNamespace))
-        {
-            query.Add($"namespace={Uri.EscapeDataString(resourceNamespace)}");
-        }
-
-        return query.Count == 0 ? path : $"{path}?{string.Join("&", query)}";
-    }
 
     private static void EnsureIfMatch(string ifMatch, string operation)
     {

--- a/src/Honua.Admin/Services/Admin/SdkAdminModelMapper.cs
+++ b/src/Honua.Admin/Services/Admin/SdkAdminModelMapper.cs
@@ -1,0 +1,399 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using Honua.Admin.Models.Admin;
+using SdkAccessPolicyResponse = Honua.Sdk.Admin.Models.AccessPolicyResponse;
+using SdkColumnInfo = Honua.Sdk.Admin.Models.ColumnInfo;
+using SdkConnectionDetail = Honua.Sdk.Admin.Models.SecureConnectionDetail;
+using SdkConnectionSummary = Honua.Sdk.Admin.Models.SecureConnectionSummary;
+using SdkConnectionTestResult = Honua.Sdk.Admin.Models.ConnectionTestResult;
+using SdkCreateConnectionRequest = Honua.Sdk.Admin.Models.CreateSecureConnectionRequest;
+using SdkEncryptionValidationResult = Honua.Sdk.Admin.Models.EncryptionValidationResult;
+using SdkKeyRotationResult = Honua.Sdk.Admin.Models.KeyRotationResult;
+using SdkLayerMetadataResponse = Honua.Sdk.Admin.Models.LayerMetadataResponse;
+using SdkLayerStyleResponse = Honua.Sdk.Admin.Models.LayerStyleResponse;
+using SdkLayerStyleUpdateRequest = Honua.Sdk.Admin.Models.LayerStyleUpdateRequest;
+using SdkMapServerSettingsResponse = Honua.Sdk.Admin.Models.MapServerSettingsResponse;
+using SdkMetadataResource = Honua.Sdk.Admin.Models.MetadataResource;
+using SdkPublishedLayerSummary = Honua.Sdk.Admin.Models.PublishedLayerSummary;
+using SdkPublishLayerRequest = Honua.Sdk.Admin.Models.PublishLayerRequest;
+using SdkResourceMetadata = Honua.Sdk.Admin.Models.ResourceMetadata;
+using SdkServiceSettingsResponse = Honua.Sdk.Admin.Models.ServiceSettingsResponse;
+using SdkServiceSummary = Honua.Sdk.Admin.Models.ServiceSummary;
+using SdkTableInfo = Honua.Sdk.Admin.Models.TableInfo;
+using SdkTimeInfoResponse = Honua.Sdk.Admin.Models.TimeInfoResponse;
+using SdkUpdateAccessPolicyRequest = Honua.Sdk.Admin.Models.UpdateAccessPolicyRequest;
+using SdkUpdateConnectionRequest = Honua.Sdk.Admin.Models.UpdateSecureConnectionRequest;
+using SdkUpdateLayerMetadataRequest = Honua.Sdk.Admin.Models.UpdateLayerMetadataRequest;
+using SdkUpdateMapServerSettingsRequest = Honua.Sdk.Admin.Models.UpdateMapServerSettingsRequest;
+using SdkUpdateTimeInfoRequest = Honua.Sdk.Admin.Models.UpdateTimeInfoRequest;
+
+namespace Honua.Admin.Services.Admin;
+
+internal static class SdkAdminModelMapper
+{
+    public static IReadOnlyList<TOut> MapList<TIn, TOut>(IReadOnlyList<TIn> source, Func<TIn, TOut> map)
+    {
+        var result = new TOut[source.Count];
+        for (var i = 0; i < source.Count; i++)
+        {
+            result[i] = map(source[i]);
+        }
+
+        return result;
+    }
+
+    public static ConnectionSummary ToConnectionSummary(SdkConnectionSummary connection) => new()
+    {
+        ConnectionId = connection.ConnectionId,
+        Name = connection.Name,
+        Description = connection.Description,
+        Host = connection.Host,
+        Port = connection.Port,
+        DatabaseName = connection.DatabaseName,
+        Username = connection.Username,
+        SslRequired = connection.SslRequired,
+        SslMode = connection.SslMode,
+        StorageType = connection.StorageType,
+        IsActive = connection.IsActive,
+        HealthStatus = connection.HealthStatus,
+        LastHealthCheck = connection.LastHealthCheck,
+        CreatedAt = connection.CreatedAt,
+        CreatedBy = connection.CreatedBy,
+    };
+
+    public static ConnectionDetail ToConnectionDetail(SdkConnectionDetail connection) => new()
+    {
+        ConnectionId = connection.ConnectionId,
+        Name = connection.Name,
+        Description = connection.Description,
+        Host = connection.Host,
+        Port = connection.Port,
+        DatabaseName = connection.DatabaseName,
+        Username = connection.Username,
+        SslRequired = connection.SslRequired,
+        SslMode = connection.SslMode,
+        StorageType = connection.StorageType,
+        IsActive = connection.IsActive,
+        HealthStatus = connection.HealthStatus,
+        LastHealthCheck = connection.LastHealthCheck,
+        CreatedAt = connection.CreatedAt,
+        CreatedBy = connection.CreatedBy,
+        CredentialReference = connection.CredentialReference,
+        EncryptionVersion = connection.EncryptionVersion,
+        UpdatedAt = connection.UpdatedAt,
+    };
+
+    public static SdkCreateConnectionRequest ToSdk(CreateConnectionRequest request) => new()
+    {
+        Name = request.Name,
+        Description = request.Description,
+        Host = request.Host,
+        Port = request.Port,
+        DatabaseName = request.DatabaseName,
+        Username = request.Username,
+        Password = request.Password,
+        SecretReference = request.SecretReference,
+        SecretType = request.SecretType,
+        SslRequired = request.SslRequired,
+        SslMode = request.SslMode,
+    };
+
+    public static SdkUpdateConnectionRequest ToSdk(UpdateConnectionRequest request) => new()
+    {
+        Description = request.Description,
+        Host = request.Host,
+        Port = request.Port,
+        DatabaseName = request.DatabaseName,
+        Username = request.Username,
+        Password = request.Password,
+        SslRequired = request.SslRequired,
+        SslMode = request.SslMode,
+        IsActive = request.IsActive,
+    };
+
+    public static TestConnectionResult ToTestConnectionResult(SdkConnectionTestResult result) => new()
+    {
+        ConnectionId = result.ConnectionId,
+        ConnectionName = result.ConnectionName,
+        IsHealthy = result.IsHealthy,
+        TestedAt = result.TestedAt,
+        Message = result.Message ?? string.Empty,
+    };
+
+    public static EncryptionValidationResult ToEncryptionValidationResult(SdkEncryptionValidationResult result) => new()
+    {
+        IsValid = result.IsValid,
+        CurrentKeyVersion = result.CurrentKeyVersion,
+        ValidatedAt = result.ValidatedAt,
+        Message = result.Message ?? string.Empty,
+    };
+
+    public static KeyRotationResult ToKeyRotationResult(SdkKeyRotationResult result) => new()
+    {
+        PreviousKeyVersion = result.PreviousKeyVersion,
+        NewKeyVersion = result.NewKeyVersion,
+        RotatedAt = result.RotatedAt,
+        Message = result.Message ?? string.Empty,
+    };
+
+    public static DiscoveredTable ToDiscoveredTable(SdkTableInfo table) => new()
+    {
+        Schema = table.Schema,
+        Table = table.Table,
+        GeometryColumn = table.GeometryColumn,
+        GeometryType = table.GeometryType,
+        Srid = table.Srid,
+        EstimatedRows = table.EstimatedRows,
+        Columns = MapList(table.Columns, ToTableColumn),
+    };
+
+    public static TableColumn ToTableColumn(SdkColumnInfo column) => new()
+    {
+        Name = column.Name,
+        DataType = column.DataType,
+        IsNullable = column.IsNullable,
+        IsPrimaryKey = column.IsPrimaryKey,
+        MaxLength = column.MaxLength,
+    };
+
+    public static LayerSummary ToLayerSummary(SdkPublishedLayerSummary layer) => new()
+    {
+        LayerId = layer.LayerId,
+        LayerName = layer.LayerName,
+        Schema = layer.Schema,
+        Table = layer.Table,
+        Description = layer.Description,
+        GeometryType = layer.GeometryType,
+        Srid = layer.Srid,
+        PrimaryKey = layer.PrimaryKey,
+        FieldCount = layer.FieldCount,
+        Enabled = layer.Enabled,
+        ServiceName = layer.ServiceName,
+    };
+
+    public static SdkPublishLayerRequest ToSdk(PublishLayerRequest request) => new()
+    {
+        Schema = request.Schema,
+        Table = request.Table,
+        LayerName = request.LayerName,
+        Description = request.Description,
+        GeometryColumn = request.GeometryColumn,
+        GeometryType = request.GeometryType,
+        Srid = request.Srid,
+        PrimaryKey = request.PrimaryKey,
+        Fields = request.Fields,
+        ServiceName = request.ServiceName,
+        Enabled = request.Enabled,
+    };
+
+    public static LayerStyle ToLayerStyle(SdkLayerStyleResponse style) => new()
+    {
+        MapLibreStyle = style.MapLibreStyle,
+        DrawingInfo = style.DrawingInfo,
+    };
+
+    public static SdkLayerStyleUpdateRequest ToSdk(LayerStyleUpdateRequest request) => new()
+    {
+        MapLibreStyle = request.MapLibreStyle,
+        DrawingInfo = request.DrawingInfo,
+    };
+
+    public static ServiceSummary ToServiceSummary(SdkServiceSummary service) => new()
+    {
+        ServiceName = service.ServiceName,
+        Description = service.Description,
+        LayerCount = service.LayerCount,
+        EnabledProtocols = service.EnabledProtocols ?? Array.Empty<string>(),
+    };
+
+    public static ServiceSettings ToServiceSettings(SdkServiceSettingsResponse settings) => new()
+    {
+        ServiceName = settings.ServiceName,
+        EnabledProtocols = settings.EnabledProtocols ?? Array.Empty<string>(),
+        AvailableProtocols = settings.AvailableProtocols ?? Array.Empty<string>(),
+        AccessPolicy = ToAccessPolicySettings(settings.AccessPolicy),
+        TimeInfo = ToTimeInfoSettings(settings.TimeInfo),
+        MapServer = ToMapServerSettings(settings.MapServer),
+    };
+
+    public static SdkUpdateMapServerSettingsRequest ToSdk(MapServerSettings settings) => new()
+    {
+        MaxImageWidth = settings.MaxImageWidth,
+        MaxImageHeight = settings.MaxImageHeight,
+        DefaultImageWidth = settings.DefaultImageWidth,
+        DefaultImageHeight = settings.DefaultImageHeight,
+        DefaultDpi = settings.DefaultDpi,
+        DefaultFormat = settings.DefaultFormat,
+        DefaultTransparent = settings.DefaultTransparent,
+        MaxFeaturesPerLayer = settings.MaxFeaturesPerLayer,
+    };
+
+    public static SdkUpdateAccessPolicyRequest ToSdk(AccessPolicySettings settings) => new()
+    {
+        AllowAnonymous = settings.AllowAnonymous,
+        AllowAnonymousWrite = settings.AllowAnonymousWrite,
+        AllowedRoles = ToArrayOrNull(settings.AllowedRoles),
+        AllowedWriteRoles = ToArrayOrNull(settings.AllowedWriteRoles),
+    };
+
+    public static SdkUpdateTimeInfoRequest ToSdk(TimeInfoSettings settings) => new()
+    {
+        StartTimeField = settings.StartTimeField,
+        EndTimeField = settings.EndTimeField,
+        TrackIdField = settings.TrackIdField,
+    };
+
+    public static SdkUpdateLayerMetadataRequest ToSdk(UpdateLayerMetadataRequest request) => new()
+    {
+        AccessPolicy = request.AccessPolicy is null ? null : ToSdk(request.AccessPolicy),
+        TimeInfo = request.TimeInfo is null ? null : ToSdk(request.TimeInfo),
+    };
+
+    public static LayerMetadataResponse ToLayerMetadataResponse(SdkLayerMetadataResponse response) => new()
+    {
+        LayerId = response.LayerId,
+        LayerName = response.LayerName,
+        AccessPolicy = ToAccessPolicySettings(response.AccessPolicy),
+        TimeInfo = ToTimeInfoSettings(response.TimeInfo),
+    };
+
+    public static MetadataResource ToMetadataResource(SdkMetadataResource resource) => new()
+    {
+        ApiVersion = resource.ApiVersion,
+        Kind = resource.Kind,
+        Metadata = ToResourceMetadata(resource.Metadata),
+        Spec = resource.Spec,
+        Status = resource.Status,
+    };
+
+    public static SdkMetadataResource ToSdk(MetadataResource resource) => new()
+    {
+        ApiVersion = resource.ApiVersion,
+        Kind = resource.Kind,
+        Metadata = ToSdk(resource.Metadata),
+        Spec = resource.Spec,
+        Status = resource.Status,
+    };
+
+    private static AccessPolicySettings? ToAccessPolicySettings(SdkAccessPolicyResponse? policy)
+    {
+        if (policy is null)
+        {
+            return null;
+        }
+
+        return new AccessPolicySettings
+        {
+            AllowAnonymous = policy.AllowAnonymous,
+            AllowAnonymousWrite = policy.AllowAnonymousWrite,
+            AllowedRoles = policy.AllowedRoles,
+            AllowedWriteRoles = policy.AllowedWriteRoles,
+        };
+    }
+
+    private static TimeInfoSettings? ToTimeInfoSettings(SdkTimeInfoResponse? timeInfo)
+    {
+        if (timeInfo is null)
+        {
+            return null;
+        }
+
+        return new TimeInfoSettings
+        {
+            StartTimeField = timeInfo.StartTimeField,
+            EndTimeField = timeInfo.EndTimeField,
+            TrackIdField = timeInfo.TrackIdField,
+        };
+    }
+
+    private static MapServerSettings ToMapServerSettings(SdkMapServerSettingsResponse? settings)
+        => settings is null
+            ? new MapServerSettings()
+            : new MapServerSettings
+            {
+                MaxImageWidth = settings.MaxImageWidth,
+                MaxImageHeight = settings.MaxImageHeight,
+                DefaultImageWidth = settings.DefaultImageWidth,
+                DefaultImageHeight = settings.DefaultImageHeight,
+                DefaultDpi = settings.DefaultDpi,
+                DefaultFormat = settings.DefaultFormat,
+                DefaultTransparent = settings.DefaultTransparent,
+                MaxFeaturesPerLayer = settings.MaxFeaturesPerLayer,
+            };
+
+    private static ResourceMetadata? ToResourceMetadata(SdkResourceMetadata? metadata)
+    {
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        return new ResourceMetadata
+        {
+            Id = metadata.Id,
+            Name = metadata.Name,
+            Namespace = metadata.Namespace,
+            Labels = metadata.Labels,
+            Annotations = metadata.Annotations,
+            ResourceVersion = metadata.ResourceVersion,
+            Generation = metadata.Generation,
+            CreatedAt = metadata.CreatedAt,
+            UpdatedAt = metadata.UpdatedAt,
+        };
+    }
+
+    private static SdkResourceMetadata? ToSdk(ResourceMetadata? metadata)
+    {
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        return new SdkResourceMetadata
+        {
+            Id = metadata.Id,
+            Name = metadata.Name,
+            Namespace = metadata.Namespace,
+            Labels = metadata.Labels,
+            Annotations = metadata.Annotations,
+            ResourceVersion = metadata.ResourceVersion,
+            Generation = ToSdkGeneration(metadata.Generation),
+            CreatedAt = metadata.CreatedAt,
+            UpdatedAt = metadata.UpdatedAt,
+        };
+    }
+
+    private static int? ToSdkGeneration(long? generation)
+    {
+        if (generation is null)
+        {
+            return null;
+        }
+
+        if (generation is < int.MinValue or > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(generation), generation, "Metadata generation exceeds the SDK contract range.");
+        }
+
+        return (int)generation.Value;
+    }
+
+    private static string[]? ToArrayOrNull(IReadOnlyList<string>? values)
+    {
+        if (values is null)
+        {
+            return null;
+        }
+
+        var result = new string[values.Count];
+        for (var i = 0; i < values.Count; i++)
+        {
+            result[i] = values[i];
+        }
+
+        return result;
+    }
+}

--- a/tests/Honua.Admin.IntegrationTests/Tests/ContainerizedAdminApiEndToEndTests.cs
+++ b/tests/Honua.Admin.IntegrationTests/Tests/ContainerizedAdminApiEndToEndTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Honua.Admin.IntegrationTests.Fixtures;
 using Honua.Admin.Models.Admin;
+using Honua.Sdk.Admin.Exceptions;
 using Xunit;
 
 namespace Honua.Admin.IntegrationTests.Tests;
@@ -293,6 +294,11 @@ public sealed class ContainerizedAdminApiEndToEndTests
             // A published layer can make connection deletion fail on current
             // server images. Cleanup is best-effort so this admin-client E2E
             // lane reports the lifecycle assertion that failed, not teardown.
+        }
+        catch (HonuaAdminApiException)
+        {
+            // SDK-backed admin clients surface the same server-side failure as a
+            // typed API exception. Keep cleanup best-effort for this known case.
         }
     }
 

--- a/tests/Honua.Admin.Tests/HonuaAdminClientServiceSettingsTests.cs
+++ b/tests/Honua.Admin.Tests/HonuaAdminClientServiceSettingsTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Services.Admin;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class HonuaAdminClientServiceSettingsTests
+{
+    [Fact]
+    public async Task GetServiceSettingsAsync_preserves_admin_defaults_for_partial_sdk_payloads()
+    {
+        using var handler = new RecordingHandler(req =>
+        {
+            Assert.Equal(HttpMethod.Get, req.Method);
+            Assert.Equal(
+                "https://admin.example.test/api/v1/admin/services/default/settings",
+                req.RequestUri!.ToString());
+
+            return JsonOk(
+                """
+                {
+                  "success": true,
+                  "data": {
+                    "serviceName": "default",
+                    "enabledProtocols": null,
+                    "availableProtocols": null,
+                    "mapServer": null
+                  }
+                }
+                """);
+        });
+        var client = MakeClient(handler);
+
+        var settings = await client.GetServiceSettingsAsync("default", CancellationToken.None);
+
+        Assert.Equal("default", settings.ServiceName);
+        Assert.Empty(settings.EnabledProtocols);
+        Assert.Empty(settings.AvailableProtocols);
+        Assert.NotNull(settings.MapServer);
+        Assert.Null(settings.MapServer.MaxImageWidth);
+        Assert.Null(settings.MapServer.DefaultFormat);
+    }
+
+    private static HonuaAdminClient MakeClient(HttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://admin.example.test/"),
+        };
+        return new HonuaAdminClient(http, new NullTelemetry());
+    }
+
+    private static HttpResponseMessage JsonOk(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(responder(request));
+    }
+
+    private sealed class NullTelemetry : IAdminTelemetry
+    {
+        public void PageNavigated(string pageRoute, string? principalId) { }
+        public void DestructiveAction(string action, string? targetId, string? principalId) { }
+        public void ClientRequestFailed(string operation, string error) { }
+    }
+}


### PR DESCRIPTION
## Summary
- make the main admin UI client delegate SDK-stable surfaces to `Honua.Sdk.Admin`
- add a local projection mapper so UI-only computed properties stay in this repo while SDK owns reusable HTTP/envelope handling
- route connections, table discovery, layer publishing/styles, service settings, and metadata resource reads/deletes through the SDK client
- keep server-info, manifest/GitOps, deploy control, recent-error response, and metadata writes local where SDK contracts still lack admin-required details
- update container E2E cleanup to tolerate the SDK typed API exception for the known published-layer connection delete failure

## SDK gaps intentionally left local
- deploy preflight still needs diagnostics query support in the SDK
- deploy submit/rollback still need reason-body support in the SDK
- recent-errors still needs capacity/instance metadata in the SDK response
- metadata create/update still need response ETag preservation in the SDK client

## Verification
- `dotnet restore Honua.Admin.sln`
- `dotnet build src/Honua.Admin/Honua.Admin.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true`
- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-restore --filter "HonuaAdminClientMetadataTests|PublishingWorkspaceStateTests|OperationsConsoleStateTests" --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-restore --filter "Category=ContainerE2E" --logger "console;verbosity=minimal"`
- `dotnet build Honua.Admin.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Admin.sln --verify-no-changes --no-restore`
- `git diff --check`

Part of #66.