### PR TITLE
feat: complete SDK admin client cutover

### DIFF
--- a/src/Honua.Admin/Honua.Admin.csproj
+++ b/src/Honua.Admin/Honua.Admin.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="Blazor-ApexCharts" Version="3.4.0" />
-    <PackageReference Include="Honua.Sdk.Admin" Version="0.1.1-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Admin" Version="0.1.2-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Admin/Services/Admin/HonuaAdminClient.cs
+++ b/src/Honua.Admin/Services/Admin/HonuaAdminClient.cs
@@ -262,12 +262,10 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
             cancellationToken);
 
     public Task<MetadataResourceResponse> CreateMetadataResourceAsync(MetadataResource resource, CancellationToken cancellationToken)
-        => SendMetadataResourceAsync(
+        => ExecuteSdkAsync(
             nameof(CreateMetadataResourceAsync),
-            HttpMethod.Post,
-            $"{ApiVersionPrefix}/metadata/resources/",
-            resource,
-            ifMatch: null,
+            async ct => SdkAdminModelMapper.ToMetadataResourceResponse(
+                await _sdk.CreateMetadataResourceWithResponseAsync(SdkAdminModelMapper.ToSdk(resource), ct).ConfigureAwait(false)),
             cancellationToken);
 
     public Task<MetadataResourceResponse> UpdateMetadataResourceAsync(
@@ -280,12 +278,16 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     {
         EnsureIfMatch(ifMatch, nameof(UpdateMetadataResourceAsync));
 
-        return SendMetadataResourceAsync(
+        return ExecuteSdkAsync(
             nameof(UpdateMetadataResourceAsync),
-            HttpMethod.Put,
-            MetadataResourcePath(kind, resourceNamespace, name),
-            resource,
-            ifMatch,
+            async ct => SdkAdminModelMapper.ToMetadataResourceResponse(
+                await _sdk.UpdateMetadataResourceWithResponseAsync(
+                    kind,
+                    resourceNamespace,
+                    name,
+                    SdkAdminModelMapper.ToSdk(resource),
+                    ifMatch,
+                    ct).ConfigureAwait(false)),
             cancellationToken);
     }
 
@@ -308,22 +310,44 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     }
 
     public Task<DeployPreflightResult> GetDeployPreflightAsync(CancellationToken cancellationToken)
-        => GetAsync(nameof(GetDeployPreflightAsync), $"{ApiVersionPrefix}/deploy/preflight?includeDiagnostics=true", TypeInfo<DeployPreflightResult>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetDeployPreflightAsync),
+            async ct => SdkAdminModelMapper.ToDeployPreflightResult(await _sdk.GetDeployPreflightAsync(includeDiagnostics: true, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<DeployPlan> PlanDeployAsync(DeployPlanRequest request, CancellationToken cancellationToken)
-        => SendAsync(nameof(PlanDeployAsync), HttpMethod.Post, $"{ApiVersionPrefix}/deploy/plan", request, TypeInfo<DeployPlanRequest>(), TypeInfo<DeployPlan>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(PlanDeployAsync),
+            async ct => SdkAdminModelMapper.ToDeployPlan(
+                await _sdk.CreateDeployPlanAsync(SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<DeployOperation> CreateDeployOperationAsync(CreateDeployOperationRequest request, CancellationToken cancellationToken)
-        => SendAsync(nameof(CreateDeployOperationAsync), HttpMethod.Post, $"{ApiVersionPrefix}/deploy/operations", request, TypeInfo<CreateDeployOperationRequest>(), TypeInfo<DeployOperation>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(CreateDeployOperationAsync),
+            async ct => SdkAdminModelMapper.ToDeployOperation(
+                await _sdk.CreateDeployOperationAsync(SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<DeployOperation> GetDeployOperationAsync(string operationId, CancellationToken cancellationToken)
-        => GetAsync(nameof(GetDeployOperationAsync), $"{ApiVersionPrefix}/deploy/operations/{Uri.EscapeDataString(operationId)}", TypeInfo<DeployOperation>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetDeployOperationAsync),
+            async ct => SdkAdminModelMapper.ToDeployOperation(await _sdk.GetDeployOperationAsync(operationId, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<DeployOperation> SubmitDeployOperationAsync(string operationId, SubmitDeployOperationRequest request, CancellationToken cancellationToken)
-        => SendAsync(nameof(SubmitDeployOperationAsync), HttpMethod.Post, $"{ApiVersionPrefix}/deploy/operations/{Uri.EscapeDataString(operationId)}/submit", request, TypeInfo<SubmitDeployOperationRequest>(), TypeInfo<DeployOperation>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(SubmitDeployOperationAsync),
+            async ct => SdkAdminModelMapper.ToDeployOperation(
+                await _sdk.SubmitDeployOperationAsync(operationId, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<DeployOperation> RollbackDeployOperationAsync(string operationId, RollbackDeployOperationRequest request, CancellationToken cancellationToken)
-        => SendAsync(nameof(RollbackDeployOperationAsync), HttpMethod.Post, $"{ApiVersionPrefix}/deploy/operations/{Uri.EscapeDataString(operationId)}/rollback", request, TypeInfo<RollbackDeployOperationRequest>(), TypeInfo<DeployOperation>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(RollbackDeployOperationAsync),
+            async ct => SdkAdminModelMapper.ToDeployOperation(
+                await _sdk.RollbackDeployOperationAsync(operationId, SdkAdminModelMapper.ToSdk(request), ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ManifestApplyResult> ApplyManifestAsync(ManifestApplyRequest request, CancellationToken cancellationToken)
         => SendApiAsync(
@@ -455,13 +479,22 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
             cancellationToken);
 
     public Task<RecentErrorsResponse> GetRecentErrorsAsync(CancellationToken cancellationToken)
-        => GetAsync(nameof(GetRecentErrorsAsync), $"{ApiVersionPrefix}/observability/errors", TypeInfo<RecentErrorsResponse>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetRecentErrorsAsync),
+            async ct => SdkAdminModelMapper.ToRecentErrorsResponse(await _sdk.GetRecentErrorsResponseAsync(limit: null, ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<ObservabilityStatusResponse> GetTelemetryStatusAsync(CancellationToken cancellationToken)
-        => GetAsync(nameof(GetTelemetryStatusAsync), $"{ApiVersionPrefix}/observability/telemetry", TypeInfo<ObservabilityStatusResponse>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetTelemetryStatusAsync),
+            async ct => SdkAdminModelMapper.ToObservabilityStatusResponse(await _sdk.GetTelemetryStatusAsync(ct).ConfigureAwait(false)),
+            cancellationToken);
 
     public Task<MigrationObservabilityResponse> GetMigrationStatusAsync(CancellationToken cancellationToken)
-        => GetAsync(nameof(GetMigrationStatusAsync), $"{ApiVersionPrefix}/observability/migrations", TypeInfo<MigrationObservabilityResponse>(), cancellationToken);
+        => ExecuteSdkAsync(
+            nameof(GetMigrationStatusAsync),
+            async ct => SdkAdminModelMapper.ToMigrationObservabilityResponse(await _sdk.GetMigrationStatusAsync(ct).ConfigureAwait(false)),
+            cancellationToken);
 
     private static JsonTypeInfo<T> TypeInfo<T>()
         => (JsonTypeInfo<T>)AdminJsonContext.Default.GetTypeInfo(typeof(T))!;
@@ -572,73 +605,6 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         }
     }
 
-    private async Task<MetadataResourceResponse> GetMetadataResourceCoreAsync(
-        string operation,
-        string path,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var response = await _http.GetAsync(path, cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-            return await ReadMetadataResourceResponseAsync(operation, response, cancellationToken).ConfigureAwait(false);
-        }
-        catch (HttpRequestException ex)
-        {
-            _telemetry.ClientRequestFailed(operation, ex.Message);
-            throw;
-        }
-    }
-
-    private async Task<MetadataResourceResponse> SendMetadataResourceAsync(
-        string operation,
-        HttpMethod method,
-        string path,
-        MetadataResource resource,
-        string? ifMatch,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var message = new HttpRequestMessage(method, path)
-            {
-                Content = new StringContent(
-                    JsonSerializer.Serialize(resource, TypeInfo<MetadataResource>()),
-                    Encoding.UTF8,
-                    "application/json"),
-            };
-
-            if (!string.IsNullOrWhiteSpace(ifMatch))
-            {
-                message.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-            }
-
-            using var response = await _http.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-            return await ReadMetadataResourceResponseAsync(operation, response, cancellationToken).ConfigureAwait(false);
-        }
-        catch (HttpRequestException ex)
-        {
-            _telemetry.ClientRequestFailed(operation, ex.Message);
-            throw;
-        }
-    }
-
-    private static async Task<MetadataResourceResponse> ReadMetadataResourceResponseAsync(
-        string operation,
-        HttpResponseMessage response,
-        CancellationToken cancellationToken)
-    {
-        var envelope = await response.Content
-            .ReadFromJsonAsync(TypeInfo<AdminApiResponse<MetadataResource>>(), cancellationToken)
-            .ConfigureAwait(false);
-        return new MetadataResourceResponse
-        {
-            Resource = Unwrap(operation, envelope ?? throw new InvalidOperationException($"{operation} returned an empty response.")),
-            ETag = response.Headers.ETag?.ToString(),
-        };
-    }
-
     private async Task<TResponse> SendApiAsync<TRequest, TResponse>(
         string operation,
         HttpMethod method,
@@ -662,9 +628,6 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
 
         return envelope.Data ?? throw new InvalidOperationException($"{operation} returned an empty data payload.");
     }
-
-    private static string MetadataResourcePath(string kind, string resourceNamespace, string name)
-        => $"{ApiVersionPrefix}/metadata/resources/{Uri.EscapeDataString(kind)}/{Uri.EscapeDataString(resourceNamespace)}/{Uri.EscapeDataString(name)}";
 
     private static void EnsureIfMatch(string ifMatch, string operation)
     {

--- a/src/Honua.Admin/Services/Admin/SdkAdminModelMapper.cs
+++ b/src/Honua.Admin/Services/Admin/SdkAdminModelMapper.cs
@@ -10,6 +10,16 @@ using SdkConnectionDetail = Honua.Sdk.Admin.Models.SecureConnectionDetail;
 using SdkConnectionSummary = Honua.Sdk.Admin.Models.SecureConnectionSummary;
 using SdkConnectionTestResult = Honua.Sdk.Admin.Models.ConnectionTestResult;
 using SdkCreateConnectionRequest = Honua.Sdk.Admin.Models.CreateSecureConnectionRequest;
+using SdkCreateDeployOperationRequest = Honua.Sdk.Admin.Models.CreateDeployOperationRequest;
+using SdkCreateDeployPlanRequest = Honua.Sdk.Admin.Models.CreateDeployPlanRequest;
+using SdkDeployBackendCapabilities = Honua.Sdk.Admin.Models.DeployBackendCapabilities;
+using SdkDeployOperation = Honua.Sdk.Admin.Models.DeployOperation;
+using SdkDeployPlan = Honua.Sdk.Admin.Models.DeployPlan;
+using SdkDeployPlanTarget = Honua.Sdk.Admin.Models.DeployPlanTarget;
+using SdkDeployPreflightDatabaseCompatibility = Honua.Sdk.Admin.Models.DeployPreflightDatabaseCompatibility;
+using SdkDeployPreflightMigration = Honua.Sdk.Admin.Models.DeployPreflightMigration;
+using SdkDeployPreflightReadiness = Honua.Sdk.Admin.Models.DeployPreflightReadiness;
+using SdkDeployPreflightResult = Honua.Sdk.Admin.Models.DeployPreflightResult;
 using SdkEncryptionValidationResult = Honua.Sdk.Admin.Models.EncryptionValidationResult;
 using SdkKeyRotationResult = Honua.Sdk.Admin.Models.KeyRotationResult;
 using SdkLayerMetadataResponse = Honua.Sdk.Admin.Models.LayerMetadataResponse;
@@ -17,12 +27,19 @@ using SdkLayerStyleResponse = Honua.Sdk.Admin.Models.LayerStyleResponse;
 using SdkLayerStyleUpdateRequest = Honua.Sdk.Admin.Models.LayerStyleUpdateRequest;
 using SdkMapServerSettingsResponse = Honua.Sdk.Admin.Models.MapServerSettingsResponse;
 using SdkMetadataResource = Honua.Sdk.Admin.Models.MetadataResource;
+using SdkMetadataResourceResponse = Honua.Sdk.Admin.Models.MetadataResourceResponse;
+using SdkMigrationStatus = Honua.Sdk.Admin.Models.MigrationStatus;
 using SdkPublishedLayerSummary = Honua.Sdk.Admin.Models.PublishedLayerSummary;
 using SdkPublishLayerRequest = Honua.Sdk.Admin.Models.PublishLayerRequest;
+using SdkRecentError = Honua.Sdk.Admin.Models.RecentError;
+using SdkRecentErrorsResponse = Honua.Sdk.Admin.Models.RecentErrorsResponse;
 using SdkResourceMetadata = Honua.Sdk.Admin.Models.ResourceMetadata;
+using SdkRollbackDeployOperationRequest = Honua.Sdk.Admin.Models.RollbackDeployOperationRequest;
 using SdkServiceSettingsResponse = Honua.Sdk.Admin.Models.ServiceSettingsResponse;
 using SdkServiceSummary = Honua.Sdk.Admin.Models.ServiceSummary;
+using SdkSubmitDeployOperationRequest = Honua.Sdk.Admin.Models.SubmitDeployOperationRequest;
 using SdkTableInfo = Honua.Sdk.Admin.Models.TableInfo;
+using SdkTelemetryStatus = Honua.Sdk.Admin.Models.TelemetryStatus;
 using SdkTimeInfoResponse = Honua.Sdk.Admin.Models.TimeInfoResponse;
 using SdkUpdateAccessPolicyRequest = Honua.Sdk.Admin.Models.UpdateAccessPolicyRequest;
 using SdkUpdateConnectionRequest = Honua.Sdk.Admin.Models.UpdateSecureConnectionRequest;
@@ -278,6 +295,120 @@ internal static class SdkAdminModelMapper
         Status = resource.Status,
     };
 
+    public static MetadataResourceResponse ToMetadataResourceResponse(SdkMetadataResourceResponse response) => new()
+    {
+        Resource = ToMetadataResource(response.Resource),
+        ETag = response.ETag,
+    };
+
+    public static SdkCreateDeployPlanRequest ToSdk(DeployPlanRequest request) => new()
+    {
+        TargetId = request.TargetId,
+        DesiredRevision = request.DesiredRevision,
+        CurrentRevision = request.CurrentRevision,
+        Parameters = request.Parameters,
+    };
+
+    public static SdkCreateDeployOperationRequest ToSdk(CreateDeployOperationRequest request) => new()
+    {
+        TargetId = request.TargetId,
+        DesiredRevision = request.DesiredRevision,
+        CurrentRevision = request.CurrentRevision,
+        Reason = request.Reason,
+        IdempotencyKey = request.IdempotencyKey,
+        CorrelationId = request.CorrelationId,
+        Priority = request.Priority,
+        SubmitImmediately = request.SubmitImmediately,
+        Parameters = request.Parameters,
+    };
+
+    public static SdkSubmitDeployOperationRequest ToSdk(SubmitDeployOperationRequest request) => new()
+    {
+        Reason = request.Reason,
+    };
+
+    public static SdkRollbackDeployOperationRequest ToSdk(RollbackDeployOperationRequest request) => new()
+    {
+        Reason = request.Reason,
+    };
+
+    public static DeployPreflightResult ToDeployPreflightResult(SdkDeployPreflightResult result) => new()
+    {
+        Status = result.Status,
+        ReadyForCoordinatedDeploy = result.ReadyForCoordinatedDeploy,
+        Message = result.Message,
+        ServerVersion = result.ServerVersion,
+        Environment = result.Environment,
+        DeploymentMode = result.DeploymentMode,
+        InstanceName = result.InstanceName,
+        GeneratedAt = result.GeneratedAt,
+        Readiness = ToDeployPreflightReadiness(result.Readiness),
+        Migration = ToDeployPreflightMigration(result.Migration),
+        DatabaseCompatibility = ToDeployPreflightDatabaseCompatibility(result.DatabaseCompatibility),
+    };
+
+    public static DeployPlan ToDeployPlan(SdkDeployPlan plan) => new()
+    {
+        Target = plan.Target is null ? new DeployPlanTarget() : ToDeployPlanTarget(plan.Target),
+        ReadyToSubmit = plan.ReadyToSubmit,
+        RequiresApproval = plan.RequiresApproval,
+        RequiresOutOfBandMigrations = plan.RequiresOutOfBandMigrations,
+        BackendRegistered = plan.BackendRegistered,
+        Capabilities = ToDeployBackendCapabilities(plan.Capabilities),
+        Warnings = plan.Warnings,
+        BlockingReasons = plan.BlockingReasons,
+        GeneratedAt = plan.GeneratedAt,
+    };
+
+    public static DeployOperation ToDeployOperation(SdkDeployOperation operation) => new()
+    {
+        OperationId = operation.OperationId,
+        Kind = operation.Kind,
+        Status = operation.Status,
+        Priority = operation.Priority,
+        Target = operation.Target is null ? null : ToDeployPlanTarget(operation.Target),
+        ProviderOperationId = operation.ProviderOperationId,
+        CurrentPhase = operation.CurrentPhase,
+        ObservedState = operation.ObservedState,
+        ErrorMessage = operation.ErrorMessage,
+        Warnings = operation.Warnings,
+        BlockingReasons = operation.BlockingReasons,
+        RequestedBy = operation.RequestedBy,
+        Reason = operation.Reason,
+        CorrelationId = operation.CorrelationId,
+        CreatedAt = operation.CreatedAt,
+        UpdatedAt = operation.UpdatedAt,
+        CompletedAt = operation.CompletedAt,
+    };
+
+    public static RecentErrorsResponse ToRecentErrorsResponse(SdkRecentErrorsResponse response) => new()
+    {
+        Capacity = response.Capacity,
+        InstanceId = response.InstanceId,
+        Errors = MapList(response.Errors, ToRecentErrorEntry),
+    };
+
+    public static ObservabilityStatusResponse ToObservabilityStatusResponse(SdkTelemetryStatus status) => new()
+    {
+        TracingEnabled = status.TracingEnabled,
+        OtlpConfigured = status.OtlpConfigured,
+        OtlpEndpoint = status.OtlpEndpoint,
+    };
+
+    public static MigrationObservabilityResponse ToMigrationObservabilityResponse(SdkMigrationStatus status) => new()
+    {
+        Status = status.Status,
+        IsReady = status.IsReady,
+        IsFailed = status.IsFailed,
+        Message = status.Message,
+        PlanAvailable = status.PlanAvailable,
+        UpgradeRequired = status.UpgradeRequired,
+        PendingScripts = status.PendingScripts,
+        ExecutedButNotDiscoveredScripts = status.ExecutedButNotDiscoveredScripts,
+        PlanError = status.PlanError,
+        GeneratedAt = status.GeneratedAt,
+    };
+
     private static AccessPolicySettings? ToAccessPolicySettings(SdkAccessPolicyResponse? policy)
     {
         if (policy is null)
@@ -360,25 +491,10 @@ internal static class SdkAdminModelMapper
             Labels = metadata.Labels,
             Annotations = metadata.Annotations,
             ResourceVersion = metadata.ResourceVersion,
-            Generation = ToSdkGeneration(metadata.Generation),
+            Generation = metadata.Generation,
             CreatedAt = metadata.CreatedAt,
             UpdatedAt = metadata.UpdatedAt,
         };
-    }
-
-    private static int? ToSdkGeneration(long? generation)
-    {
-        if (generation is null)
-        {
-            return null;
-        }
-
-        if (generation is < int.MinValue or > int.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(generation), generation, "Metadata generation exceeds the SDK contract range.");
-        }
-
-        return (int)generation.Value;
     }
 
     private static string[]? ToArrayOrNull(IReadOnlyList<string>? values)
@@ -396,4 +512,78 @@ internal static class SdkAdminModelMapper
 
         return result;
     }
+
+    private static DeployPreflightReadiness? ToDeployPreflightReadiness(SdkDeployPreflightReadiness? readiness)
+        => readiness is null
+            ? null
+            : new DeployPreflightReadiness
+            {
+                IsReady = readiness.IsReady,
+                StatusCode = readiness.StatusCode,
+                Message = readiness.Message,
+            };
+
+    private static DeployPreflightMigration? ToDeployPreflightMigration(SdkDeployPreflightMigration? migration)
+        => migration is null
+            ? null
+            : new DeployPreflightMigration
+            {
+                LifecycleStatus = migration.LifecycleStatus,
+                Message = migration.Message,
+                PlanAvailable = migration.PlanAvailable,
+                UpgradeRequired = migration.UpgradeRequired,
+                PendingScripts = migration.PendingScripts,
+                ExecutedButNotDiscoveredScripts = migration.ExecutedButNotDiscoveredScripts,
+                PlanError = migration.PlanError,
+            };
+
+    private static DeployPreflightDatabaseCompatibility? ToDeployPreflightDatabaseCompatibility(SdkDeployPreflightDatabaseCompatibility? compatibility)
+        => compatibility is null
+            ? null
+            : new DeployPreflightDatabaseCompatibility
+            {
+                IsCompatible = compatibility.IsCompatible,
+                EngineVersion = compatibility.EngineVersion,
+                PostGisVersion = compatibility.PostGisVersion,
+                PostGisRasterVersion = compatibility.PostGisRasterVersion,
+                InstalledExtensions = compatibility.InstalledExtensions,
+                Warnings = compatibility.Warnings,
+                ErrorMessage = compatibility.ErrorMessage,
+            };
+
+    private static DeployPlanTarget ToDeployPlanTarget(SdkDeployPlanTarget target) => new()
+    {
+        TargetId = target.TargetId,
+        TargetKind = target.TargetKind,
+        Backend = target.Backend,
+        Environment = target.Environment,
+        TargetName = target.TargetName,
+        ArtifactReference = target.ArtifactReference,
+        RuntimeProfile = target.RuntimeProfile,
+        CurrentRevision = target.CurrentRevision,
+        DesiredRevision = target.DesiredRevision,
+        Parameters = target.Parameters,
+    };
+
+    private static DeployBackendCapabilities? ToDeployBackendCapabilities(SdkDeployBackendCapabilities? capabilities)
+        => capabilities is null
+            ? null
+            : new DeployBackendCapabilities
+            {
+                SupportsRollback = capabilities.SupportsRollback,
+                SupportsCancellation = capabilities.SupportsCancellation,
+                SupportsTrafficShifting = capabilities.SupportsTrafficShifting,
+                RequiresOutOfBandMigrations = capabilities.RequiresOutOfBandMigrations,
+                SupportsProgressPolling = capabilities.SupportsProgressPolling,
+                SupportsRevisionPinning = capabilities.SupportsRevisionPinning,
+            };
+
+    private static RecentErrorEntry ToRecentErrorEntry(SdkRecentError error) => new()
+    {
+        Timestamp = error.Timestamp,
+        CorrelationId = error.CorrelationId,
+        Path = error.Path,
+        StatusCode = error.StatusCode,
+        Message = error.Message,
+    };
 }

--- a/tests/Honua.Admin.IntegrationTests/Tests/ContainerizedAdminApiEndToEndTests.cs
+++ b/tests/Honua.Admin.IntegrationTests/Tests/ContainerizedAdminApiEndToEndTests.cs
@@ -224,7 +224,7 @@ public sealed class ContainerizedAdminApiEndToEndTests
         Assert.NotEqual(createdEtag, updatedEtag);
         Assert.NotEqual(loaded.Resource.Metadata?.ResourceVersion, updated.Resource.Metadata?.ResourceVersion);
 
-        var staleUpdate = await Assert.ThrowsAsync<HttpRequestException>(() =>
+        var staleUpdate = await Assert.ThrowsAsync<HonuaAdminApiException>(() =>
             fixture.AdminClient.UpdateMetadataResourceAsync(
                 "Layer",
                 "default",


### PR DESCRIPTION
## Summary
- bump `Honua.Sdk.Admin` to the published `0.1.2-alpha.1` GitHub Packages release
- route remaining SDK-stable admin metadata writes, deploy control, and observability calls through `Honua.Sdk.Admin`
- remove local metadata write HTTP helpers and the obsolete metadata generation `int` range shim now that the SDK uses `long?`
- align the container E2E stale-ETag assertion with the SDK `HonuaAdminApiException` surface

Refs #66.
Depends on honua-io/honua-sdk-dotnet#82 and release `dotnet-sdk-v0.1.2-alpha.1`.

## Testing
- `dotnet restore tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configfile /tmp/honua-server-admin-local-nuget.config`
- `dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --no-restore`
- `dotnet restore tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configfile /tmp/honua-server-admin-local-nuget.config`
- `dotnet test tests/Honua.Admin.IntegrationTests/Honua.Admin.IntegrationTests.csproj --configuration Release --no-restore --filter "Category=ContainerE2E"`
- `dotnet format Honua.Admin.sln --verify-no-changes --no-restore`

Note: local restore against GitHub Packages is blocked by this machine token lacking `read:packages`, so verification used the package artifact from the successful SDK publish run as a temporary local feed while keeping the project pinned to the published package version.