### PR TITLE
test: validate SDK admin browser boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ injects credentials server-side (or replace the dev auth scaffold with a
 real OIDC bearer-token flow). Tracked as a follow-on in
 [`docs/identity-admin-gaps.md`](docs/identity-admin-gaps.md).
 
+`Honua.Sdk.Admin` is the reusable REST client behind the admin UI adapter. The
+browser-safe boundary and smoke coverage are documented in
+[`docs/browser-sdk-validation.md`](docs/browser-sdk-validation.md).
+
 ### Operator Spec Workspace
 
 The S1 operator workspace lives at `/operator/spec` (gated by `[Authorize]`;

--- a/docs/admin-ui-quality-gates.md
+++ b/docs/admin-ui-quality-gates.md
@@ -57,6 +57,20 @@ The PR gate renders these top workflows with the deterministic
 Add a row here when a workflow becomes release-critical, then extend
 `AdminQualityGateTests.TopWorkflows` in the same PR.
 
+## SDK browser smoke
+
+The admin app consumes `Honua.Sdk.Admin` through NuGet and adapts it behind
+`IHonuaAdminClient`. Browser-sensitive SDK changes should keep
+`HonuaAdminClientBrowserSafetyTests` green; those tests exercise SDK-backed
+observability and deploy-control calls through an injected `HttpClient` handler
+without native transports or static credentials.
+
+The `Publish Verification` job remains the WebAssembly build gate. It proves
+the SDK package graph still publishes with the Blazor app and keeps bundle-size
+budgets in check. See
+[Browser SDK Validation](browser-sdk-validation.md) for the auth, CORS, and
+native-transport boundaries.
+
 ## Release checklist
 
 Before tagging or merging a release branch:
@@ -64,6 +78,8 @@ Before tagging or merging a release branch:
 - confirm `CI Gate` and `Require CI Success` passed on the release candidate;
 - review the publish-size output in `Publish Verification` and compare it with
   the budgets above;
+- confirm SDK-backed admin client smoke tests passed when the release changes
+  `Honua.Sdk.Admin`, admin client DI, auth handlers, or admin REST adapters;
 - run the top workflow smoke suite locally if the release contains major UI or
   dependency changes;
 - complete the manual accessibility pass for changed workflows;

--- a/docs/browser-sdk-validation.md
+++ b/docs/browser-sdk-validation.md
@@ -1,0 +1,55 @@
+# Browser SDK Validation
+
+Issue
+[#67](https://github.com/honua-io/honua-server-admin/issues/67) tracks the
+admin UI browser/WASM validation for `Honua.Sdk.Admin`.
+
+The admin app is a Blazor WebAssembly host. That means SDK usage must stay on
+the browser-safe REST path:
+
+- `Honua.Sdk.Admin` is consumed as a NuGet package.
+- The UI adapter remains `IHonuaAdminClient`.
+- SDK-backed calls run through the app-provided `HttpClient` and the browser
+  fetch stack.
+- Native gRPC/HTTP2 is not part of the admin browser path. `Honua.Sdk.Grpc`
+  should stay out of this app until a gRPC-Web endpoint and browser transport
+  plan are available.
+
+## Current Validation
+
+The PR gate validates three layers:
+
+| Gate | Coverage |
+| --- | --- |
+| Unit smoke | `HonuaAdminClientBrowserSafetyTests` exercises `IHonuaAdminClient -> HonuaAdminClient -> Honua.Sdk.Admin` with a supplied `HttpClient` handler for observability and deploy-preflight calls. |
+| Blazor publish | `Publish Verification` publishes `src/Honua.Admin` as WebAssembly and verifies the published output plus bundle budgets. |
+| Stub UI smoke | `AdminQualityGateTests` renders release-critical routes with deterministic local stubs so UI regressions do not require a live server. |
+
+The unit smoke is intentionally same-process and same-origin. It proves the
+adapter does not require native transports or static credentials. A live
+browser/CORS run should be added once the fake-server harness exists.
+
+## Auth Boundary
+
+`HonuaServer:ApiKey` is development-only. Blazor WebAssembly configuration is
+downloaded by clients, so production builds must not forward a static admin API
+key from browser config. `Program.cs` only attaches `X-API-Key` in Development;
+non-Development builds log a warning and refuse to forward it.
+
+Production deployments should use one of these patterns:
+
+- same-origin BFF that injects privileged admin credentials server-side;
+- delegated operator bearer tokens from the real OIDC login flow;
+- another app-owned auth flow that never places privileged server secrets in
+  `wwwroot`, generated static config, or downloaded appsettings files.
+
+## CORS Boundary
+
+Same-origin deployments avoid browser CORS entirely and are the preferred admin
+shape when a BFF is present. Cross-origin deployments need honua-server to allow
+the admin app origin, methods, and credential headers used by the REST admin
+surface. That server policy is outside this repository, but admin UI changes
+must not bypass it by adding native transports or hidden static credentials.
+
+The SDK package matrix lives in
+[`honua-sdk-dotnet/docs/browser-wasm-support.md`](https://github.com/honua-io/honua-sdk-dotnet/blob/trunk/docs/browser-wasm-support.md).

--- a/tests/Honua.Admin.Tests/HonuaAdminClientBrowserSafetyTests.cs
+++ b/tests/Honua.Admin.Tests/HonuaAdminClientBrowserSafetyTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Admin.Services.Admin;
+using Xunit;
+
+namespace Honua.Admin.Tests;
+
+public sealed class HonuaAdminClientBrowserSafetyTests
+{
+    [Fact]
+    public async Task GetRecentErrorsAsync_uses_sdk_client_over_supplied_http_pipeline()
+    {
+        using var handler = new RecordingHandler(req =>
+        {
+            Assert.Equal(HttpMethod.Get, req.Method);
+            Assert.Equal("https://admin.example.test/api/v1/admin/observability/errors", req.RequestUri!.ToString());
+            Assert.False(req.Headers.Contains("X-API-Key"));
+            Assert.Null(req.Headers.Authorization);
+
+            return JsonOk(
+                """
+                {
+                  "capacity": 10,
+                  "instanceId": "browser-node",
+                  "errors": [
+                    {
+                      "timestamp": "2026-04-29T12:00:00Z",
+                      "correlationId": "corr-browser",
+                      "path": "/api/v1/admin/config",
+                      "statusCode": 500,
+                      "message": "boom"
+                    }
+                  ]
+                }
+                """);
+        });
+        IHonuaAdminClient client = MakeClient(handler);
+
+        var result = await client.GetRecentErrorsAsync(CancellationToken.None);
+
+        Assert.Equal(10, result.Capacity);
+        Assert.Equal("browser-node", result.InstanceId);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("corr-browser", error.CorrelationId);
+        Assert.Equal("/api/v1/admin/config", error.Path);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetDeployPreflightAsync_uses_sdk_diagnostics_query_over_supplied_http_pipeline()
+    {
+        using var handler = new RecordingHandler(req =>
+        {
+            Assert.Equal(HttpMethod.Get, req.Method);
+            Assert.Equal(
+                "https://admin.example.test/api/v1/admin/deploy/preflight?includeDiagnostics=true",
+                req.RequestUri!.ToString());
+            Assert.False(req.Headers.Contains("X-API-Key"));
+            Assert.Null(req.Headers.Authorization);
+
+            return JsonOk(
+                """
+                {
+                  "status": "ready",
+                  "readyForCoordinatedDeploy": true,
+                  "message": "Instance is ready for coordinated deployment.",
+                  "serverVersion": "0.1.0",
+                  "environment": "Development",
+                  "deploymentMode": "SingleInstance",
+                  "instanceName": "browser-node",
+                  "generatedAt": "2026-04-29T12:00:00Z",
+                  "readiness": {
+                    "isReady": true,
+                    "statusCode": 200,
+                    "message": "ready"
+                  },
+                  "migration": null,
+                  "databaseCompatibility": null
+                }
+                """);
+        });
+        IHonuaAdminClient client = MakeClient(handler);
+
+        var result = await client.GetDeployPreflightAsync(CancellationToken.None);
+
+        Assert.Equal("ready", result.Status);
+        Assert.True(result.ReadyForCoordinatedDeploy);
+        Assert.Equal("browser-node", result.InstanceName);
+        Assert.Equal(200, result.Readiness?.StatusCode);
+        Assert.Single(handler.Requests);
+    }
+
+    private static HonuaAdminClient MakeClient(HttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://admin.example.test/"),
+        };
+        return new HonuaAdminClient(http, new NullTelemetry());
+    }
+
+    private static HttpResponseMessage JsonOk(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class NullTelemetry : IAdminTelemetry
+    {
+        public void PageNavigated(string pageRoute, string? principalId) { }
+        public void DestructiveAction(string action, string? targetId, string? principalId) { }
+        public void ClientRequestFailed(string operation, string error) { }
+    }
+}


### PR DESCRIPTION
## Summary
- document the admin UI browser/WASM SDK boundary for Honua.Sdk.Admin
- add SDK-backed IHonuaAdminClient smoke tests over an injected HttpClient pipeline
- link the smoke coverage from the admin quality gates and README

## Validation
- dotnet test tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj --configuration Release --filter HonuaAdminClientBrowserSafetyTests /p:TreatWarningsAsErrors=true
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity minimal
- git diff --check

Refs #67
Depends on honua-sdk-dotnet#62 documentation landing for the cross-repo browser/WASM matrix link.