### PR TITLE
chore: update admin SDK package

### DIFF
--- a/src/Honua.Admin/Honua.Admin.csproj
+++ b/src/Honua.Admin/Honua.Admin.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="Blazor-ApexCharts" Version="3.4.0" />
-    <PackageReference Include="Honua.Sdk.Admin" Version="0.1.2-alpha.1" />
+    <PackageReference Include="Honua.Sdk.Admin" Version="0.1.15-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update the Blazor admin app to consume Honua.Sdk.Admin 0.1.15-alpha.1 from GitHub Packages
- keep the admin UI on the NuGet-based SDK dependency path for the browser/WASM validation work

Related to #67

## Validation
- dotnet restore Honua.Admin.sln --configfile /tmp/honua-server-admin-local.nuget.config (temporary local source because local gh token lacks GitHub Packages read scope)
- dotnet build Honua.Admin.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Admin.sln --no-build --no-restore --configuration Release --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1
- dotnet format Honua.Admin.sln --verify-no-changes --verbosity diagnostic --no-restore
- dotnet publish src/Honua.Admin/Honua.Admin.csproj --configuration Release --output /tmp/honua-admin-publish --no-restore
- publish output/budget check: 37,689,175 bytes total; 32,625,074 framework bytes; 16,667,395 wasm bytes